### PR TITLE
[codex] add conditional App chat resume cache

### DIFF
--- a/docs/chat-chain-changes/2026-08-23-app-single-chat-resume-pagination.md
+++ b/docs/chat-chain-changes/2026-08-23-app-single-chat-resume-pagination.md
@@ -9,3 +9,9 @@ The App can request older persisted messages through the existing paginated
 conversation endpoint. Resume pagination is applied only when building the
 outbound display payload; it does not trim session runtime state, persisted
 messages, compression snapshots, or the database-backed model history.
+
+The App now resumes through the dedicated `app.resume` socket event and always
+sends its last cache `id`. Studio replies on `app.resumed`; an unchanged message
+page omits `messages`, so the App can reuse its account- and machine-scoped
+snapshot while still receiving fresh run, queue, usage, and session metadata.
+The original `resume` / `resumed` contract remains unchanged for the Web UI.

--- a/packages/server/src/services/app-relay/client.ts
+++ b/packages/server/src/services/app-relay/client.ts
@@ -32,6 +32,7 @@ const ALLOWED_SOCKET_NAMESPACES = new Set(['/chat-run', '/group-chat', '/workflo
 const ALLOWED_CHAT_RUN_CLIENT_EVENTS = new Set([
   'run',
   'resume',
+  'app.resume',
   'abort',
   'insert_queued_run',
   'cancel_queued_run',

--- a/packages/server/src/services/app-relay/server.ts
+++ b/packages/server/src/services/app-relay/server.ts
@@ -41,6 +41,7 @@ const ALLOWED_REQUEST_HEADERS = new Set([
 const ALLOWED_CHAT_RUN_CLIENT_EVENTS = new Set([
   'run',
   'resume',
+  'app.resume',
   'abort',
   'insert_queued_run',
   'cancel_queued_run',

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -33,7 +33,12 @@ import {
   parseCodingAgentSessionCommand,
 } from '../../coding-agents/session-command'
 import { contentBlocksToString } from './content-blocks'
-import { buildOutboundRunEvent, buildResumeEvents, buildResumeMessagePage } from './resume-payload'
+import {
+  buildAppResumeMessagePage,
+  buildOutboundRunEvent,
+  buildResumeEvents,
+  buildResumeMessagePage,
+} from './resume-payload'
 import type {
   BackgroundContinuationContext,
   ChatCodingAgentId,
@@ -582,6 +587,23 @@ export class ChatRunSocket {
       }
       socket.join(`session:${sid}`)
       await this.resumeSession(socket, sid)
+    })
+
+    socket.on('app.resume', async (data: { session_id?: string; id?: string }) => {
+      if (!data.session_id || typeof data.id !== 'string' || data.id.length > 128) return
+      const sid = data.session_id
+      try {
+        requireSocketSessionAccess(sid)
+      } catch (err) {
+        socket.emit('run.failed', {
+          event: 'run.failed',
+          session_id: sid,
+          error: err instanceof Error ? err.message : String(err),
+        })
+        return
+      }
+      socket.join(`session:${sid}`)
+      await this.resumeSession(socket, sid, { event: 'app.resumed', cachedId: data.id })
     })
 
     socket.on('abort', (data: { session_id?: string }) => {
@@ -1223,7 +1245,11 @@ export class ChatRunSocket {
 
   // --- Resume ---
 
-  private async resumeSession(socket: Socket, sid: string) {
+  private async resumeSession(
+    socket: Socket,
+    sid: string,
+    options?: { event: 'app.resumed'; cachedId: string },
+  ) {
     let state = this.sessionMap.get(sid)
     if (!state) {
       state = await loadSessionStateFromDb(sid, this.sessionMap)
@@ -1239,9 +1265,13 @@ export class ChatRunSocket {
       messageTotal: state.messageTotal,
       messageStateBaselineCount: state.messageStateBaselineCount,
     })
-    socket.emit('resumed', {
+    const appMessagePage = options
+      ? buildAppResumeMessagePage(messagePage, options.cachedId)
+      : null
+    const outboundMessagePage = appMessagePage || messagePage
+    socket.emit(options?.event || 'resumed', {
       session_id: sid,
-      ...messagePage,
+      ...outboundMessagePage,
       parentSessionId: sessionDetail?.parent_session_id || null,
       forkPointMessageId: sessionDetail?.fork_point_message_id || null,
       parentTitle: sessionDetail?.parent_title || null,
@@ -1274,8 +1304,9 @@ export class ChatRunSocket {
       backgroundPending: this.backgroundPendingCount(state),
     })
 
-    logger.info('[chat-run-socket] socket %s resumed session %s (working: %s, messages: %d)',
-      socket.id, sid, state.isWorking, state.messages.length)
+    logger.info('[chat-run-socket] socket %s resumed session %s (working: %s, messages: %d, app cache: %s)',
+      socket.id, sid, state.isWorking, state.messages.length,
+      appMessagePage ? (appMessagePage.messagesCached ? 'hit' : 'miss') : 'n/a')
   }
 
   private async reattachBridgeRun(socket: Socket, sid: string, state: SessionState) {

--- a/packages/server/src/services/hermes/run-chat/resume-payload.ts
+++ b/packages/server/src/services/hermes/run-chat/resume-payload.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto'
 import type { SessionMessage } from './types'
 
 export const RESUME_TOOL_RESULT_DISPLAY_LIMIT = 1_000
@@ -38,6 +39,12 @@ export interface ResumeMessagePage {
   messageLoadedCount: number
   messagePageLimit: number
   hasMoreBefore: boolean
+}
+
+export type AppResumeMessagePage = Omit<ResumeMessagePage, 'messages'> & {
+  id: string
+  messages?: SessionMessage[]
+  messagesCached: boolean
 }
 
 function stringifyLength(value: unknown): number {
@@ -220,6 +227,34 @@ export function buildResumeMessagePage(
     messagePageLimit,
     hasMoreBefore: messageTotal > messageLoadedCount,
   }
+}
+
+/**
+ * Build the App-only conditional message page. The App persists the last full
+ * page under this opaque id and sends the id with every `app.resume`. When the
+ * page is unchanged, only pagination metadata and live run state cross the
+ * relay; the App reuses its cached messages.
+ */
+export function buildAppResumeMessagePage(
+  page: ResumeMessagePage,
+  cachedIdInput: unknown,
+): AppResumeMessagePage {
+  const id = createHash('sha256')
+    .update(JSON.stringify(page))
+    .digest('hex')
+    .slice(0, 32)
+  const cachedId = typeof cachedIdInput === 'string' ? cachedIdInput.trim() : ''
+  if (cachedId && cachedId === id) {
+    return {
+      id,
+      messagesCached: true,
+      messageTotal: page.messageTotal,
+      messageLoadedCount: page.messageLoadedCount,
+      messagePageLimit: page.messagePageLimit,
+      hasMoreBefore: page.hasMoreBefore,
+    }
+  }
+  return { ...page, id, messagesCached: false }
 }
 
 /**

--- a/tests/server/app-relay-client.test.ts
+++ b/tests/server/app-relay-client.test.ts
@@ -439,6 +439,22 @@ describe('AppRelayClient', () => {
       event: 'run',
     })))
 
+    const resumeAck = vi.fn()
+    remote.__handlers.get('app.socket.event')({
+      id: 'relay-chat-1',
+      event: 'app.resume',
+      payload: { session_id: 'session-1', id: 'cache-1' },
+    }, resumeAck)
+    expect(local.emit).toHaveBeenCalledWith('app.resume', {
+      session_id: 'session-1',
+      id: 'cache-1',
+    })
+    await vi.waitFor(() => expect(resumeAck).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'relay-chat-1',
+      ok: true,
+      event: 'app.resume',
+    })))
+
     const insertAck = vi.fn()
     remote.__handlers.get('app.socket.event')({
       id: 'relay-chat-1',

--- a/tests/server/app-relay-server.test.ts
+++ b/tests/server/app-relay-server.test.ts
@@ -600,6 +600,22 @@ describe('LocalAppRelayServer', () => {
     })))
     expect(local.emit).toHaveBeenCalledWith('run', { session_id: 'session-1', input: 'hello' })
 
+    const resumeAck = vi.fn()
+    app.__handlers.get('socket.event')({
+      id: 'chat-1',
+      event: 'app.resume',
+      payload: { session_id: 'session-1', id: 'cache-1' },
+    }, resumeAck)
+    await vi.waitFor(() => expect(resumeAck).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'chat-1',
+      ok: true,
+      event: 'app.resume',
+    })))
+    expect(local.emit).toHaveBeenCalledWith('app.resume', {
+      session_id: 'session-1',
+      id: 'cache-1',
+    })
+
     const insertAck = vi.fn()
     app.__handlers.get('socket.event')({
       id: 'chat-1',

--- a/tests/server/run-chat-queued-item.test.ts
+++ b/tests/server/run-chat-queued-item.test.ts
@@ -675,6 +675,45 @@ describe('ChatRunSocket queued bridge runs', () => {
     }))
   })
 
+  it('serves App resume messages once and then accepts their cache id', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { handlers, io, socket } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+    ;(server as any).sessionMap.set('session-1', {
+      messages: [
+        { id: 1, session_id: 'session-1', role: 'user', content: 'hello', timestamp: 1 },
+        { id: 2, session_id: 'session-1', role: 'assistant', content: 'world', timestamp: 2 },
+      ],
+      isWorking: false,
+      isAborting: false,
+      events: [],
+      queue: [],
+    })
+
+    ;(server as any).onConnection(socket)
+    await handlers.get('app.resume')?.({ session_id: 'session-1', id: '' })
+    const initial = socket.emit.mock.calls.find(([event]) => event === 'app.resumed')?.[1]
+
+    expect(initial).toMatchObject({
+      session_id: 'session-1',
+      messages: expect.any(Array),
+      messagesCached: false,
+    })
+    expect(initial.id).toMatch(/^[a-f0-9]{32}$/)
+    expect(socket.join).toHaveBeenCalledWith('session:session-1')
+
+    socket.emit.mockClear()
+    await handlers.get('app.resume')?.({ session_id: 'session-1', id: initial.id })
+
+    expect(socket.emit).toHaveBeenCalledWith('app.resumed', expect.objectContaining({
+      session_id: 'session-1',
+      id: initial.id,
+      messagesCached: true,
+    }))
+    const cached = socket.emit.mock.calls.find(([event]) => event === 'app.resumed')?.[1]
+    expect(cached).not.toHaveProperty('messages')
+  })
+
   it('reattaches a loaded running bridge run during resume', async () => {
     bridgeMock.statusIfLoaded.mockResolvedValueOnce({
       ok: true,

--- a/tests/server/run-chat-resume-payload.test.ts
+++ b/tests/server/run-chat-resume-payload.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildAppResumeMessagePage,
   buildOutboundToolMessage,
   buildOutboundRunEvent,
   buildResumeEvents,
@@ -77,6 +78,43 @@ describe('buildResumeMessages', () => {
     expect(page.messageTotal).toBe(1_000)
     expect(page.messageLoadedCount).toBe(150)
     expect(page.hasMoreBefore).toBe(true)
+  })
+
+  it('omits App messages when the supplied cache id still matches', () => {
+    const page = buildResumeMessagePage([
+      message({ id: 1, role: 'user', content: 'hello' }),
+      message({ id: 2, role: 'assistant', content: 'world' }),
+    ])
+
+    const initial = buildAppResumeMessagePage(page, '')
+    const cached = buildAppResumeMessagePage(page, initial.id)
+
+    expect(initial).toMatchObject({
+      messages: page.messages,
+      messagesCached: false,
+    })
+    expect(initial.id).toMatch(/^[a-f0-9]{32}$/)
+    expect(cached).toEqual({
+      id: initial.id,
+      messagesCached: true,
+      messageTotal: 2,
+      messageLoadedCount: 2,
+      messagePageLimit: RESUME_MESSAGE_PAGE_LIMIT,
+      hasMoreBefore: false,
+    })
+  })
+
+  it('returns a new App page when cached message content changed under the same message id', () => {
+    const before = buildAppResumeMessagePage(buildResumeMessagePage([
+      message({ id: 7, role: 'assistant', content: 'partial' }),
+    ]), '')
+    const after = buildAppResumeMessagePage(buildResumeMessagePage([
+      message({ id: 7, role: 'assistant', content: 'complete' }),
+    ]), before.id)
+
+    expect(after.messagesCached).toBe(false)
+    expect(after.id).not.toBe(before.id)
+    expect(after.messages?.[0].content).toBe('complete')
   })
 
   it('truncates only the outbound tool result without mutating session history', () => {


### PR DESCRIPTION
## Summary
- add dedicated `app.resume` / `app.resumed` events for App chat restoration
- return an opaque content id and omit unchanged message pages when the App cache id matches
- allow the new event through both relay directions while preserving the existing Web UI `resume` / `resumed` contract
- document the chat-chain behavior and cover cache hits, cache invalidation, and relay forwarding

## Impact
App foreground restoration can reuse its scoped local message snapshot while still receiving fresh run, queue, usage, and session metadata, reducing repeated message payload transfer.

## Validation
- `npm run test -- tests/server/app-relay-client.test.ts tests/server/app-relay-server.test.ts tests/server/run-chat-queued-item.test.ts tests/server/run-chat-resume-payload.test.ts`
- `npm run harness:check`
- `npm run build`

## Notes
- The optimization activates when used with the companion App client update; older clients continue using the unchanged resume contract.