### PR TITLE
[codex] hide global Coding Agent reasoning effort control

### DIFF
--- a/docs/chat-chain-changes/2026-08-25-hide-global-coding-agent-reasoning-effort.md
+++ b/docs/chat-chain-changes/2026-08-25-hide-global-coding-agent-reasoning-effort.md
@@ -1,0 +1,11 @@
+---
+date: 2026-08-25
+pr: pending
+feature: Hide global Coding Agent reasoning effort
+impact: Global Coding Agent chats no longer show a per-session reasoning effort control that the runtime intentionally ignores.
+---
+
+The single-chat composer continues to expose reasoning effort for Hermes,
+Ekko, and scoped Coding Agent sessions. Global Codex, Claude, and Pi sessions
+inherit their native CLI configuration, so the ineffective session-level
+selector is now hidden.

--- a/docs/chat-chain-changes/2026-08-25-hide-global-coding-agent-reasoning-effort.md
+++ b/docs/chat-chain-changes/2026-08-25-hide-global-coding-agent-reasoning-effort.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-25
-pr: pending
+pr: 2728
 feature: Hide global Coding Agent reasoning effort
 impact: Global Coding Agent chats no longer show a per-session reasoning effort control that the runtime intentionally ignores.
 ---

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -74,6 +74,9 @@ const reasoningEffortAccentStyle = computed(() => ({
     || reasoningEffortAccentColors[0],
 }))
 const isMoaSession = computed(() => chatStore.activeSession?.provider === 'moa')
+const isGlobalCodingAgentSession = computed(() =>
+  chatStore.activeSession?.codingAgentMode === 'global'
+)
 const reasoningEffortLabel = computed<string>(() => {
   const v = currentReasoningEffort.value
   if (!v) return t('chat.reasoningEffort.defaultLabel')
@@ -1178,7 +1181,7 @@ function isImage(type: string): boolean {
           </NTooltip>
 
           <NPopover
-            v-if="!isMoaSession"
+            v-if="!isMoaSession && !isGlobalCodingAgentSession"
             trigger="click"
             placement="top-start"
           >

--- a/tests/client/chat-input-draft.test.ts
+++ b/tests/client/chat-input-draft.test.ts
@@ -245,6 +245,7 @@ describe('ChatInput draft persistence', () => {
       source: 'coding_agent',
       agent: 'codex',
       codingAgentId: 'codex',
+      codingAgentMode: 'scoped',
     })
     await nextTick()
 
@@ -252,6 +253,19 @@ describe('ChatInput draft persistence', () => {
     expect(wrapper.find('.n-slider-stub').exists()).toBe(true)
     expect(wrapper.get('.n-slider-stub').attributes('min')).toBe('0')
     expect(wrapper.get('.n-slider-stub').attributes('max')).toBe('7')
+  })
+
+  it('hides the reasoning effort selector for global coding-agent sessions', async () => {
+    const wrapper = mountForSession('session-global-codex', {
+      source: 'coding_agent',
+      agent: 'codex',
+      codingAgentId: 'codex',
+      codingAgentMode: 'global',
+    })
+    await nextTick()
+
+    expect(wrapper.find('.reasoning-effort-button').exists()).toBe(false)
+    expect(wrapper.find('.n-slider-stub').exists()).toBe(false)
   })
 
   it('hides the reasoning effort selector for MoA sessions', async () => {


### PR DESCRIPTION
## Summary
- hide the per-session reasoning effort selector for global Coding Agent chats
- keep the selector available for Hermes, Ekko, and scoped Coding Agent sessions
- add focused UI regression coverage and a chat-chain change fragment

## Why
Global Codex, Claude, and Pi sessions inherit their native CLI configuration. Studio already omits `reasoning_effort` for these runs, so showing the selector implied an override that could not take effect.

## Validation
- `npm run harness:check`
- `npm run test -- --run tests/client/chat-input-draft.test.ts -t "reasoning effort selector"`
- `npm run build`

## Known test issue
- The existing `hides bridge autocomplete for non-Hermes slash prefixes` test fails when run in isolation because `/ter` currently keeps the bridge autocomplete open; this is unrelated to the reasoning-effort visibility change.