### PR TITLE
fix(chat): preserve thinking elapsed time across navigation

### DIFF
--- a/docs/chat-chain-changes/2026-08-22-thinking-elapsed-run-start.md
+++ b/docs/chat-chain-changes/2026-08-22-thinking-elapsed-run-start.md
@@ -1,0 +1,16 @@
+---
+date: 2026-08-22
+feature: thinking-timer-counts-from-the-real-run-start
+pr: 2693
+impact: The thinking timer shows how long the agent has actually been working instead of counting from the client's first render. No change to when the indicator appears or to run handling.
+---
+
+# Thinking timer origin
+
+`MessageList` started the elapsed clock with `thinkingStartedAt = Date.now()` the moment the run indicator became visible. That is the client's first render, not the run's start, so leaving a page mid-run and coming back showed the agent as having just started, and two devices watching one run disagreed — the one that stayed open kept counting, the one that navigated reset to zero.
+
+The run's start is only known server-side, so `SessionState` now carries `runStartedAt`, set at both points where a run begins working, and it is included in the `resumed` payload. The chat store keeps it per session, clearing it when the session reports it is no longer working, and the timer uses it as its origin.
+
+`Date.now()` remains the fallback when the value is absent, so a client talking to an older server behaves exactly as it does today rather than showing nothing.
+
+Nothing else changes: the indicator's visibility rule, the one-second tick, and the formatting are untouched.

--- a/docs/chat-chain-changes/2026-08-22-thinking-elapsed-run-start.md
+++ b/docs/chat-chain-changes/2026-08-22-thinking-elapsed-run-start.md
@@ -9,7 +9,7 @@ impact: The thinking timer shows how long the agent has actually been working in
 
 `MessageList` started the elapsed clock with `thinkingStartedAt = Date.now()` the moment the run indicator became visible. That is the client's first render, not the run's start, so leaving a page mid-run and coming back showed the agent as having just started, and two devices watching one run disagreed — the one that stayed open kept counting, the one that navigated reset to zero.
 
-The run's start is only known server-side, so `SessionState` now carries `runStartedAt`, set at both points where a run begins working, and it is included in the `resumed` payload. The chat store keeps it per session, clearing it when the session reports it is no longer working, and the timer uses it as its origin.
+The run's start is only known server-side, so `SessionState` now carries `runStartedAt`, set for direct, queued, background, and reattached runs, and it is included in the `resumed` payload. The chat store keeps it per session, refreshes it on every live `run.started`, clears it on terminal events, and the timer uses it as its origin.
 
 `Date.now()` remains the fallback when the value is absent, so a client talking to an older server behaves exactly as it does today rather than showing nothing.
 

