### PR TITLE
fix(chat): preserve tool calls across coding agent runs

### DIFF
--- a/docs/chat-chain-changes/2026-08-25-pr-2730-run-scoped-tool-calls.md
+++ b/docs/chat-chain-changes/2026-08-25-pr-2730-run-scoped-tool-calls.md
@@ -1,0 +1,9 @@
+---
+date: 2026-08-25
+pr: 2730
+feature: Run-scoped coding-agent tool calls
+impact: Studio now keeps tool calls and reasoning associated with the run that emitted them, so coding agents that reuse tool call IDs no longer overwrite earlier tool cards during streaming, resume replay, or history reconstruction.
+---
+
+Tool completion events without a matching start event now create a completed
+tool card, preserving calls when a stream reconnects after the start event.

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -787,6 +787,29 @@ function readRunMarker(value: unknown): string | null | undefined {
   return undefined
 }
 
+function normalizedRunMarker(value: unknown): string | null {
+  const runMarker = readRunMarker(value)
+  return typeof runMarker === 'string' && runMarker.trim() !== '' ? runMarker.trim() : null
+}
+
+function toolInstanceKey(value: unknown, toolCallId: string): string {
+  return `${normalizedRunMarker(value) || 'legacy'}\u0000${toolCallId}`
+}
+
+function setToolMetadata<T>(map: Map<string, T>, message: unknown, toolCallId: string, value: T) {
+  const scopedKey = toolInstanceKey(message, toolCallId)
+  const legacyKey = toolInstanceKey(null, toolCallId)
+  map.set(scopedKey, value)
+  // Some older rows only persisted the run marker on the tool result. Keep a
+  // best-effort fallback without allowing it to override an exact scoped key.
+  if (!map.has(legacyKey)) map.set(legacyKey, value)
+}
+
+function getToolMetadata<T>(map: Map<string, T>, message: unknown, toolCallId: string): T | undefined {
+  return map.get(toolInstanceKey(message, toolCallId))
+    ?? map.get(toolInstanceKey(null, toolCallId))
+}
+
 function isQueueInsertionInterruption(value: unknown): boolean {
   if (!value || typeof value !== 'object') return false
   const event = value as Pick<RunEvent, 'interrupted' | 'stop_reason'>
@@ -865,9 +888,9 @@ function mapHermesMessages(msgs: HermesMessage[]): Message[] {
     if (msg.role === 'assistant' && msg.tool_calls) {
       for (const tc of msg.tool_calls) {
         if (tc.id) {
-          if (tc.function?.name) toolNameMap.set(tc.id, tc.function.name)
-          if (hasRuntimeToolPayload(tc.function?.arguments)) toolArgsMap.set(tc.id, tc.function.arguments)
-          if (msg.reasoning?.trim()) toolReasoningMap.set(tc.id, msg.reasoning)
+          if (tc.function?.name) setToolMetadata(toolNameMap, msg, tc.id, tc.function.name)
+          if (hasRuntimeToolPayload(tc.function?.arguments)) setToolMetadata(toolArgsMap, msg, tc.id, tc.function.arguments)
+          if (msg.reasoning?.trim()) setToolMetadata(toolReasoningMap, msg, tc.id, msg.reasoning)
         }
       }
     }
@@ -900,9 +923,24 @@ function mapHermesMessages(msgs: HermesMessage[]): Message[] {
     // so they can render as tool lines without becoming model-context tool results.
     if (msg.role === 'tool' || isPersistedMoaToolDisplay(msg)) {
       const tcId = msg.tool_call_id || ''
-      const toolName = msg.tool_name || toolNameMap.get(tcId) || undefined
-      const toolArgs = toolArgsMap.has(tcId) ? toolArgsMap.get(tcId) : undefined
-      const toolReasoning = toolReasoningMap.get(tcId)
+      const exactPlaceholderIdx = result.findIndex(m =>
+        m.role === 'tool'
+        && m.toolCallId === tcId
+        && !m.toolResult
+        && normalizedRunMarker(m) === normalizedRunMarker(msg),
+      )
+      const placeholderIdx = exactPlaceholderIdx !== -1
+        ? exactPlaceholderIdx
+        : result.findIndex(m =>
+            m.role === 'tool'
+            && m.toolCallId === tcId
+            && !m.toolResult
+            && normalizedRunMarker(m) === null,
+          )
+      const placeholder = placeholderIdx !== -1 ? result[placeholderIdx] : undefined
+      const toolName = msg.tool_name || getToolMetadata(toolNameMap, msg, tcId) || placeholder?.toolName || undefined
+      const toolArgs = getToolMetadata(toolArgsMap, msg, tcId) ?? placeholder?.toolArgs
+      const toolReasoning = getToolMetadata(toolReasoningMap, msg, tcId) || placeholder?.reasoning
       const moaPayload = parsePersistedMoaToolPayload(toolName, (msg as any).content)
       const backgroundDelegate = isBackgroundDelegateToolPayload(toolName, (msg as any).content)
       const delegatePayload = toolName === 'delegate_task'
@@ -921,10 +959,8 @@ function mapHermesMessages(msgs: HermesMessage[]): Message[] {
           preview = contentText.slice(0, 80)
         }
       }
-      // Find and remove the matching placeholder from tool_calls above
-      const placeholderIdx = result.findIndex(
-        m => m.role === 'tool' && m.toolName === toolName && !m.toolResult && m.id.includes('_' + tcId)
-      )
+      // Remove only the placeholder belonging to this run. Coding-agent CLIs
+      // may reuse raw ids such as `item_2` on every resumed turn.
       if (placeholderIdx !== -1) {
         result.splice(placeholderIdx, 1)
       }
@@ -2016,73 +2052,9 @@ export const useChatStore = defineStore('chat', () => {
               } else if (e.event === 'workspace.diff.completed') {
                 handleWorkspaceRunChangeEvent(sessionId, e)
               } else if (e.event === 'tool.started') {
-                const startedToolName = e.tool || e.name
-                if (
-                  isBackgroundDelegateToolPayload(startedToolName, (e as any).arguments)
-                  || (isEkkoAgentSession(sessionId) && startedToolName === 'delegate_task')
-                ) continue
-                const msgs = getSessionMsgs(sessionId)
-                const toolCallId = e.tool_call_id as string | undefined
-                const existingTool = toolCallId
-                  ? msgs.find(m => m.role === 'tool' && m.toolCallId === toolCallId)
-                  : null
-                if (existingTool) {
-                  updateMessage(sessionId, existingTool.id, {
-                    toolName: e.tool || e.name,
-                    runMarker: existingTool.runMarker || readRunMarker(e),
-                    toolArgs: hasRuntimeToolPayload((e as any).arguments) ? (e as any).arguments : existingTool.toolArgs,
-                    toolPreview: e.preview || existingTool.toolPreview,
-                    toolStatus: existingTool.toolStatus || 'running',
-                  })
-                } else {
-                  addMessage(sessionId, {
-                    id: uid(),
-                    role: 'tool',
-                    content: '',
-                    timestamp: Date.now(),
-                    toolName: e.tool || e.name,
-                    toolCallId,
-                    runMarker: readRunMarker(e),
-                    toolPreview: e.preview,
-                    toolArgs: runtimeToolPayloadOrUndefined((e as any).arguments),
-                    toolStatus: 'running',
-                  })
-                }
+                handleToolStartedEvent(sessionId, e as RunEvent)
               } else if (e.event === 'tool.completed' || e.event === 'tool.failed') {
-                const msgs = getSessionMsgs(sessionId)
-                const toolCallId = e.tool_call_id as string | undefined
-                const toolMsgs = toolCallId
-                  ? msgs.filter(m => m.role === 'tool' && m.toolCallId === toolCallId)
-                  : msgs.filter(m => m.role === 'tool' && m.toolStatus === 'running')
-                const output = runtimeToolOutputFromEvent(e)
-                const toolName = e.tool || e.name || toolMsgs[toolMsgs.length - 1]?.toolName
-                if (isBackgroundDelegateToolPayload(toolName, output)) {
-                  target.messages = target.messages.filter(message => !toolMsgs.includes(message))
-                  addHermesBackgroundDelegateAnchors(
-                    sessionId,
-                    toolCallId,
-                    output,
-                    toolMsgs[toolMsgs.length - 1]?.toolArgs,
-                  )
-                  continue
-                }
-                if (
-                  isEkkoAgentSession(sessionId)
-                  && toolName === 'delegate_task'
-                  && runtimeObjectPayload(output)?.runtime === 'ekko'
-                ) {
-                  target.messages = target.messages.filter(message => !toolMsgs.includes(message))
-                  continue
-                }
-                if (toolMsgs.length > 0) {
-                  const last = toolMsgs[toolMsgs.length - 1]
-                  updateMessage(sessionId, last.id, {
-                    runMarker: last.runMarker || readRunMarker(e),
-                    toolStatus: e.event === 'tool.failed' || e.error === true || runtimeToolOutputHasError(output) ? 'error' : 'done',
-                    toolDuration: e.duration,
-                    toolResult: output,
-                  })
-                }
+                handleToolCompletedEvent(sessionId, e as RunEvent)
               } else if (e.event === 'moa.reference' || e.event === 'moa.aggregating') {
                 handleMoaEvent(sessionId, e as RunEvent)
               } else if (String(e.event || '').startsWith('subagent.') || e.event === 'delegation.updated') {
@@ -2306,6 +2278,7 @@ export const useChatStore = defineStore('chat', () => {
     toolCallId: string | undefined,
     output: unknown,
     toolArgs: unknown,
+    runMarker?: string | null,
   ) {
     const payload = runtimeObjectPayload(output)
     if (!payload || payload.mode !== 'background' || payload.runtime === 'ekko') return
@@ -2313,7 +2286,10 @@ export const useChatStore = defineStore('chat', () => {
     const messages = getSessionMsgs(sessionId)
     for (const task of backgroundDelegateTaskDescriptors(payload, toolArgs)) {
       const anchorCallId = backgroundDelegateAnchorCallId(baseId, task.taskIndex)
-      if (messages.some(message => message.toolCallId === anchorCallId)) continue
+      if (messages.some(message =>
+        message.toolCallId === anchorCallId
+        && normalizedRunMarker(message) === (runMarker || null),
+      )) continue
       const label = `${task.taskIndex + 1}/${task.taskCount}`
       addMessage(sessionId, {
         id: uid(),
@@ -2332,6 +2308,7 @@ export const useChatStore = defineStore('chat', () => {
           goal: task.goal,
         },
         toolStatus: 'done',
+        runMarker,
       })
     }
   }
@@ -2369,6 +2346,149 @@ export const useChatStore = defineStore('chat', () => {
     if (idx !== -1) {
       s.messages[idx] = { ...s.messages[idx], ...update }
     }
+  }
+
+  function findToolMessageForEvent(
+    messages: Message[],
+    evt: RunEvent,
+    toolCallId?: string,
+  ): Message | undefined {
+    const eventRunMarker = normalizedRunMarker(evt)
+    const reversed = [...messages].reverse()
+    const hasMatchingId = (message: Message) => !toolCallId || message.toolCallId === toolCallId
+
+    if (eventRunMarker) {
+      const exact = reversed.find(message =>
+        message.role === 'tool'
+        && hasMatchingId(message)
+        && normalizedRunMarker(message) === eventRunMarker
+        && (toolCallId || message.toolStatus === 'running'),
+      )
+      if (exact) return exact
+
+      // A legacy started event may not have carried its run marker even when
+      // the corresponding completion does. Adopt only an unscoped running row.
+      return reversed.find(message =>
+        message.role === 'tool'
+        && hasMatchingId(message)
+        && normalizedRunMarker(message) === null
+        && message.toolStatus === 'running',
+      )
+    }
+
+    // Without a run marker, never revive a finalized historical row. The most
+    // recent running match is the only safe legacy fallback.
+    return reversed.find(message =>
+      message.role === 'tool'
+      && hasMatchingId(message)
+      && message.toolStatus === 'running',
+    )
+  }
+
+  function handleToolStartedEvent(sessionId: string, evt: RunEvent, reasoning?: string) {
+    const toolName = evt.tool || evt.name
+    if (
+      isBackgroundDelegateToolPayload(toolName, evt.arguments)
+      || (isEkkoAgentSession(sessionId) && toolName === 'delegate_task')
+    ) return
+
+    const toolCallId = typeof (evt as any).tool_call_id === 'string'
+      ? String((evt as any).tool_call_id)
+      : undefined
+    const messages = getSessionMsgs(sessionId)
+    const existing = toolCallId ? findToolMessageForEvent(messages, evt, toolCallId) : undefined
+    const eventRunMarker = normalizedRunMarker(evt)
+    if (existing) {
+      const isSettled = existing.toolStatus === 'done'
+        || existing.toolStatus === 'error'
+        || existing.toolResult !== undefined
+      updateMessage(sessionId, existing.id, {
+        toolName: toolName || existing.toolName,
+        runMarker: existing.runMarker || eventRunMarker,
+        toolArgs: hasRuntimeToolPayload(evt.arguments) ? evt.arguments : existing.toolArgs,
+        toolPreview: evt.preview || existing.toolPreview,
+        reasoning: existing.reasoning || reasoning,
+        toolStatus: isSettled ? existing.toolStatus : 'running',
+      })
+      return
+    }
+
+    addMessage(sessionId, {
+      id: uid(),
+      role: 'tool',
+      content: '',
+      timestamp: Date.now(),
+      toolName,
+      toolCallId,
+      runMarker: eventRunMarker,
+      toolPreview: evt.preview,
+      toolArgs: runtimeToolPayloadOrUndefined(evt.arguments),
+      reasoning,
+      toolStatus: 'running',
+    })
+  }
+
+  function handleToolCompletedEvent(sessionId: string, evt: RunEvent) {
+    const toolCallId = typeof (evt as any).tool_call_id === 'string'
+      ? String((evt as any).tool_call_id)
+      : undefined
+    const messages = getSessionMsgs(sessionId)
+    const existing = findToolMessageForEvent(messages, evt, toolCallId)
+    const output = runtimeToolOutputFromEvent(evt)
+    const toolName = evt.tool || evt.name || existing?.toolName
+    const eventRunMarker = normalizedRunMarker(evt)
+
+    if (isBackgroundDelegateToolPayload(toolName, output)) {
+      const session = sessions.value.find(item => item.id === sessionId)
+      if (session && existing) session.messages = session.messages.filter(message => message !== existing)
+      addHermesBackgroundDelegateAnchors(
+        sessionId,
+        toolCallId,
+        output,
+        existing?.toolArgs,
+        eventRunMarker,
+      )
+      return
+    }
+    if (
+      isEkkoAgentSession(sessionId)
+      && toolName === 'delegate_task'
+      && runtimeObjectPayload(output)?.runtime === 'ekko'
+    ) {
+      const session = sessions.value.find(item => item.id === sessionId)
+      if (session && existing) session.messages = session.messages.filter(message => message !== existing)
+      return
+    }
+
+    const hasError = evt.event === 'tool.failed'
+      || (evt as any).error === true
+      || runtimeToolOutputHasError(output)
+    if (existing) {
+      updateMessage(sessionId, existing.id, {
+        toolName: toolName || existing.toolName,
+        runMarker: existing.runMarker || eventRunMarker,
+        toolStatus: hasError ? 'error' : 'done',
+        toolDuration: (evt as any).duration,
+        toolResult: output,
+      })
+      return
+    }
+
+    // Completion can arrive after a reconnect even when the start event was
+    // not replayed. Preserve the call instead of silently dropping it.
+    addMessage(sessionId, {
+      id: uid(),
+      role: 'tool',
+      content: '',
+      timestamp: Date.now(),
+      toolName,
+      toolCallId,
+      runMarker: eventRunMarker,
+      toolPreview: evt.preview,
+      toolResult: output,
+      toolStatus: hasError ? 'error' : 'done',
+      toolDuration: (evt as any).duration,
+    })
   }
 
   function settleRunningTools(sessionId: string, status: 'done' | 'error') {
@@ -3890,11 +4010,10 @@ export const useChatStore = defineStore('chat', () => {
               runHadToolActivity = true
               const startedToolName = evt.tool || evt.name
               if (
-                isBackgroundDelegateToolPayload(startedToolName, (evt as any).arguments)
+                isBackgroundDelegateToolPayload(startedToolName, evt.arguments)
                 || (isEkkoAgentSession(sid) && startedToolName === 'delegate_task')
               ) break
               const msgs = getSessionMsgs(sid)
-              const toolCallId = (evt as any).tool_call_id as string | undefined
               const last = activeAssistantMessageId
                 ? msgs.find(m => m.id === activeAssistantMessageId)
                 : msgs[msgs.length - 1]
@@ -3907,33 +4026,7 @@ export const useChatStore = defineStore('chat', () => {
               }
               activeAssistantMessageId = null
               reasoningAssistantMessageId = null
-              const existingTool = toolCallId
-                ? msgs.find(m => m.role === 'tool' && m.toolCallId === toolCallId)
-                : null
-              if (existingTool) {
-                updateMessage(sid, existingTool.id, {
-                  toolName: evt.tool || evt.name,
-                  runMarker: existingTool.runMarker || readRunMarker(evt),
-                  toolArgs: hasRuntimeToolPayload((evt as any).arguments) ? (evt as any).arguments : existingTool.toolArgs,
-                  toolPreview: evt.preview || existingTool.toolPreview,
-                  reasoning: existingTool.reasoning || toolReasoning,
-                  toolStatus: existingTool.toolStatus || 'running',
-                })
-                break
-              }
-              addMessage(sid, {
-                id: uid(),
-                role: 'tool',
-                content: '',
-                timestamp: Date.now(),
-                toolName: evt.tool || evt.name,
-                toolCallId,
-                runMarker: readRunMarker(evt),
-                toolPreview: evt.preview,
-                toolArgs: runtimeToolPayloadOrUndefined((evt as any).arguments),
-                reasoning: toolReasoning,
-                toolStatus: 'running',
-              })
+              handleToolStartedEvent(sid, evt, toolReasoning)
 
               break
             }
@@ -3941,44 +4034,7 @@ export const useChatStore = defineStore('chat', () => {
             case 'tool.completed':
             case 'tool.failed': {
               runHadToolActivity = true
-              const msgs = getSessionMsgs(sid)
-              const toolCallId = (evt as any).tool_call_id as string | undefined
-              const toolMsgs = toolCallId
-                ? msgs.filter(m => m.role === 'tool' && m.toolCallId === toolCallId)
-                : msgs.filter(m => m.role === 'tool' && m.toolStatus === 'running')
-              const output = runtimeToolOutputFromEvent(evt)
-              const toolName = evt.tool || evt.name || toolMsgs[toolMsgs.length - 1]?.toolName
-              if (isBackgroundDelegateToolPayload(toolName, output)) {
-                const session = sessions.value.find(item => item.id === sid)
-                if (session) session.messages = session.messages.filter(message => !toolMsgs.includes(message))
-                addHermesBackgroundDelegateAnchors(
-                  sid,
-                  toolCallId,
-                  output,
-                  toolMsgs[toolMsgs.length - 1]?.toolArgs,
-                )
-                break
-              }
-              if (
-                isEkkoAgentSession(sid)
-                && toolName === 'delegate_task'
-                && runtimeObjectPayload(output)?.runtime === 'ekko'
-              ) {
-                const session = sessions.value.find(item => item.id === sid)
-                if (session) session.messages = session.messages.filter(message => !toolMsgs.includes(message))
-                break
-              }
-              if (toolMsgs.length > 0) {
-                const last = toolMsgs[toolMsgs.length - 1]
-                const hasError = evt.event === 'tool.failed' || (evt as any).error === true || runtimeToolOutputHasError(output)
-                const duration = (evt as any).duration
-                updateMessage(sid, last.id, {
-                  runMarker: last.runMarker || readRunMarker(evt),
-                  toolStatus: hasError ? 'error' : 'done',
-                  toolDuration: duration,
-                  toolResult: output,
-                })
-              }
+              handleToolCompletedEvent(sid, evt)
 
               break
             }
@@ -4613,11 +4669,10 @@ export const useChatStore = defineStore('chat', () => {
           runHadToolActivity = true
           const startedToolName = evt.tool || evt.name
           if (
-            isBackgroundDelegateToolPayload(startedToolName, (evt as any).arguments)
+            isBackgroundDelegateToolPayload(startedToolName, evt.arguments)
             || (isEkkoAgentSession(sid) && startedToolName === 'delegate_task')
           ) break
           const msgs = getSessionMsgs(sid)
-          const toolCallId = (evt as any).tool_call_id as string | undefined
           const last = activeAssistantMessageId
             ? msgs.find(m => m.id === activeAssistantMessageId)
             : msgs[msgs.length - 1]
@@ -4630,33 +4685,7 @@ export const useChatStore = defineStore('chat', () => {
           }
           activeAssistantMessageId = null
           reasoningAssistantMessageId = null
-          const existingTool = toolCallId
-            ? msgs.find(m => m.role === 'tool' && m.toolCallId === toolCallId)
-            : null
-          if (existingTool) {
-            updateMessage(sid, existingTool.id, {
-              toolName: evt.tool || evt.name,
-              runMarker: existingTool.runMarker || readRunMarker(evt),
-              toolArgs: hasRuntimeToolPayload((evt as any).arguments) ? (evt as any).arguments : existingTool.toolArgs,
-              toolPreview: evt.preview || existingTool.toolPreview,
-              reasoning: existingTool.reasoning || toolReasoning,
-              toolStatus: existingTool.toolStatus || 'running',
-            })
-            break
-          }
-          addMessage(sid, {
-            id: uid(),
-            role: 'tool',
-            content: '',
-            timestamp: Date.now(),
-            toolName: evt.tool || evt.name,
-            toolCallId,
-            runMarker: readRunMarker(evt),
-            toolPreview: evt.preview,
-            toolArgs: runtimeToolPayloadOrUndefined((evt as any).arguments),
-            reasoning: toolReasoning,
-            toolStatus: 'running',
-          })
+          handleToolStartedEvent(sid, evt, toolReasoning)
 
           break
         }
@@ -4664,43 +4693,7 @@ export const useChatStore = defineStore('chat', () => {
         case 'tool.completed':
         case 'tool.failed': {
           runHadToolActivity = true
-          const msgs = getSessionMsgs(sid)
-          const toolCallId = (evt as any).tool_call_id as string | undefined
-          const toolMsgs = toolCallId
-            ? msgs.filter(m => m.role === 'tool' && m.toolCallId === toolCallId)
-            : msgs.filter(m => m.role === 'tool' && m.toolStatus === 'running')
-          const output = runtimeToolOutputFromEvent(evt)
-          const toolName = evt.tool || evt.name || toolMsgs[toolMsgs.length - 1]?.toolName
-          if (isBackgroundDelegateToolPayload(toolName, output)) {
-            const session = sessions.value.find(item => item.id === sid)
-            if (session) session.messages = session.messages.filter(message => !toolMsgs.includes(message))
-            addHermesBackgroundDelegateAnchors(
-              sid,
-              toolCallId,
-              output,
-              toolMsgs[toolMsgs.length - 1]?.toolArgs,
-            )
-            break
-          }
-          if (
-            isEkkoAgentSession(sid)
-            && toolName === 'delegate_task'
-            && runtimeObjectPayload(output)?.runtime === 'ekko'
-          ) {
-            const session = sessions.value.find(item => item.id === sid)
-            if (session) session.messages = session.messages.filter(message => !toolMsgs.includes(message))
-            break
-          }
-          if (toolMsgs.length > 0) {
-            const hasError = evt.event === 'tool.failed' || (evt as any).error === true || runtimeToolOutputHasError(output)
-            const last = toolMsgs[toolMsgs.length - 1]
-            updateMessage(sid, last.id, {
-              runMarker: last.runMarker || readRunMarker(evt),
-              toolStatus: hasError ? 'error' : 'done',
-              toolDuration: (evt as any).duration,
-              toolResult: output,
-            })
-          }
+          handleToolCompletedEvent(sid, evt)
 
           break
         }

--- a/packages/server/src/services/hermes/run-chat/response-stream.ts
+++ b/packages/server/src/services/hermes/run-chat/response-stream.ts
@@ -327,6 +327,7 @@ export function applyResponseStreamEvent(
         })
       } else if (toolReasoning) {
         const toolCallMessage = state.messages.find(message =>
+          message.runMarker === runMarker &&
           message.role === 'assistant' &&
           message.tool_calls?.some(tool => tool.id === callId),
         )

--- a/tests/client/chat-store-compression-state.test.ts
+++ b/tests/client/chat-store-compression-state.test.ts
@@ -1392,4 +1392,122 @@ describe('chat store compression state', () => {
     expect(tool?.toolStatus).toBe('done')
     expect(tool?.toolResult).toEqual({ ok: true })
   })
+
+  it('scopes repeated tool ids in registered session handlers', async () => {
+    const store = useChatStore()
+    store.sessions = [makeSession('session-1')]
+    await store.switchSession('session-1')
+    store.activeSession!.messages = [{
+      id: 'old-tool',
+      role: 'tool',
+      content: '',
+      timestamp: Date.now() - 1_000,
+      toolName: 'Command',
+      toolCallId: 'item_2',
+      toolResult: 'old result',
+      toolStatus: 'done',
+      runMarker: 'run-a',
+    }]
+
+    handlers.onToolStarted({
+      event: 'tool.started',
+      tool: 'Command',
+      tool_call_id: 'item_2',
+      arguments: { command: 'ls' },
+      run_marker: 'run-b',
+    })
+    handlers.onToolCompleted({
+      event: 'tool.completed',
+      tool: 'Command',
+      tool_call_id: 'item_2',
+      output: 'new result',
+      run_marker: 'run-b',
+    })
+
+    expect(store.activeSession?.messages.filter(message => message.role === 'tool')).toEqual([
+      expect.objectContaining({
+        id: 'old-tool',
+        runMarker: 'run-a',
+        toolResult: 'old result',
+      }),
+      expect.objectContaining({
+        runMarker: 'run-b',
+        toolStatus: 'done',
+        toolResult: 'new result',
+      }),
+    ])
+  })
+
+  it('scopes repeated tool ids while replaying resume events', async () => {
+    chatApi.resumeSession.mockImplementation((sessionId: string, onResumed: (data: any) => void) => {
+      onResumed({
+        session_id: sessionId,
+        isWorking: true,
+        messages: [
+          {
+            id: 1,
+            role: 'assistant',
+            content: '',
+            run_marker: 'run-a',
+            tool_calls: [{
+              id: 'item_2',
+              type: 'function',
+              function: { name: 'Command', arguments: '{"command":"pwd"}' },
+            }],
+            finish_reason: 'tool_calls',
+            timestamp: 1,
+          },
+          {
+            id: 2,
+            role: 'tool',
+            content: 'old result',
+            tool_name: 'Command',
+            tool_call_id: 'item_2',
+            run_marker: 'run-a',
+            timestamp: 2,
+          },
+        ],
+        events: [
+          {
+            event: 'tool.started',
+            data: {
+              event: 'tool.started',
+              tool: 'Command',
+              tool_call_id: 'item_2',
+              arguments: { command: 'ls' },
+              run_marker: 'run-b',
+            },
+          },
+          {
+            event: 'tool.completed',
+            data: {
+              event: 'tool.completed',
+              tool: 'Command',
+              tool_call_id: 'item_2',
+              output: 'new result',
+              run_marker: 'run-b',
+            },
+          },
+        ],
+      })
+      return {} as any
+    })
+    const store = useChatStore()
+    store.sessions = [makeSession('session-1')]
+
+    await store.switchSession('session-1')
+
+    expect(store.messages.filter(message => message.role === 'tool')).toEqual([
+      expect.objectContaining({
+        runMarker: 'run-a',
+        toolStatus: 'done',
+        toolResult: 'old result',
+      }),
+      expect.objectContaining({
+        runMarker: 'run-b',
+        toolStatus: 'done',
+        toolResult: 'new result',
+      }),
+    ])
+  })
 })

--- a/tests/client/chat-store-reasoning-tool-boundary.test.ts
+++ b/tests/client/chat-store-reasoning-tool-boundary.test.ts
@@ -210,6 +210,205 @@ describe('chat store reasoning/tool boundaries', () => {
     ])
   })
 
+  it('restores repeated tool ids with metadata from their own runs', async () => {
+    const store = useChatStore()
+    const session = makeSession()
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+    sessionsApi.fetchSessionMessagesPage.mockResolvedValue({
+      session: { id: 'session-1', title: 'session' },
+      messages: [
+        {
+          id: 1,
+          role: 'assistant',
+          content: '',
+          reasoning: 'reasoning for run A',
+          run_marker: 'run-a',
+          tool_calls: [{
+            id: 'item_2',
+            type: 'function',
+            function: { name: 'Command', arguments: '{"command":"pwd"}' },
+          }],
+          timestamp: 1,
+          finish_reason: 'tool_calls',
+        },
+        {
+          id: 2,
+          role: 'tool',
+          content: 'result A',
+          tool_call_id: 'item_2',
+          run_marker: 'run-a',
+          timestamp: 2,
+        },
+        {
+          id: 3,
+          role: 'assistant',
+          content: '',
+          reasoning: 'reasoning for run B',
+          run_marker: 'run-b',
+          tool_calls: [{
+            id: 'item_2',
+            type: 'function',
+            function: { name: 'Web Search', arguments: '{"query":"Hermes"}' },
+          }],
+          timestamp: 3,
+          finish_reason: 'tool_calls',
+        },
+        {
+          id: 4,
+          role: 'tool',
+          content: 'result B',
+          tool_call_id: 'item_2',
+          run_marker: 'run-b',
+          timestamp: 4,
+        },
+      ],
+      total: 4,
+      hasMore: false,
+    })
+
+    await store.refreshActiveSession()
+
+    expect(store.messages).toEqual([
+      expect.objectContaining({
+        role: 'tool',
+        toolCallId: 'item_2',
+        runMarker: 'run-a',
+        toolName: 'Command',
+        toolArgs: '{"command":"pwd"}',
+        reasoning: 'reasoning for run A',
+        toolResult: 'result A',
+      }),
+      expect.objectContaining({
+        role: 'tool',
+        toolCallId: 'item_2',
+        runMarker: 'run-b',
+        toolName: 'Web Search',
+        toolArgs: '{"query":"Hermes"}',
+        reasoning: 'reasoning for run B',
+        toolResult: 'result B',
+      }),
+    ])
+  })
+
+  it('keeps repeated coding-agent tool ids separate across live runs', async () => {
+    const store = useChatStore()
+    const session = makeSession()
+    session.source = 'coding_agent'
+    session.agent = 'codex'
+    session.codingAgentId = 'codex'
+    session.messages = [{
+      id: 'old-tool',
+      role: 'tool',
+      content: '',
+      timestamp: Date.now() - 1_000,
+      toolName: 'Command',
+      toolCallId: 'item_2',
+      toolArgs: '{"command":"pwd"}',
+      toolResult: 'old result',
+      toolStatus: 'done',
+      runMarker: 'run-a',
+    }]
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+
+    await store.sendMessage('run another command')
+
+    const onEvent = chatApi.startRunViaSocket.mock.calls[0][1] as (event: RunEvent) => void
+    onEvent({ event: 'run.started', session_id: 'session-1', run_marker: 'run-b' })
+    onEvent({
+      event: 'tool.started',
+      session_id: 'session-1',
+      run_marker: 'run-b',
+      tool_call_id: 'item_2',
+      tool: 'Command',
+      arguments: '{"command":"ls"}',
+    } as RunEvent)
+
+    expect(store.messages.filter(message => message.role === 'tool')).toEqual([
+      expect.objectContaining({
+        id: 'old-tool',
+        runMarker: 'run-a',
+        toolStatus: 'done',
+        toolResult: 'old result',
+      }),
+      expect.objectContaining({
+        runMarker: 'run-b',
+        toolStatus: 'running',
+        toolArgs: '{"command":"ls"}',
+      }),
+    ])
+
+    onEvent({
+      event: 'tool.completed',
+      session_id: 'session-1',
+      run_marker: 'run-b',
+      tool_call_id: 'item_2',
+      tool: 'Command',
+      output: 'new result',
+    } as RunEvent)
+
+    expect(store.messages.filter(message => message.role === 'tool')).toEqual([
+      expect.objectContaining({
+        id: 'old-tool',
+        runMarker: 'run-a',
+        toolStatus: 'done',
+        toolResult: 'old result',
+      }),
+      expect.objectContaining({
+        runMarker: 'run-b',
+        toolStatus: 'done',
+        toolResult: 'new result',
+      }),
+    ])
+  })
+
+  it('creates a scoped tool row when completion arrives without a start event', async () => {
+    const store = useChatStore()
+    const session = makeSession()
+    session.messages = [{
+      id: 'old-tool',
+      role: 'tool',
+      content: '',
+      timestamp: Date.now() - 1_000,
+      toolName: 'Command',
+      toolCallId: 'item_2',
+      toolResult: 'old result',
+      toolStatus: 'done',
+      runMarker: 'run-a',
+    }]
+    store.sessions = [session]
+    store.activeSessionId = 'session-1'
+    store.activeSession = session
+
+    await store.sendMessage('resume the run')
+
+    const onEvent = chatApi.startRunViaSocket.mock.calls[0][1] as (event: RunEvent) => void
+    onEvent({
+      event: 'tool.completed',
+      session_id: 'session-1',
+      run_marker: 'run-b',
+      tool_call_id: 'item_2',
+      tool: 'Command',
+      output: 'replayed result',
+    } as RunEvent)
+
+    expect(store.messages.filter(message => message.role === 'tool')).toEqual([
+      expect.objectContaining({
+        id: 'old-tool',
+        runMarker: 'run-a',
+        toolResult: 'old result',
+      }),
+      expect.objectContaining({
+        runMarker: 'run-b',
+        toolStatus: 'done',
+        toolResult: 'replayed result',
+      }),
+    ])
+  })
+
   it('attaches completion output to post-tool reasoning when no body delta arrived', async () => {
     const store = useChatStore()
     const session = makeSession()

--- a/tests/server/response-stream-reasoning-storage.test.ts
+++ b/tests/server/response-stream-reasoning-storage.test.ts
@@ -128,6 +128,62 @@ describe('response stream reasoning storage', () => {
     expect(state.responseRun?.pendingReasoning).toBeUndefined()
   })
 
+  it('keeps duplicate tool reasoning updates scoped to the current run', () => {
+    const previousToolCall = {
+      id: 'item_2',
+      type: 'function',
+      function: { name: 'Command', arguments: '{"command":"pwd"}' },
+    }
+    const state: SessionState = {
+      messages: [{
+        id: 1,
+        session_id: 'session-1',
+        runMarker: 'run-a',
+        role: 'assistant',
+        content: '',
+        reasoning: 'reasoning for run A',
+        reasoning_content: 'reasoning for run A',
+        tool_calls: [previousToolCall],
+        finish_reason: 'tool_calls',
+        timestamp: 1,
+      }],
+      isWorking: false,
+      events: [],
+      queue: [],
+    }
+    const repeatedToolCall = {
+      type: 'function_call',
+      call_id: 'item_2',
+      name: 'Command',
+      arguments: '{"command":"ls"}',
+    }
+
+    applyResponseStreamEvent(state, 'session-1', 'run-b', 'response.created', {
+      response: { id: 'resp-b', status: 'in_progress' },
+    })
+    applyResponseStreamEvent(state, 'session-1', 'run-b', 'response.reasoning.delta', {
+      delta: 'reasoning for run B',
+    })
+    applyResponseStreamEvent(state, 'session-1', 'run-b', 'response.output_item.done', {
+      item: repeatedToolCall,
+    })
+    applyResponseStreamEvent(state, 'session-1', 'run-b', 'response.output_item.done', {
+      item: repeatedToolCall,
+    })
+
+    expect(state.messages[0]).toMatchObject({
+      runMarker: 'run-a',
+      reasoning: 'reasoning for run A',
+      reasoning_content: 'reasoning for run A',
+    })
+    expect(state.messages[1]).toMatchObject({
+      runMarker: 'run-b',
+      reasoning: 'reasoning for run B',
+      reasoning_content: 'reasoning for run B',
+      tool_calls: [expect.objectContaining({ id: 'item_2' })],
+    })
+  })
+
   it('flushes reasoning fields to message storage', () => {
     const state: SessionState = { messages: [], isWorking: false, events: [], queue: [] }
 


### PR DESCRIPTION
## Summary

- scope tool-call correlation by run marker so reused tool call IDs from later coding-agent runs create separate cards
- use one reducer for live streaming, registered session events, and resume replay
- synthesize a completed tool card when a completion event arrives without its start event
- keep reasoning-message updates within the current run
- add regression coverage for history loading, live streams, resume replay, registered handlers, and cross-run reasoning storage
- document the chat-chain behavior change required by the repository harness

## Why

Some coding agents reuse IDs such as item_2 in separate runs. Studio previously matched those IDs globally, causing later tool calls to overwrite or merge into earlier cards. Reloading or resuming could appear correct because the reconstruction path behaved differently.

## Validation

- npm run harness:check
- 65 targeted client/server tests passed
- client Vue TypeScript build passed
- server TypeScript no-emit check passed
- git diff check passed

The event/API shape is unchanged, so the App client does not require a corresponding change.