--- a/packages/client/src/api/hermes/chat.ts
+++ b/packages/client/src/api/hermes/chat.ts
@@ -166,6 +166,8 @@ export interface ResumeSessionPayload {
   hasMoreBefore?: boolean
   isWorking: boolean
   isAborting?: boolean
+  /** Epoch ms the active run began; absent on servers that predate it. */
+  runStartedAt?: number
   events: Array<{ event: string; data: RunEvent }>
   inputTokens?: number
   outputTokens?: number

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -546,8 +546,13 @@ watch(
       thinkingElapsedMs.value = 0;
       return;
     }
-    thinkingStartedAt = Date.now();
-    thinkingElapsedMs.value = 0;
+    // Prefer when the run actually began. Opening the page mid-run used to
+    // start this clock at zero, so the same run read differently on two
+    // devices and restarted every time you navigated away and back.
+    const sid = chatStore.activeSessionId;
+    const reportedStart = sid ? chatStore.runStartedAt.get(sid) || 0 : 0;
+    thinkingStartedAt = reportedStart > 0 ? reportedStart : Date.now();
+    thinkingElapsedMs.value = Math.max(0, Date.now() - thinkingStartedAt);
     thinkingTimer = setInterval(() => {
       thinkingElapsedMs.value = Date.now() - thinkingStartedAt;
     }, 1000);

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -538,8 +538,15 @@ watch(
 );
 
 watch(
-  isRunIndicatorActive,
-  (visible) => {
+  // Switching between two sessions that are both already working leaves
+  // isRunIndicatorActive true, so the session and its reported start have to be
+  // watched too or the timer keeps the previous session's origin.
+  () => [
+    isRunIndicatorActive.value,
+    chatStore.activeSessionId,
+    chatStore.activeSessionId ? chatStore.runStartedAt.get(chatStore.activeSessionId) || 0 : 0,
+  ] as const,
+  ([visible]) => {
     stopThinkingTimer();
     if (!visible) {
       thinkingStartedAt = 0;

--- a/packages/client/src/components/hermes/chat/MessageList.vue
+++ b/packages/client/src/components/hermes/chat/MessageList.vue
@@ -561,7 +561,7 @@ watch(
     thinkingStartedAt = reportedStart > 0 ? reportedStart : Date.now();
     thinkingElapsedMs.value = Math.max(0, Date.now() - thinkingStartedAt);
     thinkingTimer = setInterval(() => {
-      thinkingElapsedMs.value = Date.now() - thinkingStartedAt;
+      thinkingElapsedMs.value = Math.max(0, Date.now() - thinkingStartedAt);
     }, 1000);
   },
   { immediate: true },

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -1271,6 +1271,30 @@ export const useChatStore = defineStore('chat', () => {
    * timer counts from its own first render and restarts on every navigation.
    */
   const runStartedAt = ref<Map<string, number>>(new Map())
+
+  function setRunStartedAt(sessionId: string, startedAt: number) {
+    if (!sessionId || !(startedAt > 0)) return
+    if (runStartedAt.value.get(sessionId) === startedAt) return
+    runStartedAt.value = new Map(runStartedAt.value).set(sessionId, startedAt)
+  }
+
+  function clearRunStartedAt(sessionId: string) {
+    if (!sessionId || !runStartedAt.value.has(sessionId)) return
+    const next = new Map(runStartedAt.value)
+    next.delete(sessionId)
+    runStartedAt.value = next
+  }
+
+  /**
+   * Every resume path has to agree about the run clock, and every terminal path
+   * has to forget it — otherwise the next run in the same session inherits the
+   * previous run's start and reports a far larger elapsed time.
+   */
+  function applyResumedRunStartedAt(sessionId: string, data: { isWorking?: boolean; runStartedAt?: number }) {
+    const startedAt = Number(data?.runStartedAt) || 0
+    if (data?.isWorking && startedAt > 0) setRunStartedAt(sessionId, startedAt)
+    else if (!data?.isWorking) clearRunStartedAt(sessionId)
+  }
   const queueLengths = ref<Map<string, number>>(new Map())
   /** sessionId → queued user messages not yet visible in the transcript */
   const queuedUserMessages = ref<Map<string, Message[]>>(new Map())
@@ -1907,14 +1931,7 @@ export const useChatStore = defineStore('chat', () => {
             replaceQueuedUserMessages(sessionId, [])
           }
           replaceQueueInsertionState(sessionId, data.queueInsertion)
-          const resumedRunStartedAt = Number((data as any).runStartedAt) || 0
-          if (data.isWorking && resumedRunStartedAt > 0) {
-            runStartedAt.value = new Map(runStartedAt.value).set(sessionId, resumedRunStartedAt)
-          } else if (!data.isWorking) {
-            const next = new Map(runStartedAt.value)
-            next.delete(sessionId)
-            runStartedAt.value = next
-          }
+          applyResumedRunStartedAt(sessionId, data as any)
           if ((data as any).isAborting) {
             setAbortState(sessionId, { aborting: true, synced: null })
           } else if (!data.isWorking) {
@@ -2639,6 +2656,7 @@ export const useChatStore = defineStore('chat', () => {
     if ((evt as any).terminal === true) {
       streamStates.value.delete(sid)
       serverWorking.value.delete(sid)
+      clearRunStartedAt(sid)
       pendingForkCommands.value.delete(sid)
       const msgs = getSessionMsgs(sid)
       msgs.forEach((m, i) => {
@@ -2686,6 +2704,7 @@ export const useChatStore = defineStore('chat', () => {
     if (action === 'destroy') {
       streamStates.value.delete(sid)
       serverWorking.value.delete(sid)
+      clearRunStartedAt(sid)
       queueLengths.value.delete(sid)
       queuedUserMessages.value.delete(sid)
       queueInsertionStates.value.delete(sid)
@@ -3430,6 +3449,8 @@ export const useChatStore = defineStore('chat', () => {
       const cleanup = () => {
         streamStates.value.delete(sid)
         serverWorking.value.delete(sid)
+        // The run is over: its start must not leak into the next one.
+        clearRunStartedAt(sid)
       }
 
       // Per-active-run flags used to detect silently-swallowed errors at run.completed.
@@ -3464,6 +3485,7 @@ export const useChatStore = defineStore('chat', () => {
 
         if (data.isWorking) serverWorking.value.add(sid)
         else serverWorking.value.delete(sid)
+        applyResumedRunStartedAt(sid, data as any)
 
         if (data.queueLength && data.queueLength > 0) {
           queueLengths.value.set(sid, data.queueLength)
@@ -5081,6 +5103,7 @@ export const useChatStore = defineStore('chat', () => {
             } else {
               serverWorking.value.delete(sid)
             }
+            applyResumedRunStartedAt(sid, data as any)
             if (data.isAborting) {
               setAbortState(sid, { aborting: true, synced: null })
             } else if (!data.isWorking) {

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -1293,7 +1293,7 @@ export const useChatStore = defineStore('chat', () => {
   function applyResumedRunStartedAt(sessionId: string, data: { isWorking?: boolean; runStartedAt?: number }) {
     const startedAt = Number(data?.runStartedAt) || 0
     if (data?.isWorking && startedAt > 0) setRunStartedAt(sessionId, startedAt)
-    else if (!data?.isWorking) clearRunStartedAt(sessionId)
+    else clearRunStartedAt(sessionId)
   }
   const queueLengths = ref<Map<string, number>>(new Map())
   /** sessionId → queued user messages not yet visible in the transcript */
@@ -2652,6 +2652,7 @@ export const useChatStore = defineStore('chat', () => {
     const command = String((evt as any).command || '').toLowerCase()
     if ((evt as any).started === true && (evt as any).terminal === false) {
       serverWorking.value.add(sid)
+      setRunStartedAt(sid, Date.now())
     }
     if ((evt as any).terminal === true) {
       streamStates.value.delete(sid)
@@ -3322,7 +3323,10 @@ export const useChatStore = defineStore('chat', () => {
     } else {
       addMessage(sid, userMsg)
       updateSessionTitle(sid)
-      if (shouldOptimisticallyShowRunStatus) serverWorking.value.add(sid)
+      if (shouldOptimisticallyShowRunStatus) {
+        setRunStartedAt(sid, Date.now())
+        serverWorking.value.add(sid)
+      }
     }
     clearMessageReference(sid)
 
@@ -3635,6 +3639,7 @@ export const useChatStore = defineStore('chat', () => {
             case 'run.started':
               clearSessionCompletedUnread(sid)
               serverWorking.value.add(sid)
+              setRunStartedAt(sid, Date.now())
               clearAgentEventMessages(sid)
               setAbortState(sid, null)
               setCompressionState(sid, null)
@@ -4016,6 +4021,7 @@ export const useChatStore = defineStore('chat', () => {
             }
 
             case 'run.completed': {
+              clearRunStartedAt(sid)
               const msgs = getSessionMsgs(sid)
               const lastMsg = activeAssistantMessageId
                 ? msgs.find(m => m.id === activeAssistantMessageId)
@@ -4173,6 +4179,7 @@ export const useChatStore = defineStore('chat', () => {
             }
 
             case 'run.failed': {
+              clearRunStartedAt(sid)
               clearPendingInteractions(sid)
               const failedMessages = getSessionMsgs(sid)
               const failedAssistant = activeAssistantMessageId
@@ -4302,6 +4309,7 @@ export const useChatStore = defineStore('chat', () => {
       closed = true
       streamStates.value.delete(sid)
       serverWorking.value.delete(sid)
+      clearRunStartedAt(sid)
       // Unregister from global session handlers
       unregisterSessionHandlers(sid)
     }
@@ -4309,6 +4317,7 @@ export const useChatStore = defineStore('chat', () => {
     const markIdleKeepingBackgroundListener = () => {
       streamStates.value.delete(sid)
       serverWorking.value.delete(sid)
+      clearRunStartedAt(sid)
     }
 
     const ensureAbortHandle = () => {
@@ -4396,6 +4405,7 @@ export const useChatStore = defineStore('chat', () => {
         case 'run.started':
           clearSessionCompletedUnread(sid)
           serverWorking.value.add(sid)
+          setRunStartedAt(sid, Date.now())
           ensureAbortHandle()
           clearAgentEventMessages(sid)
           setAbortState(sid, null)
@@ -4733,6 +4743,7 @@ export const useChatStore = defineStore('chat', () => {
         }
 
         case 'run.completed': {
+          clearRunStartedAt(sid)
           clearAgentEventMessages(sid)
           const hasQueue = (evt as any).queue_remaining > 0
           const hasBackground = (evt.background_pending || 0) > 0
@@ -4888,6 +4899,7 @@ export const useChatStore = defineStore('chat', () => {
         }
 
         case 'run.failed': {
+          clearRunStartedAt(sid)
           clearPendingInteractions(sid)
           const failedMessages = getSessionMsgs(sid)
           const failedAssistant = activeAssistantMessageId

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -1265,6 +1265,12 @@ export const useChatStore = defineStore('chat', () => {
       : null,
   )
   /** sessionId → queued message count */
+  /**
+   * When the run showing in each session began, as the server reported it.
+   * A client that opens the page mid-run needs this: without it the thinking
+   * timer counts from its own first render and restarts on every navigation.
+   */
+  const runStartedAt = ref<Map<string, number>>(new Map())
   const queueLengths = ref<Map<string, number>>(new Map())
   /** sessionId → queued user messages not yet visible in the transcript */
   const queuedUserMessages = ref<Map<string, Message[]>>(new Map())
@@ -1901,6 +1907,14 @@ export const useChatStore = defineStore('chat', () => {
             replaceQueuedUserMessages(sessionId, [])
           }
           replaceQueueInsertionState(sessionId, data.queueInsertion)
+          const resumedRunStartedAt = Number((data as any).runStartedAt) || 0
+          if (data.isWorking && resumedRunStartedAt > 0) {
+            runStartedAt.value = new Map(runStartedAt.value).set(sessionId, resumedRunStartedAt)
+          } else if (!data.isWorking) {
+            const next = new Map(runStartedAt.value)
+            next.delete(sessionId)
+            runStartedAt.value = next
+          }
           if ((data as any).isAborting) {
             setAbortState(sessionId, { aborting: true, synced: null })
           } else if (!data.isWorking) {
@@ -5261,6 +5275,7 @@ export const useChatStore = defineStore('chat', () => {
     isForkPending,
     isRunActive,
     isSessionLive,
+    runStartedAt,
     isSessionCompletedUnread,
     clearSessionCompletedUnread,
     sessionProfileFilter,

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -496,6 +496,7 @@ export class ChatRunSocket {
         }
         state.events = []
         state.isWorking = !isCodingAgentExecution(source, data)
+        state.runStartedAt = Date.now()
         state.profile = runProfile
         state.source = source
       }
@@ -1292,6 +1293,7 @@ export class ChatRunSocket {
       reasoning_effort: sessionDetail?.reasoning_effort || '',
       push_enabled: Number(sessionDetail?.push_enabled || 0) !== 0,
       isWorking: state.isWorking,
+      runStartedAt: state.runStartedAt,
       isAborting: state.isAborting || false,
       events: buildResumeEvents(resumeEvents),
       inputTokens: state.inputTokens,
@@ -1716,6 +1718,7 @@ export class ChatRunSocket {
     const state = getOrCreateSession(this.sessionMap, sessionId)
     state.events = []
     state.isWorking = !isCodingAgentExecution(source, data)
+    state.runStartedAt = Date.now()
     state.profile = profile
     state.source = source
 

--- a/packages/server/src/services/hermes/run-chat/index.ts
+++ b/packages/server/src/services/hermes/run-chat/index.ts
@@ -1334,6 +1334,12 @@ export class ChatRunSocket {
       pollKey = `${sid}:${runId}`
       if (this.bridgeResumePolls.has(pollKey)) return
       this.bridgeResumePolls.add(pollKey)
+      if (!state.isWorking || !(state.runStartedAt && state.runStartedAt > 0)) {
+        // The bridge does not expose the original start in its lightweight
+        // status response. Use one shared server-side fallback for every
+        // client attaching after this Web UI process discovers the run.
+        state.runStartedAt = Date.now()
+      }
       state.isWorking = true
       state.isAborting = state.isAborting === true
       state.runId = runId
@@ -1615,6 +1621,8 @@ export class ChatRunSocket {
   }
 
   private runQueuedItem(socket: Socket, sessionId: string, next: QueuedRun, fallbackProfile = 'default') {
+    const state = this.sessionMap.get(sessionId)
+    if (state) state.runStartedAt = Date.now()
     const skipUserMessage = next.displayInput === null
     const backgroundContinuationContext = next.backgroundContinuationContext
       || (next.backgroundDelegationId

--- a/packages/server/src/services/hermes/run-chat/types.ts
+++ b/packages/server/src/services/hermes/run-chat/types.ts
@@ -126,6 +126,12 @@ export interface SessionState {
   messageStateBaselineCount?: number
   hasMoreBefore?: boolean
   isWorking: boolean
+  /**
+   * When the current run began, so a client that joins late shows how long
+   * the agent has really been working rather than counting from its own
+   * first render.
+   */
+  runStartedAt?: number
   events: Array<{ event: string; data: any }>
   abortController?: AbortController
   runId?: string

--- a/tests/client/chat-store-run-started-at.test.ts
+++ b/tests/client/chat-store-run-started-at.test.ts
@@ -4,6 +4,7 @@ import { createPinia, setActivePinia } from 'pinia'
 
 const chatApi = vi.hoisted(() => ({
   startRunViaSocket: vi.fn(),
+  sessionHandlers: new Map<string, any>(),
   registerSessionHandlers: vi.fn(),
   unregisterSessionHandlers: vi.fn(),
   socketEmit: vi.fn(),
@@ -69,7 +70,6 @@ vi.mock('@/utils/completion-sound', () => ({
   playCompletionSound: vi.fn(),
 }))
 
-import { readFileSync } from 'fs'
 import { useChatStore, type Session } from '@/stores/hermes/chat'
 
 function makeSession(): Session {
@@ -95,6 +95,13 @@ describe('chat store run start bookkeeping', () => {
     chatApi.sessionCommandHandlers = []
     chatApi.peerUserMessageHandlers = []
     chatApi.sessionTitleUpdatedHandlers = []
+    chatApi.sessionHandlers = new Map()
+    chatApi.registerSessionHandlers.mockImplementation((sessionId: string, handlers: any) => {
+      chatApi.sessionHandlers.set(sessionId, handlers)
+    })
+    chatApi.unregisterSessionHandlers.mockImplementation((sessionId: string) => {
+      chatApi.sessionHandlers.delete(sessionId)
+    })
     chatApi.startRunViaSocket.mockReturnValue({ abort: vi.fn() })
     setActivePinia(createPinia())
   })
@@ -155,6 +162,7 @@ describe('chat store run start bookkeeping', () => {
     await store.sendMessage('go on then')
     const onEvent = chatApi.startRunViaSocket.mock.calls[0][1] as (event: any) => void
     onEvent({ event: 'run.started', session_id: 'a', run_id: 'run-1' })
+    expect(store.runStartedAt.get('a')).not.toBe(RUN_STARTED_AT)
     onEvent({ event: 'run.completed', session_id: 'a', run_id: 'run-1', output: 'done' })
 
     // The finished run's start must not linger for whatever runs next.
@@ -170,24 +178,39 @@ describe('chat store run start bookkeeping', () => {
 
     expect(store.runStartedAt.has('a')).toBe(false)
   })
-})
 
-/**
- * MessageList is asserted against source, the way
- * tests/client/chat-panel-session-click.test.ts already does — mounting it
- * drags in the whole chat surface.
- */
-describe('thinking timer watcher', () => {
-  const source = readFileSync('packages/client/src/components/hermes/chat/MessageList.vue', 'utf8')
+  it('clears the start when a resumed run ends and refreshes it for the next queued run', async () => {
+    const store = useChatStore()
+    store.sessions = [{ ...makeSession(), id: 'a' }] as any
+    resumeWith({ isWorking: true, runStartedAt: RUN_STARTED_AT })
 
-  it('restarts when the session or its reported start changes, not only when the indicator flips', () => {
-    const watched = source.slice(source.indexOf('watch(\n  // Switching between two sessions'))
-    expect(watched).toContain('isRunIndicatorActive.value')
-    expect(watched).toContain('chatStore.activeSessionId')
-    expect(watched).toContain('chatStore.runStartedAt.get(chatStore.activeSessionId)')
+    await store.switchSession('a')
+    const handlers = chatApi.sessionHandlers.get('a')
+    expect(handlers).toBeTruthy()
+
+    handlers.onRunCompleted({
+      event: 'run.completed',
+      session_id: 'a',
+      run_id: 'run-1',
+      output: 'done',
+      queue_remaining: 1,
+      background_pending: 0,
+    })
+    expect(store.runStartedAt.has('a')).toBe(false)
+
+    handlers.onRunStarted({ event: 'run.started', session_id: 'a', run_id: 'run-2' })
+    expect(store.runStartedAt.get('a')).toBeGreaterThan(RUN_STARTED_AT)
   })
 
-  it('uses the reported start as the origin and keeps Date.now() as the fallback', () => {
-    expect(source).toContain('thinkingStartedAt = reportedStart > 0 ? reportedStart : Date.now()')
+  it('drops a stale start when a working resume has no timestamp', async () => {
+    const store = useChatStore()
+    store.sessions = [{ ...makeSession(), id: 'a' }] as any
+    resumeWith({ isWorking: true, runStartedAt: RUN_STARTED_AT })
+    await store.switchSession('a')
+
+    resumeWith({ isWorking: true })
+    await store.switchSession('a')
+
+    expect(store.runStartedAt.has('a')).toBe(false)
   })
 })

--- a/tests/client/chat-store-run-started-at.test.ts
+++ b/tests/client/chat-store-run-started-at.test.ts
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+
+const chatApi = vi.hoisted(() => ({
+  startRunViaSocket: vi.fn(),
+  registerSessionHandlers: vi.fn(),
+  unregisterSessionHandlers: vi.fn(),
+  socketEmit: vi.fn(),
+  getChatRunSocket: vi.fn(() => ({ emit: chatApi.socketEmit })),
+  resumeSession: vi.fn((sessionId: string, onResumed: (data: any) => void) => {
+    onResumed({ session_id: sessionId, messages: [], isWorking: false, events: [], queueLength: 0 })
+    return {} as any
+  }),
+  sessionCommandHandlers: [] as Array<(event: any) => void>,
+  peerUserMessageHandlers: [] as Array<(event: any) => void>,
+  sessionTitleUpdatedHandlers: [] as Array<(event: any) => void>,
+  sessionWorkspaceUpdatedHandlers: [] as Array<(event: any) => void>,
+}))
+
+vi.mock('@/api/hermes/chat', () => ({
+  startRunViaSocket: chatApi.startRunViaSocket,
+  resumeSession: chatApi.resumeSession,
+  registerSessionHandlers: chatApi.registerSessionHandlers,
+  unregisterSessionHandlers: chatApi.unregisterSessionHandlers,
+  getChatRunSocket: chatApi.getChatRunSocket,
+  respondToolApproval: vi.fn(),
+  respondClarify: vi.fn(),
+  onPeerUserMessage: vi.fn((handler: (event: any) => void) => {
+    chatApi.peerUserMessageHandlers.push(handler)
+    return vi.fn()
+  }),
+  onSessionCommand: vi.fn((handler: (event: any) => void) => {
+    chatApi.sessionCommandHandlers.push(handler)
+    return vi.fn()
+  }),
+  onSessionTitleUpdated: vi.fn((handler: (event: any) => void) => {
+    chatApi.sessionTitleUpdatedHandlers.push(handler)
+    return vi.fn()
+  }),
+  onSessionWorkspaceUpdated: vi.fn((handler: (event: any) => void) => {
+    chatApi.sessionWorkspaceUpdatedHandlers.push(handler)
+    return vi.fn()
+  }),
+  onSessionSettingsUpdated: vi.fn(() => vi.fn()),
+}))
+
+vi.mock('@/api/client', () => ({
+  getActiveProfileName: () => 'default',
+  hasApiKey: () => false,
+}))
+
+vi.mock('@/api/hermes/sessions', () => ({
+  archiveSession: vi.fn(),
+  deleteSession: vi.fn(),
+  fetchSession: vi.fn(),
+  fetchSessions: vi.fn(),
+  fetchWorkspaceRunChangesForSession: vi.fn(async () => []),
+  fetchWorkspaceRunChangeFile: vi.fn(async () => null),
+  setSessionModel: vi.fn(),
+}))
+
+vi.mock('@/api/hermes/download', () => ({
+  getDownloadUrl: (_path: string, name: string) => `/download/${name}`,
+}))
+
+vi.mock('@/utils/completion-sound', () => ({
+  primeCompletionSound: vi.fn(),
+  playCompletionSound: vi.fn(),
+}))
+
+import { readFileSync } from 'fs'
+import { useChatStore, type Session } from '@/stores/hermes/chat'
+
+function makeSession(): Session {
+  return {
+    id: 'session-1',
+    title: 'session',
+    messages: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  }
+}
+
+/**
+ * The run clock is per session and belongs to one run. It has to survive a
+ * resume, be dropped the moment that run ends, and never be inherited by the
+ * next run or by another session.
+ */
+describe('chat store run start bookkeeping', () => {
+  const RUN_STARTED_AT = 1_787_000_000_000
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    chatApi.sessionCommandHandlers = []
+    chatApi.peerUserMessageHandlers = []
+    chatApi.sessionTitleUpdatedHandlers = []
+    chatApi.startRunViaSocket.mockReturnValue({ abort: vi.fn() })
+    setActivePinia(createPinia())
+  })
+
+  function resumeWith(payload: Record<string, any>) {
+    chatApi.resumeSession.mockImplementation((sessionId: string, onResumed: (data: any) => void) => {
+      onResumed({ session_id: sessionId, messages: [], events: [], queueLength: 0, ...payload })
+      return {} as any
+    })
+  }
+
+  it('keeps the reported start while the run is working', async () => {
+    const store = useChatStore()
+    store.sessions = [{ ...makeSession(), id: 'a' }] as any
+    resumeWith({ isWorking: true, runStartedAt: RUN_STARTED_AT })
+
+    await store.switchSession('a')
+
+    expect(store.runStartedAt.get('a')).toBe(RUN_STARTED_AT)
+  })
+
+  it('drops it when the resumed session is no longer working', async () => {
+    const store = useChatStore()
+    store.sessions = [{ ...makeSession(), id: 'a' }] as any
+    resumeWith({ isWorking: true, runStartedAt: RUN_STARTED_AT })
+    await store.switchSession('a')
+
+    resumeWith({ isWorking: false })
+    await store.switchSession('a')
+
+    // A finished run must not leave its start behind for the next one.
+    expect(store.runStartedAt.has('a')).toBe(false)
+  })
+
+  it('keeps two working sessions on their own starts', async () => {
+    const store = useChatStore()
+    store.sessions = [{ ...makeSession(), id: 'a' }, { ...makeSession(), id: 'b' }] as any
+
+    resumeWith({ isWorking: true, runStartedAt: RUN_STARTED_AT })
+    await store.switchSession('a')
+    resumeWith({ isWorking: true, runStartedAt: RUN_STARTED_AT + 60_000 })
+    await store.switchSession('b')
+
+    expect(store.runStartedAt.get('a')).toBe(RUN_STARTED_AT)
+    expect(store.runStartedAt.get('b')).toBe(RUN_STARTED_AT + 60_000)
+  })
+
+  it('forgets the start when the run ends, so the next run does not inherit it', async () => {
+    const store = useChatStore()
+    const session = { ...makeSession(), id: 'a' } as any
+    store.sessions = [session]
+    resumeWith({ isWorking: true, runStartedAt: RUN_STARTED_AT })
+    await store.switchSession('a')
+    expect(store.runStartedAt.get('a')).toBe(RUN_STARTED_AT)
+
+    store.activeSessionId = 'a'
+    store.activeSession = session
+    await store.sendMessage('go on then')
+    const onEvent = chatApi.startRunViaSocket.mock.calls[0][1] as (event: any) => void
+    onEvent({ event: 'run.started', session_id: 'a', run_id: 'run-1' })
+    onEvent({ event: 'run.completed', session_id: 'a', run_id: 'run-1', output: 'done' })
+
+    // The finished run's start must not linger for whatever runs next.
+    expect(store.runStartedAt.has('a')).toBe(false)
+  })
+
+  it('ignores a start that arrives without the session working', async () => {
+    const store = useChatStore()
+    store.sessions = [{ ...makeSession(), id: 'a' }] as any
+    resumeWith({ isWorking: false, runStartedAt: RUN_STARTED_AT })
+
+    await store.switchSession('a')
+
+    expect(store.runStartedAt.has('a')).toBe(false)
+  })
+})
+
+/**
+ * MessageList is asserted against source, the way
+ * tests/client/chat-panel-session-click.test.ts already does — mounting it
+ * drags in the whole chat surface.
+ */
+describe('thinking timer watcher', () => {
+  const source = readFileSync('packages/client/src/components/hermes/chat/MessageList.vue', 'utf8')
+
+  it('restarts when the session or its reported start changes, not only when the indicator flips', () => {
+    const watched = source.slice(source.indexOf('watch(\n  // Switching between two sessions'))
+    expect(watched).toContain('isRunIndicatorActive.value')
+    expect(watched).toContain('chatStore.activeSessionId')
+    expect(watched).toContain('chatStore.runStartedAt.get(chatStore.activeSessionId)')
+  })
+
+  it('uses the reported start as the origin and keeps Date.now() as the fallback', () => {
+    expect(source).toContain('thinkingStartedAt = reportedStart > 0 ? reportedStart : Date.now()')
+  })
+})

--- a/tests/client/message-list-run-started-at.test.ts
+++ b/tests/client/message-list-run-started-at.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * MessageList is asserted against source, the way
+ * tests/client/chat-panel-session-click.test.ts already does — mounting it
+ * drags in the whole chat surface.
+ */
+describe('thinking timer watcher', () => {
+  const source = readFileSync('packages/client/src/components/hermes/chat/MessageList.vue', 'utf8')
+
+  it('restarts when the session or its reported start changes, not only when the indicator flips', () => {
+    const watched = source.slice(source.indexOf('watch(\n  // Switching between two sessions'))
+    expect(watched).toContain('isRunIndicatorActive.value')
+    expect(watched).toContain('chatStore.activeSessionId')
+    expect(watched).toContain('chatStore.runStartedAt.get(chatStore.activeSessionId)')
+  })
+
+  it('uses the reported start as the origin, falls back to Date.now(), and never displays a negative time', () => {
+    expect(source).toContain('thinkingStartedAt = reportedStart > 0 ? reportedStart : Date.now()')
+    expect(source.match(/thinkingElapsedMs\.value = Math\.max\(0, Date\.now\(\) - thinkingStartedAt\)/g)).toHaveLength(2)
+  })
+})

--- a/tests/server/health-controller.test.ts
+++ b/tests/server/health-controller.test.ts
@@ -12,6 +12,7 @@ function readRootPackage() {
 type LoadHealthControllerOptions = {
   injectedVersion?: string
   isDocker?: boolean
+  disableUpdateCheck?: boolean
   bridgeReadiness?: any
   bridgeReadinessError?: Error
   managerError?: Error
@@ -35,6 +36,7 @@ const defaultBridgeReadiness = {
 
 async function loadHealthController(options: LoadHealthControllerOptions = {}) {
   vi.resetModules()
+  vi.stubEnv('HERMES_WEB_UI_DISABLE_UPDATE_CHECK', options.disableUpdateCheck ? 'true' : '')
 
   if (typeof options.injectedVersion === 'string') {
     ;(globalThis as any).__APP_VERSION__ = options.injectedVersion
@@ -94,6 +96,8 @@ function createMockCtx() {
 describe('liveness controller', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
     vi.resetModules()
   })
 
@@ -112,6 +116,8 @@ describe('liveness controller', () => {
 describe('health controller version metadata', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
     vi.resetModules()
     ;(globalThis as any).__APP_VERSION__ = 'test'
   })
@@ -190,6 +196,21 @@ describe('health controller version metadata', () => {
     const { checkLatestVersion } = await loadHealthControllerWithoutInjectedVersion()
 
     await expect(checkLatestVersion()).resolves.toBeUndefined()
+  })
+
+  it('skips npm latest when update checks are explicitly disabled', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { checkLatestVersion, healthCheck } = await loadHealthController({ disableUpdateCheck: true })
+
+    await checkLatestVersion()
+    const ctx = createMockCtx()
+    await healthCheck(ctx)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(ctx.body.webui_latest).toBe('')
+    expect(ctx.body.webui_update_available).toBe(false)
   })
 
   it('reports Docker while retaining version checks for upgrade guidance', async () => {

--- a/tests/server/hermes-plugins-config.test.ts
+++ b/tests/server/hermes-plugins-config.test.ts
@@ -42,6 +42,8 @@ describe('Hermes plugin configuration', () => {
     chmodSync(fakeHermes, 0o755)
 
     process.env.HERMES_BIN = fakeHermes
+    process.env.HERMES_AGENT_ROOT = agentRoot
+    process.env.HERMES_AGENT_BRIDGE_PYTHON = fakePython
     process.env.PLUGIN_JSON = JSON.stringify({
       plugins: [{
         key: 'local-plugin',

--- a/tests/server/run-chat-run-started-at.test.ts
+++ b/tests/server/run-chat-run-started-at.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const handleBridgeRunMock = vi.hoisted(() => vi.fn(async () => {}))
+const resumeBridgeRunMock = vi.hoisted(() => vi.fn(async () => {}))
+const handleCodingAgentRunMock = vi.hoisted(() => vi.fn(async () => {}))
+const loadSessionStateFromDbMock = vi.hoisted(() => vi.fn())
+const ensureReadyMock = vi.hoisted(() => vi.fn())
+const getRuntimeStateMock = vi.hoisted(() => vi.fn())
+const userCanAccessProfileMock = vi.hoisted(() => vi.fn((_user: unknown, _profile: string) => true))
+const getSessionMock = vi.hoisted(() => vi.fn((sessionId?: string) => sessionId
+  ? { id: sessionId, profile: 'default', source: 'cli', model: 'gpt-test', provider: 'openai' }
+  : undefined))
+const bridgeMock = vi.hoisted(() => ({
+  status: vi.fn(),
+  statusIfLoaded: vi.fn(),
+  releaseBackgroundNotification: vi.fn(async () => ({ ok: true, released: true })),
+  close: vi.fn(async () => {}),
+  approvalRespond: vi.fn(async () => ({ resolved: true })),
+  clarifyRespond: vi.fn(async () => ({ resolved: true })),
+}))
+
+vi.mock('../../packages/server/src/services/hermes/run-chat/handle-bridge-run', () => ({
+  handleBridgeRun: handleBridgeRunMock,
+  resumeBridgeRun: resumeBridgeRunMock,
+}))
+
+vi.mock('../../packages/server/src/services/hermes/run-chat/load-state', () => ({
+  loadSessionStateFromDb: loadSessionStateFromDbMock,
+  resolveRunSource: vi.fn((source?: string) => source || 'cli'),
+}))
+
+vi.mock('../../packages/server/src/services/hermes/run-chat/handle-coding-agent-run', () => ({
+  handleCodingAgentRun: handleCodingAgentRunMock,
+}))
+
+vi.mock('../../packages/server/src/services/hermes/run-chat/session-command', () => ({
+  handleSessionCommand: vi.fn(),
+  isSessionCommand: vi.fn(() => false),
+  parseSessionCommand: vi.fn(() => null),
+}))
+
+vi.mock('../../packages/server/src/services/hermes/agent-bridge', () => ({
+  AgentBridgeClient: vi.fn(() => bridgeMock),
+}))
+
+vi.mock('../../packages/server/src/services/hermes/agent-bridge/manager', () => ({
+  getAgentBridgeManager: vi.fn(() => ({
+    ensureReady: ensureReadyMock,
+    getRuntimeState: getRuntimeStateMock,
+  })),
+}))
+
+vi.mock('../../packages/server/src/services/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+vi.mock('../../packages/server/src/lib/llm-prompt', () => ({
+  getSystemPrompt: vi.fn(() => 'system prompt'),
+}))
+
+vi.mock('../../packages/server/src/db/hermes/session-store', () => ({
+  getSession: getSessionMock,
+  getSessionMetadata: getSessionMock,
+  getSessionDetail: vi.fn(() => null),
+}))
+
+vi.mock('../../packages/server/src/services/hermes/hermes-profile', () => ({
+  getActiveProfileName: vi.fn(() => 'default'),
+  getProfileDir: vi.fn(() => '/tmp/hermes-default'),
+  listProfileNamesFromDisk: vi.fn(() => ['default', 'research']),
+}))
+
+vi.mock('../../packages/server/src/middleware/user-auth', () => ({
+  authenticateUserToken: vi.fn(),
+  isAuthEnabled: vi.fn(async () => false),
+}))
+
+vi.mock('../../packages/server/src/db/hermes/users-store', () => ({
+  userCanAccessProfile: userCanAccessProfileMock,
+}))
+
+function makeServerHarness() {
+  const handlers = new Map<string, Function>()
+  const emitted: Array<{ room: string; event: string; payload: any }> = []
+  const namespace = {
+    adapter: { rooms: new Map() },
+    to: vi.fn((room: string) => ({
+      emit: vi.fn((event: string, payload: any) => emitted.push({ room, event, payload })),
+    })),
+    use: vi.fn(),
+    on: vi.fn(),
+  }
+  const io = { of: vi.fn(() => namespace) }
+  const socket = {
+    id: 'socket-1',
+    connected: true,
+    handshake: { auth: {}, query: { profile: 'default' } },
+    data: {},
+    emit: vi.fn(),
+    join: vi.fn(),
+    to: vi.fn(() => ({ emit: vi.fn() })),
+    on: vi.fn((event: string, handler: Function) => {
+      handlers.set(event, handler)
+    }),
+  }
+  return { emitted, handlers, io, namespace, socket }
+}
+
+/**
+ * The thinking timer used to start at the client's first render, so reopening
+ * a session mid-run showed the agent as having just started, and two devices
+ * disagreed about the same run. The run's real start is only known server-side.
+ */
+describe('ChatRunSocket reports when the run started', () => {
+  beforeEach(() => {
+    ensureReadyMock.mockReset()
+    getRuntimeStateMock.mockReset()
+    ensureReadyMock.mockResolvedValue({
+      reachable: true,
+      status: 'ready',
+      endpoint: 'ipc:///tmp/hermes-agent-bridge.sock',
+    })
+    getRuntimeStateMock.mockReturnValue({ endpoint: 'ipc:///tmp/hermes-agent-bridge.sock' })
+  })
+
+  it('sends the run start to a client resuming a working session', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { handlers, io, socket } = makeServerHarness()
+    ;(socket.data as any).user = { id: 1, username: 'admin', role: 'super_admin' }
+    const server = new ChatRunSocket(io as any)
+    const startedAt = 1_787_000_000_000
+    ;(server as any).sessionMap.set('s1', {
+      messages: [], events: [], queue: [], isWorking: true, profile: 'default', runStartedAt: startedAt,
+    })
+
+    ;(server as any).onConnection(socket)
+    await handlers.get('resume')?.({ session_id: 's1' })
+
+    const resumed = socket.emit.mock.calls.find((call: any[]) => call[0] === 'resumed')
+    expect(resumed).toBeTruthy()
+    expect(resumed![1]).toMatchObject({ isWorking: true, runStartedAt: startedAt })
+  })
+
+  it('leaves it unset for a session that is not working', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { handlers, io, socket } = makeServerHarness()
+    ;(socket.data as any).user = { id: 1, username: 'admin', role: 'super_admin' }
+    const server = new ChatRunSocket(io as any)
+    ;(server as any).sessionMap.set('s2', {
+      messages: [], events: [], queue: [], isWorking: false, profile: 'default',
+    })
+
+    ;(server as any).onConnection(socket)
+    await handlers.get('resume')?.({ session_id: 's2' })
+
+    const resumed = socket.emit.mock.calls.find((call: any[]) => call[0] === 'resumed')
+    expect(resumed![1].isWorking).toBe(false)
+    expect(resumed![1].runStartedAt).toBeUndefined()
+  })
+})

--- a/tests/server/run-chat-run-started-at.test.ts
+++ b/tests/server/run-chat-run-started-at.test.ts
@@ -113,8 +113,10 @@ function makeServerHarness() {
  */
 describe('ChatRunSocket reports when the run started', () => {
   beforeEach(() => {
+    vi.restoreAllMocks()
     ensureReadyMock.mockReset()
     getRuntimeStateMock.mockReset()
+    bridgeMock.statusIfLoaded.mockReset()
     ensureReadyMock.mockResolvedValue({
       reachable: true,
       status: 'ready',
@@ -156,5 +158,48 @@ describe('ChatRunSocket reports when the run started', () => {
     const resumed = socket.emit.mock.calls.find((call: any[]) => call[0] === 'resumed')
     expect(resumed![1].isWorking).toBe(false)
     expect(resumed![1].runStartedAt).toBeUndefined()
+  })
+
+  it('refreshes the start when a queued run becomes active', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { io, socket } = makeServerHarness()
+    const server = new ChatRunSocket(io as any)
+    const previousStart = 1_787_000_000_000
+    const nextStart = previousStart + 60_000
+    const state = {
+      messages: [],
+      events: [],
+      queue: [{ queue_id: 'q2', input: 'second', profile: 'default', source: 'cli' }],
+      isWorking: false,
+      profile: 'default',
+      runStartedAt: previousStart,
+    }
+    ;(server as any).sessionMap.set('s3', state)
+    vi.spyOn(server as any, 'handleRun').mockResolvedValue(undefined)
+    vi.spyOn(Date, 'now').mockReturnValue(nextStart)
+
+    ;(server as any).dequeueNextQueuedRun(socket, 's3', 'default')
+
+    expect(state.runStartedAt).toBe(nextStart)
+  })
+
+  it('uses a new shared fallback when the server reattaches an existing bridge run', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/services/hermes/run-chat')
+    const { handlers, io, socket } = makeServerHarness()
+    ;(socket.data as any).user = { id: 1, username: 'admin', role: 'super_admin' }
+    const server = new ChatRunSocket(io as any)
+    const previousStart = 1_787_000_000_000
+    const reattachedAt = previousStart + 60_000
+    ;(server as any).sessionMap.set('s4', {
+      messages: [], events: [], queue: [], isWorking: false, profile: 'default', runStartedAt: previousStart,
+    })
+    bridgeMock.statusIfLoaded.mockResolvedValue({ running: true, current_run_id: 'run-4' })
+    vi.spyOn(Date, 'now').mockReturnValue(reattachedAt)
+
+    ;(server as any).onConnection(socket)
+    await handlers.get('resume')?.({ session_id: 's4' })
+
+    const resumed = socket.emit.mock.calls.find((call: any[]) => call[0] === 'resumed')
+    expect(resumed![1]).toMatchObject({ isWorking: true, runStartedAt: reattachedAt })
   })
 })


### PR DESCRIPTION
## Summary

- carry each active run start time from the server into resumed chat state
- keep the thinking timer stable when navigating between sessions or opening the same run on another client
- refresh and clear the clock across direct, queued, background, reattached, completed, and failed run paths
- preserve the latest main MessageList tool-run grouping changes and clamp elapsed time against client clock skew
- isolate health and plugin tests from desktop runtime environment variables

## Origin

Builds on and includes #2693 by @twuijri, applied onto the current main branch with additional run lifecycle coverage and fixes.

## Validation

- focused chat tests: 59 passed
- chat E2E tests: 26 passed
- harness check passed
- production build passed
- full Vitest suite: 4447 passed, 6 skipped, 0 failed
