### PR TITLE
[codex] improve attachment transfers and media previews

### DIFF
--- a/docs/chat-chain-changes/2026-08-25-pr-2732-attachment-content-and-preview.md
+++ b/docs/chat-chain-changes/2026-08-25-pr-2732-attachment-content-and-preview.md
@@ -1,0 +1,15 @@
+---
+date: 2026-08-25
+pr: 2732
+feature: Attachment content blocks and group attachment previews
+impact: Browser and workflow files retain file content blocks, stored group-chat documents preview through their authenticated attachment URL, user-sent videos play inline in single and group messages, and App group attachments can upload in progress-reporting chunks.
+---
+
+Inline video rendering is intentionally limited to user messages; Agent video
+attachments keep their existing file behavior. Workspace-originated group
+attachments continue to use workspace preview and editing behavior.
+
+App group attachments now open one room-scoped upload session, append ordered
+256 KiB chunks, and complete into the same private room attachment store used by
+the multipart route. The existing per-room upload count and attachment quotas
+still apply; chunks do not consume separate room upload slots.

--- a/docs/chat-chain-changes/2026-08-25-pr-2732-attachment-content-and-preview.md
+++ b/docs/chat-chain-changes/2026-08-25-pr-2732-attachment-content-and-preview.md
@@ -13,3 +13,16 @@ App group attachments now open one room-scoped upload session, append ordered
 256 KiB chunks, and complete into the same private room attachment store used by
 the multipart route. The existing per-room upload count and attachment quotas
 still apply; chunks do not consume separate room upload slots.
+
+App relay download failures now retain a stable error code and structured
+session diagnostics, including the last confirmed byte and chunk counts. Source
+stream failures are reported as `download_source_read_failed`, while expired or
+missing sessions remain distinguishable as `download_not_found`.
+Downloads with a declared content length now complete as soon as every declared
+byte has arrived, avoiding a redundant EOF read that could misclassify a closing
+HTTP stream as a failed final chunk.
+
+App media upload and download requests now allow five minutes. Cloud and LAN
+relay timeout caps, download-session idle expiry, and single/group chunked-upload
+session expiry use the same five-minute window; ordinary HTTP and bridged Socket
+requests keep their existing shorter defaults.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6624,6 +6624,171 @@
         ]
       }
     },
+    "/api/hermes/group-chat/rooms/{roomId}/attachment-uploads": {
+      "post": {
+        "tags": [
+          "Group Chat"
+        ],
+        "summary": "Create attachment-uploads",
+        "description": "POST /api/hermes/group-chat/rooms/:roomId/attachment-uploads",
+        "operationId": "createAttachment-uploads",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/group-chat/rooms/{roomId}/attachment-uploads/{id}": {
+      "delete": {
+        "tags": [
+          "Group Chat"
+        ],
+        "summary": "Delete :id",
+        "description": "DELETE /api/hermes/group-chat/rooms/:roomId/attachment-uploads/:id",
+        "operationId": "deleteAttachment-uploads",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/group-chat/rooms/{roomId}/attachment-uploads/{id}/chunks": {
+      "put": {
+        "tags": [
+          "Group Chat"
+        ],
+        "summary": "Update chunks",
+        "description": "PUT /api/hermes/group-chat/rooms/:roomId/attachment-uploads/:id/chunks",
+        "operationId": "updateChunks",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/api/hermes/group-chat/rooms/{roomId}/attachment-uploads/{id}/complete": {
+      "post": {
+        "tags": [
+          "Group Chat"
+        ],
+        "summary": "Create complete",
+        "description": "POST /api/hermes/group-chat/rooms/:roomId/attachment-uploads/:id/complete",
+        "operationId": "createComplete",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "parameters": [
+          {
+            "name": "roomId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
     "/api/hermes/group-chat/rooms/{roomId}/attachments": {
       "post": {
         "tags": [

--- a/packages/client/src/api/hermes/chat.ts
+++ b/packages/client/src/api/hermes/chat.ts
@@ -5,7 +5,7 @@ import type { ProviderApiMode } from './system'
 
 export type ContentBlock =
   | { type: 'text'; text: string }
-  | { type: 'image'; name: string; path: string; media_type: string; context?: string }
+  | { type: 'image'; name: string; path: string; media_type: string; context?: string; video_frame?: boolean }
   | { type: 'file'; name: string; path: string; media_type?: string; context?: string }
 
 export interface ChatMessage {

--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -19,6 +19,7 @@ import BundleCreateModal from './BundleCreateModal.vue'
 import { BRIDGE_SESSION_COMMAND_DEFINITIONS } from '@/utils/hermes/bridge-session-commands'
 import { clampChatInputHeight, isMobileChatInputViewport } from '@/utils/chat-input-height'
 import { normalizeComposerVoiceTranscript, useComposerVoiceInput } from '@/composables/useComposerVoiceInput'
+import { extractRepresentativeVideoFrames, isVideoFile } from '@/utils/video-frame-extraction'
 
 const chatStore = useChatStore()
 const appStore = useAppStore()
@@ -115,6 +116,9 @@ const textareaRef = ref<HTMLTextAreaElement>()
 const commandDropdownRef = ref<HTMLDivElement>()
 const fileInputRef = ref<HTMLInputElement>()
 const attachments = ref<Attachment[]>([])
+const pendingVideoFrameJobs = new Set<Promise<void>>()
+const isPreparingAttachments = ref(false)
+let sendAwaitingAttachments = false
 const isDragging = ref(false)
 const dragCounter = ref(0)
 const isComposing = ref(false)
@@ -864,6 +868,33 @@ function addFile(file: File) {
     url,
     file,
   })
+  if (!isVideoFile(file)) return
+
+  let job: Promise<void>
+  job = extractRepresentativeVideoFrames(file)
+    .then((frames) => {
+      if (!attachments.value.some(attachment => attachment.id === id)) return
+      for (const frame of frames) {
+        attachments.value.push({
+          id: `${id}-frame-${attachments.value.length}`,
+          name: frame.name,
+          type: frame.type,
+          size: frame.size,
+          url: URL.createObjectURL(frame),
+          file: frame,
+          videoFrameFor: id,
+        })
+      }
+    })
+    .catch(() => {
+      // Keep the original video attachment. Coding agents can still inspect its local path.
+    })
+    .finally(() => {
+      pendingVideoFrameJobs.delete(job)
+      isPreparingAttachments.value = pendingVideoFrameJobs.size > 0
+    })
+  pendingVideoFrameJobs.add(job)
+  isPreparingAttachments.value = true
 }
 
 function addFiles(files: File[]) {
@@ -936,7 +967,18 @@ defineExpose({ addFiles, focusComposer })
 
 // --- Send ---
 
-function handleSend() {
+async function handleSend() {
+  if (isPreparingAttachments.value) {
+    if (sendAwaitingAttachments) return
+    sendAwaitingAttachments = true
+    try {
+      while (pendingVideoFrameJobs.size > 0) {
+        await Promise.allSettled([...pendingVideoFrameJobs])
+      }
+    } finally {
+      sendAwaitingAttachments = false
+    }
+  }
   const text = inputText.value.trim()
   if (!text && attachments.value.length === 0) return
   if (isBridgeSession.value && text === '/skill' && attachments.value.length === 0) {
@@ -1041,11 +1083,13 @@ onUnmounted(() => {
 })
 
 function removeAttachment(id: string) {
-  const idx = attachments.value.findIndex(a => a.id === id)
-  if (idx !== -1) {
-    URL.revokeObjectURL(attachments.value[idx].url)
-    attachments.value.splice(idx, 1)
+  const removedIds = new Set([id])
+  for (const attachment of attachments.value) {
+    if (attachment.videoFrameFor === id) removedIds.add(attachment.id)
   }
+  const removed = attachments.value.filter(attachment => removedIds.has(attachment.id))
+  for (const attachment of removed) URL.revokeObjectURL(attachment.url)
+  attachments.value = attachments.value.filter(attachment => !removedIds.has(attachment.id))
 }
 
 function formatSize(bytes: number): string {
@@ -1062,9 +1106,9 @@ function isImage(type: string): boolean {
 <template>
   <div class="chat-input-area">
     <!-- Attachment previews -->
-    <div v-if="attachments.length > 0" class="attachment-previews">
+    <div v-if="attachments.some(att => !att.videoFrameFor)" class="attachment-previews">
       <div
-        v-for="att in attachments"
+        v-for="att in attachments.filter(item => !item.videoFrameFor)"
         :key="att.id"
         class="attachment-preview"
         :class="{ image: isImage(att.type), 'has-context': !!att.context }"

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -76,7 +76,7 @@ const statusItems = computed(() => {
 });
 
 type DisplayContentFile = {
-  type: 'image' | 'file'
+  type: 'image' | 'video' | 'file'
   name: string
   path?: string
   url?: string
@@ -173,6 +173,7 @@ const contentFiles = computed<DisplayContentFile[] | null>(() => {
   if (!isContentBlockArray.value) return null;
 
   return contentBlocks.value!.flatMap<DisplayContentFile>((block, index) => {
+    if ((block as any).video_frame === true) return []
     if (block.type === 'image') {
       return [{
         type: 'image' as const,
@@ -182,9 +183,11 @@ const contentFiles = computed<DisplayContentFile[] | null>(() => {
       }].filter(file => file.path)
     }
     if (block.type === 'file') {
+      const name = String((block as any).name || `file-${index + 1}`)
+      const mediaType = String((block as any).media_type || '')
       return [{
-        type: 'file' as const,
-        name: String((block as any).name || `file-${index + 1}`),
+        type: isVideo(mediaType, name) ? 'video' as const : 'file' as const,
+        name,
         path: String((block as any).path || ''),
         context: typeof (block as any).context === 'string' ? (block as any).context : undefined,
       }].filter(file => file.path)
@@ -359,6 +362,10 @@ const timeStr = computed(() => formatChatTimestamp(props.message.timestamp));
 
 function isImage(type: string): boolean {
   return type.startsWith("image/");
+}
+
+function isVideo(type: string, name: string): boolean {
+  return type.startsWith("video/") || /\.(?:mp4|mov|m4v|webm)$/i.test(name);
 }
 
 function formatSize(bytes: number): string {
@@ -1017,7 +1024,11 @@ onBeforeUnmount(() => {
                 v-for="att in message.attachments"
                 :key="att.id"
                 class="msg-attachment"
-                :class="{ image: isImage(att.type), 'has-context': !!att.context }"
+                :class="{
+                  image: isImage(att.type),
+                  video: message.role === 'user' && isVideo(att.type, att.name),
+                  'has-context': !!att.context,
+                }"
               >
                 <template v-if="isImage(att.type) && att.url">
                   <img
@@ -1026,6 +1037,19 @@ onBeforeUnmount(() => {
                     class="msg-attachment-thumb"
                     @click="previewUrl = att.url"
                   />
+                </template>
+                <template v-else-if="message.role === 'user' && isVideo(att.type, att.name) && att.url">
+                  <video
+                    class="msg-attachment-video"
+                    :src="att.url"
+                    controls
+                    playsinline
+                    preload="metadata"
+                  ></video>
+                  <div class="msg-attachment-video-footer">
+                    <span class="att-name">{{ att.name }}</span>
+                    <span class="att-size">{{ formatSize(att.size) }}</span>
+                  </div>
                 </template>
                 <template v-else>
                   <div class="msg-attachment-file" @click="handleAttachmentDownload(att)" style="cursor: pointer;" :title="t('download.downloadFile')">
@@ -1109,7 +1133,11 @@ onBeforeUnmount(() => {
                     v-for="(file, idx) in contentFiles"
                     :key="idx"
                     class="msg-attachment"
-                    :class="{ image: file.type === 'image', 'has-context': !!file.context }"
+                    :class="{
+                      image: file.type === 'image',
+                      video: file.type === 'video',
+                      'has-context': !!file.context,
+                    }"
                   >
                     <template v-if="file.type === 'image'">
                       <img
@@ -1118,6 +1146,18 @@ onBeforeUnmount(() => {
                         class="msg-attachment-thumb"
                         @click="previewUrl = getContentFileUrl(file)"
                       />
+                    </template>
+                    <template v-else-if="file.type === 'video'">
+                      <video
+                        class="msg-attachment-video"
+                        :src="getContentFileUrl(file)"
+                        controls
+                        playsinline
+                        preload="metadata"
+                      ></video>
+                      <div class="msg-attachment-video-footer">
+                        <span class="att-name">{{ file.name }}</span>
+                      </div>
                     </template>
                     <template v-else>
                       <div
@@ -1569,6 +1609,11 @@ onBeforeUnmount(() => {
   &.image.has-context {
     max-width: 420px;
   }
+
+  &.video {
+    width: min(360px, 100%);
+    background: #000;
+  }
 }
 
 .msg-attachment-thumb {
@@ -1582,6 +1627,39 @@ onBeforeUnmount(() => {
 .msg-attachment.has-context .msg-attachment-thumb {
   max-width: 420px;
   max-height: 280px;
+}
+
+.msg-attachment-video {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  max-height: 280px;
+  background: #000;
+  object-fit: contain;
+}
+
+.msg-attachment-video-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  color: $text-secondary;
+  background: rgba(0, 0, 0, 0.04);
+  font-size: 12px;
+
+  .att-name {
+    min-width: 0;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .att-size {
+    flex-shrink: 0;
+    color: $text-muted;
+    font-size: 11px;
+  }
 }
 
 .msg-attachment-context {

--- a/packages/client/src/components/hermes/files/FilePreview.vue
+++ b/packages/client/src/components/hermes/files/FilePreview.vue
@@ -28,19 +28,19 @@ const downloading = ref(false)
 const previewError = ref('')
 const previewText = ref('')
 const previewBuffer = shallowRef<ArrayBuffer | null>(null)
-const imageUrl = ref('')
+const mediaUrl = ref('')
 let requestController: AbortController | null = null
 let requestGeneration = 0
 
-function revokeImageUrl(): void {
-  if (imageUrl.value) URL.revokeObjectURL(imageUrl.value)
-  imageUrl.value = ''
+function revokeMediaUrl(): void {
+  if (mediaUrl.value) URL.revokeObjectURL(mediaUrl.value)
+  mediaUrl.value = ''
 }
 
 function resetLoadedPreview(): void {
   requestController?.abort()
   requestController = null
-  revokeImageUrl()
+  revokeMediaUrl()
   previewText.value = ''
   previewBuffer.value = null
   previewError.value = ''
@@ -66,8 +66,8 @@ async function loadPreview(): Promise<void> {
     if (!previewMimeMatches(file.type, blob.type)) {
       throw new Error(t('files.previewMimeMismatch'))
     }
-    if (file.type === 'image') {
-      imageUrl.value = URL.createObjectURL(blob)
+    if (file.type === 'image' || file.type === 'video') {
+      mediaUrl.value = URL.createObjectURL(blob)
     } else if (file.type === 'html' || file.type === 'csv') {
       const text = await blob.text()
       if (generation !== requestGeneration) return
@@ -89,6 +89,10 @@ async function loadPreview(): Promise<void> {
 
 function handleRendererError(error: Error): void {
   previewError.value = error.message || t('files.previewFailed')
+}
+
+function handleVideoError(): void {
+  previewError.value = t('files.previewFailed')
 }
 
 async function handleDownload(): Promise<void> {
@@ -182,10 +186,19 @@ onBeforeUnmount(() => {
         </div>
       </NAlert>
       <img
-        v-else-if="filesStore.previewFile.type === 'image' && imageUrl"
-        :src="imageUrl"
+        v-else-if="filesStore.previewFile.type === 'image' && mediaUrl"
+        :src="mediaUrl"
         class="preview-image"
         :alt="filesStore.previewFile.path"
+      />
+      <video
+        v-else-if="filesStore.previewFile.type === 'video' && mediaUrl"
+        :src="mediaUrl"
+        class="preview-video"
+        controls
+        playsinline
+        preload="metadata"
+        @error="handleVideoError"
       />
       <div v-else-if="filesStore.previewFile.type === 'markdown'" class="preview-markdown">
         <MarkdownRenderer :content="filesStore.previewFile.content || ''" />
@@ -297,6 +310,15 @@ onBeforeUnmount(() => {
 .preview-image {
   max-width: 100%;
   max-height: 100%;
+  object-fit: contain;
+}
+
+.preview-video {
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  background: #000;
   object-fit: contain;
 }
 

--- a/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatPanel.vue
@@ -75,6 +75,7 @@ import { handoffErrorTranslationKey } from './handoff-presentation'
 import { clearGroupChatRoomDraft } from './group-chat-room-drafts'
 
 const FilesPanel = defineAsyncComponent(async () => (await import('@/components/hermes/chat/FilesPanel.vue')).default)
+const FilePreview = defineAsyncComponent(async () => (await import('@/components/hermes/files/FilePreview.vue')).default)
 const WorkspaceDiffPreview = defineAsyncComponent(async () => (await import('@/components/hermes/files/WorkspaceDiffPreview.vue')).default)
 const DesktopBrowserPanel = defineAsyncComponent(async () => (await import('@/components/hermes/chat/DesktopBrowserPanel.vue')).default)
 const TerminalPanel = defineAsyncComponent(async () => (await import('@/components/hermes/chat/TerminalPanel.vue')).default)
@@ -828,6 +829,29 @@ function handleWorkspaceFilePreviewRequest(event: Event): void {
     })
 }
 
+function handleGroupAttachmentPreviewRequest(event: Event): void {
+    const customEvent = event as CustomEvent<{ sourceUrl?: string; fileName?: string; size?: number }>
+    const roomId = store.currentRoomId
+    const sourceUrl = String(customEvent.detail?.sourceUrl || '').trim()
+    const fileName = String(customEvent.detail?.fileName || '').trim()
+    if (!roomId || !sourceUrl || !fileName) return
+    customEvent.preventDefault()
+    toolPanelStore.closeWorkspaceDiff()
+    filesStore.closePreview()
+    void filesStore.openRemotePreview(
+        sourceUrl,
+        fileName,
+        Number(customEvent.detail?.size ?? -1),
+        { workspaceRoomId: roomId },
+    ).then(opened => {
+        if (!opened) return
+        activeWorkspacePanel.value = 'files'
+        showWorkspacePanel.value = true
+    }).catch(error => {
+        message.error(error instanceof Error ? error.message : t('files.previewFailed'))
+    })
+}
+
 function openPageSidebar() {
     if (props.standalone) return
     showSidebar.value = true
@@ -1456,6 +1480,7 @@ onMounted(() => {
     }
     window.addEventListener('hermes:open-page-sidebar', openPageSidebar)
     window.addEventListener('hermes:preview-workspace-file', handleWorkspaceFilePreviewRequest)
+    window.addEventListener('hermes:preview-group-attachment', handleGroupAttachmentPreviewRequest)
     window.addEventListener(OPEN_DESKTOP_BROWSER_PANEL_EVENT, handleOpenDesktopBrowserPanelRequest)
     window.addEventListener('resize', handleWorkspacePanelResize)
     window.addEventListener('focus', handleWindowFocus)
@@ -1475,6 +1500,7 @@ onUnmounted(() => {
     hideInlineSummaryStatus()
     window.removeEventListener('hermes:open-page-sidebar', openPageSidebar)
     window.removeEventListener('hermes:preview-workspace-file', handleWorkspaceFilePreviewRequest)
+    window.removeEventListener('hermes:preview-group-attachment', handleGroupAttachmentPreviewRequest)
     window.removeEventListener(OPEN_DESKTOP_BROWSER_PANEL_EVENT, handleOpenDesktopBrowserPanelRequest)
     window.removeEventListener('resize', handleWorkspacePanelResize)
     window.removeEventListener('focus', handleWindowFocus)
@@ -2577,6 +2603,10 @@ function handleClarifyKeydown(event: KeyboardEvent) {
                                             @attach="handleWorkspaceFileAttach"
                                         />
                                     </template>
+                                    <FilePreview
+                                        v-else-if="filesStore.previewFile?.workspaceRoomId === store.currentRoomId"
+                                        :custom-close="closeWorkspacePanel"
+                                    />
                                     <div v-else-if="activeWorkspacePanel === 'files'" class="group-workspace-empty">
                                         <svg width="38" height="38" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true">
                                             <path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -595,6 +595,10 @@ function isImage(type: string): boolean {
     return type.startsWith('image/')
 }
 
+function isVideo(type: string, name: string): boolean {
+    return type.startsWith('video/') || /\.(?:mp4|mov|m4v|webm)$/i.test(name)
+}
+
 function attachmentPath(attachment: { path?: string; url?: string }): string | null {
     if (attachment.path) return attachment.path
     try {
@@ -604,8 +608,30 @@ function attachmentPath(attachment: { path?: string; url?: string }): string | n
     }
 }
 
-function handleAttachmentClick(event: MouseEvent, attachment: { name: string; path?: string; url?: string }): void {
+function isStoredGroupAttachment(attachment: { path?: string; url?: string }): boolean {
+    const rawPath = String(attachment.path || '').trim()
+    if (rawPath) {
+        const path = rawPath.split(/[?#]/, 1)[0].split(/[\\/]/).pop() || ''
+        return /^[a-f0-9]{32}(?:\.[a-z0-9]{1,12})?$/i.test(path)
+    }
+    return /\/api\/hermes\/group-chat\/(?:rooms|invites)\/[^/?#]+\/attachments\/[^/?#]+/i.test(String(attachment.url || ''))
+}
+
+function handleAttachmentClick(event: MouseEvent, attachment: { name: string; size?: number; path?: string; url?: string }): void {
     if (!isPreviewableFile(attachment.name)) return
+    if (isStoredGroupAttachment(attachment) && attachment.url) {
+        const previewEvent = new CustomEvent('hermes:preview-group-attachment', {
+            cancelable: true,
+            detail: {
+                sourceUrl: attachment.url,
+                fileName: attachment.name,
+                size: Number(attachment.size || 0),
+            },
+        })
+        window.dispatchEvent(previewEvent)
+        if (previewEvent.defaultPrevented) event.preventDefault()
+        return
+    }
     const path = attachmentPath(attachment)
     if (!path) return
     const previewEvent = new CustomEvent('hermes:preview-workspace-file', {
@@ -741,9 +767,25 @@ onBeforeUnmount(() => {
                         v-for="att in renderedAttachments"
                         :key="att.id"
                         class="msg-attachment"
-                        :class="{ image: isImage(att.type) }"
+                        :class="{
+                            image: isImage(att.type),
+                            video: message.role === 'user' && isVideo(att.type, att.name),
+                        }"
                     >
                         <img v-if="isImage(att.type)" :src="att.url" :alt="att.name" class="msg-attachment-thumb" @click="previewUrl = att.url" />
+                        <template v-else-if="message.role === 'user' && isVideo(att.type, att.name)">
+                            <video
+                                class="msg-attachment-video"
+                                :src="att.url"
+                                controls
+                                playsinline
+                                preload="metadata"
+                            ></video>
+                            <div class="msg-attachment-video-footer">
+                                <span class="att-name">{{ att.name }}</span>
+                                <span v-if="att.size" class="att-size">{{ formatSize(att.size) }}</span>
+                            </div>
+                        </template>
                         <a v-else class="msg-attachment-file" :href="att.url" :title="t('download.downloadFile')" @click="handleAttachmentClick($event, att)">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
                                 <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
@@ -1295,6 +1337,11 @@ onBeforeUnmount(() => {
         width: 96px;
         height: 96px;
     }
+
+    &.video {
+        width: min(360px, 100%);
+        background: #000;
+    }
 }
 
 .msg-attachment-thumb {
@@ -1303,6 +1350,39 @@ onBeforeUnmount(() => {
     object-fit: cover;
     display: block;
     cursor: zoom-in;
+}
+
+.msg-attachment-video {
+    display: block;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    max-height: 280px;
+    background: #000;
+    object-fit: contain;
+}
+
+.msg-attachment-video-footer {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 7px 10px;
+    color: $text-secondary;
+    background: $bg-secondary;
+    font-size: 12px;
+
+    .att-name {
+        min-width: 0;
+        flex: 1;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .att-size {
+        flex-shrink: 0;
+        color: $text-muted;
+        font-size: 11px;
+    }
 }
 
 .msg-attachment-file {

--- a/packages/client/src/stores/hermes/chat.ts
+++ b/packages/client/src/stores/hermes/chat.ts
@@ -59,6 +59,8 @@ export interface Attachment {
   file?: File
   /** Structured context sent to the model but rendered collapsed in the UI. */
   context?: string
+  /** Original video attachment id when this file is a model-only representative frame. */
+  videoFrameFor?: string
 }
 
 export interface Message {
@@ -619,6 +621,7 @@ export async function buildContentBlocks(
           path: uploaded.path,
           media_type: attachment.type,
           ...(attachment.context?.trim() ? { context: attachment.context.trim() } : {}),
+          ...(attachment.videoFrameFor ? { video_frame: true } : {}),
         })
       } else {
         // Other files
@@ -3428,12 +3431,13 @@ export const useChatStore = defineStore('chat', () => {
       settleRuntimeDisplayForCommand(sid)
     }
 
+    const visibleAttachments = attachments?.filter(attachment => !attachment.videoFrameFor)
     const userMsg: Message = {
       id: uid(),
       role: isBridgeSlashCommand ? 'command' : 'user',
       content: submittedContent,
       timestamp: Date.now(),
-      attachments: attachments && attachments.length > 0 ? attachments : undefined,
+      attachments: visibleAttachments && visibleAttachments.length > 0 ? visibleAttachments : undefined,
       queued: shouldQueue,
       systemType: isBridgeSlashCommand ? 'command' : undefined,
     }

--- a/packages/client/src/stores/hermes/files.ts
+++ b/packages/client/src/stores/hermes/files.ts
@@ -344,7 +344,12 @@ export const useFilesStore = defineStore('files', () => {
     previewFile.value = common
   }
 
-  async function openRemotePreview(sourceUrl: string, fileName: string, size = -1): Promise<boolean> {
+  async function openRemotePreview(
+    sourceUrl: string,
+    fileName: string,
+    size = -1,
+    context: { workspaceSessionId?: string | null; workspaceRoomId?: string | null } = {},
+  ): Promise<boolean> {
     const type = getFilePreviewKind(fileName)
     if (!type) return false
     const common = {
@@ -354,6 +359,7 @@ export const useFilesStore = defineStore('files', () => {
       profile: null,
       sourceUrl,
       type,
+      ...context,
     }
     if (type === 'markdown' || type === 'text') {
       const blob = await fetchAuthenticatedBlob(sourceUrl, { profile: null })

--- a/packages/client/src/utils/hermes/file-preview.ts
+++ b/packages/client/src/utils/hermes/file-preview.ts
@@ -1,5 +1,6 @@
 export type FilePreviewKind =
   | 'image'
+  | 'video'
   | 'markdown'
   | 'text'
   | 'html'
@@ -10,6 +11,7 @@ export type FilePreviewKind =
   | 'csv'
 
 const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.bmp', '.ico'])
+const VIDEO_EXTS = new Set(['.mp4', '.mov', '.m4v', '.webm'])
 const MARKDOWN_EXTS = new Set(['.md', '.markdown'])
 const HTML_EXTS = new Set(['.html', '.htm'])
 
@@ -159,6 +161,7 @@ export function getTextPreviewLanguage(name: string): string | null {
 export function getFilePreviewKind(name: string): FilePreviewKind | null {
   const extension = getFileExtension(name)
   if (IMAGE_EXTS.has(extension)) return 'image'
+  if (VIDEO_EXTS.has(extension)) return 'video'
   if (MARKDOWN_EXTS.has(extension)) return 'markdown'
   if (HTML_EXTS.has(extension)) return 'html'
   if (extension === '.pdf') return 'pdf'
@@ -176,6 +179,7 @@ export function isPreviewableFile(name: string): boolean {
 export function previewMimeMatches(kind: FilePreviewKind, mime: string): boolean {
   const normalized = mime.split(';')[0].trim().toLowerCase()
   if (kind === 'image') return normalized.startsWith('image/')
+  if (kind === 'video') return normalized.startsWith('video/')
   if (kind === 'html') return normalized === 'text/html'
   if (kind === 'pdf') return normalized === 'application/pdf'
   if (kind === 'docx') return normalized === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'

--- a/packages/client/src/utils/video-frame-extraction.ts
+++ b/packages/client/src/utils/video-frame-extraction.ts
@@ -1,0 +1,135 @@
+const VIDEO_EXTENSIONS = new Set(['mp4', 'mov', 'm4v', 'webm', 'ogv', 'ogg'])
+const DEFAULT_FRAME_COUNT = 3
+const DEFAULT_MAX_DIMENSION = 1280
+const VIDEO_LOAD_TIMEOUT_MS = 10_000
+const VIDEO_SEEK_TIMEOUT_MS = 6_000
+
+function fileExtension(name: string): string {
+  const baseName = name.split(/[\\/]/).pop() || ''
+  const dot = baseName.lastIndexOf('.')
+  return dot >= 0 ? baseName.slice(dot + 1).toLowerCase() : ''
+}
+
+export function isVideoFile(file: Pick<File, 'name' | 'type'>): boolean {
+  return file.type.toLowerCase().startsWith('video/') || VIDEO_EXTENSIONS.has(fileExtension(file.name))
+}
+
+export function representativeVideoFrameTimes(duration: number, frameCount = DEFAULT_FRAME_COUNT): number[] {
+  if (!Number.isFinite(duration) || duration <= 0 || frameCount <= 0) return []
+  if (frameCount === 1) return [Math.min(duration / 2, Math.max(0, duration - 0.05))]
+
+  const safeEnd = Math.max(0, duration - 0.05)
+  const startRatio = 0.1
+  const endRatio = 0.9
+  const times = Array.from({ length: frameCount }, (_, index) => {
+    const ratio = startRatio + ((endRatio - startRatio) * index) / (frameCount - 1)
+    return Math.min(safeEnd, Math.max(0, duration * ratio))
+  })
+  return times.filter((time, index) => index === 0 || Math.abs(time - times[index - 1]) >= 0.01)
+}
+
+function waitForVideoEvent(
+  video: HTMLVideoElement,
+  eventName: 'loadedmetadata' | 'loadeddata' | 'seeked',
+  timeoutMs: number,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      window.clearTimeout(timeout)
+      video.removeEventListener(eventName, handleSuccess)
+      video.removeEventListener('error', handleError)
+    }
+    const handleSuccess = () => {
+      cleanup()
+      resolve()
+    }
+    const handleError = () => {
+      cleanup()
+      reject(video.error || new Error(`Failed to decode video while waiting for ${eventName}`))
+    }
+    const timeout = window.setTimeout(() => {
+      cleanup()
+      reject(new Error(`Timed out while waiting for video ${eventName}`))
+    }, timeoutMs)
+
+    video.addEventListener(eventName, handleSuccess, { once: true })
+    video.addEventListener('error', handleError, { once: true })
+  })
+}
+
+function canvasBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) resolve(blob)
+      else reject(new Error('Failed to encode extracted video frame'))
+    }, 'image/jpeg', 0.84)
+  })
+}
+
+function frameDimensions(width: number, height: number, maxDimension: number): { width: number; height: number } {
+  const scale = Math.min(1, maxDimension / Math.max(width, height))
+  return {
+    width: Math.max(1, Math.round(width * scale)),
+    height: Math.max(1, Math.round(height * scale)),
+  }
+}
+
+function frameFileName(videoName: string, index: number): string {
+  const baseName = (videoName.split(/[\\/]/).pop() || 'video').replace(/\.[^.]+$/, '') || 'video'
+  return `${baseName}-video-frame-${String(index + 1).padStart(2, '0')}.jpg`
+}
+
+export async function extractRepresentativeVideoFrames(
+  file: File,
+  options: { frameCount?: number; maxDimension?: number } = {},
+): Promise<File[]> {
+  if (typeof document === 'undefined' || typeof URL === 'undefined' || typeof URL.createObjectURL !== 'function') return []
+
+  const frameCount = Math.max(1, Math.min(5, Math.round(options.frameCount || DEFAULT_FRAME_COUNT)))
+  const maxDimension = Math.max(320, Math.min(1920, Math.round(options.maxDimension || DEFAULT_MAX_DIMENSION)))
+  const video = document.createElement('video')
+  const objectUrl = URL.createObjectURL(file)
+  video.muted = true
+  video.preload = 'auto'
+  video.playsInline = true
+
+  try {
+    const metadataReady = waitForVideoEvent(video, 'loadedmetadata', VIDEO_LOAD_TIMEOUT_MS)
+    video.src = objectUrl
+    video.load()
+    await metadataReady
+
+    if (!video.videoWidth || !video.videoHeight) return []
+    const times = representativeVideoFrameTimes(video.duration, frameCount)
+    if (times.length === 0) return []
+
+    const dimensions = frameDimensions(video.videoWidth, video.videoHeight, maxDimension)
+    const canvas = document.createElement('canvas')
+    canvas.width = dimensions.width
+    canvas.height = dimensions.height
+    const context = canvas.getContext('2d')
+    if (!context) return []
+
+    const frames: File[] = []
+    for (const [index, time] of times.entries()) {
+      if (Math.abs(video.currentTime - time) >= 0.01) {
+        const seeked = waitForVideoEvent(video, 'seeked', VIDEO_SEEK_TIMEOUT_MS)
+        video.currentTime = time
+        await seeked
+      } else if (video.readyState < 2) {
+        await waitForVideoEvent(video, 'loadeddata', VIDEO_SEEK_TIMEOUT_MS)
+      }
+      context.drawImage(video, 0, 0, dimensions.width, dimensions.height)
+      const blob = await canvasBlob(canvas)
+      frames.push(new File([blob], frameFileName(file.name, index), {
+        type: 'image/jpeg',
+        lastModified: file.lastModified,
+      }))
+    }
+    return frames
+  } finally {
+    video.removeAttribute('src')
+    video.load()
+    URL.revokeObjectURL(objectUrl)
+  }
+}

--- a/packages/server/src/controllers/hermes/group-chat-invite.ts
+++ b/packages/server/src/controllers/hermes/group-chat-invite.ts
@@ -68,7 +68,7 @@ function safeDisplayName(value: unknown, fallback = 'attachment'): string {
     return name || fallback
 }
 
-function consumeRoomUploadRate(roomId: string): boolean {
+export function consumeRoomUploadRate(roomId: string): boolean {
     const now = Date.now()
     for (const [key, entry] of roomUploadRates) {
         if (now - entry.windowStartedAt >= GROUP_CHAT_UPLOAD_WINDOW_MS) roomUploadRates.delete(key)

--- a/packages/server/src/controllers/hermes/group-chat-upload.ts
+++ b/packages/server/src/controllers/hermes/group-chat-upload.ts
@@ -1,0 +1,99 @@
+import {
+    GROUP_CHAT_UPLOAD_CHUNK_BYTES,
+    GroupChatUploadError,
+    abortGroupChatUpload,
+    appendGroupChatUploadChunk,
+    completeGroupChatUpload,
+    openGroupChatUpload,
+} from '../../services/hermes/group-chat/chunked-upload'
+import { consumeRoomUploadRate } from './group-chat-invite'
+
+function requestOwner(ctx: any): string {
+    return String(ctx.state?.user?.id || ctx.state?.user?.username || 'local')
+}
+
+function handleError(ctx: any, error: unknown): void {
+    if (error instanceof GroupChatUploadError) {
+        ctx.status = error.status
+        ctx.body = { error: error.message, code: error.code }
+        return
+    }
+    throw error
+}
+
+export async function open(ctx: any, room: { id: string }): Promise<void> {
+    if (!consumeRoomUploadRate(room.id)) {
+        ctx.status = 429
+        ctx.set('Retry-After', '60')
+        ctx.body = { error: 'Too many group chat uploads, please try again later' }
+        return
+    }
+    try {
+        const body = ctx.request.body && typeof ctx.request.body === 'object' && !Array.isArray(ctx.request.body)
+            ? ctx.request.body as Record<string, unknown>
+            : {}
+        ctx.body = await openGroupChatUpload({
+            id: body.id,
+            name: body.name,
+            size: body.size,
+            owner: requestOwner(ctx),
+            roomId: room.id,
+        })
+    } catch (error) {
+        handleError(ctx, error)
+    }
+}
+
+export async function appendChunk(ctx: any, room: { id: string }): Promise<void> {
+    try {
+        const chunks: Buffer[] = []
+        let byteLength = 0
+        for await (const rawChunk of ctx.req) {
+            const chunk = Buffer.isBuffer(rawChunk) ? rawChunk : Buffer.from(rawChunk)
+            byteLength += chunk.byteLength
+            if (byteLength > GROUP_CHAT_UPLOAD_CHUNK_BYTES) {
+                throw new GroupChatUploadError(
+                    'upload_chunk_too_large',
+                    `Upload chunks are limited to ${GROUP_CHAT_UPLOAD_CHUNK_BYTES} bytes`,
+                    413,
+                )
+            }
+            chunks.push(chunk)
+        }
+        ctx.body = await appendGroupChatUploadChunk({
+            id: ctx.params.id,
+            offset: ctx.query.offset,
+            bytes: Uint8Array.from(Buffer.concat(chunks)),
+            owner: requestOwner(ctx),
+            roomId: room.id,
+        })
+    } catch (error) {
+        handleError(ctx, error)
+    }
+}
+
+export async function complete(ctx: any, room: { id: string }): Promise<void> {
+    try {
+        const file = await completeGroupChatUpload({
+            id: ctx.params.id,
+            owner: requestOwner(ctx),
+            roomId: room.id,
+        })
+        ctx.body = { files: [file] }
+    } catch (error) {
+        handleError(ctx, error)
+    }
+}
+
+export async function abort(ctx: any, room: { id: string }): Promise<void> {
+    try {
+        await abortGroupChatUpload({
+            id: ctx.params.id,
+            owner: requestOwner(ctx),
+            roomId: room.id,
+        })
+        ctx.body = { ok: true }
+    } catch (error) {
+        handleError(ctx, error)
+    }
+}

--- a/packages/server/src/routes/hermes/group-chat.ts
+++ b/packages/server/src/routes/hermes/group-chat.ts
@@ -17,6 +17,7 @@ import {
 } from '../../services/hermes/group-chat/access'
 import { setGroupChatRuntimeServer } from '../../services/hermes/group-chat/runtime'
 import * as inviteCtrl from '../../controllers/hermes/group-chat-invite'
+import * as uploadCtrl from '../../controllers/hermes/group-chat-upload'
 import * as workspaceCtrl from '../../controllers/hermes/group-chat-workspace'
 import * as agentLinkCtrl from '../../controllers/hermes/group-chat-agent-link'
 import * as remoteWorkspaceCtrl from '../../controllers/hermes/group-chat-remote-workspace'
@@ -105,6 +106,26 @@ async function authorizedAttachmentRoom(ctx: any): Promise<any | null> {
 groupChatRoutes.post('/api/hermes/group-chat/rooms/:roomId/attachments', async (ctx) => {
     const room = await authorizedAttachmentRoom(ctx)
     if (room) await inviteCtrl.uploadRoomAttachment(ctx, room)
+})
+
+groupChatRoutes.post('/api/hermes/group-chat/rooms/:roomId/attachment-uploads', async (ctx) => {
+    const room = await authorizedAttachmentRoom(ctx)
+    if (room) await uploadCtrl.open(ctx, room)
+})
+
+groupChatRoutes.put('/api/hermes/group-chat/rooms/:roomId/attachment-uploads/:id/chunks', async (ctx) => {
+    const room = await authorizedAttachmentRoom(ctx)
+    if (room) await uploadCtrl.appendChunk(ctx, room)
+})
+
+groupChatRoutes.post('/api/hermes/group-chat/rooms/:roomId/attachment-uploads/:id/complete', async (ctx) => {
+    const room = await authorizedAttachmentRoom(ctx)
+    if (room) await uploadCtrl.complete(ctx, room)
+})
+
+groupChatRoutes.delete('/api/hermes/group-chat/rooms/:roomId/attachment-uploads/:id', async (ctx) => {
+    const room = await authorizedAttachmentRoom(ctx)
+    if (room) await uploadCtrl.abort(ctx, room)
 })
 
 groupChatRoutes.get('/api/hermes/group-chat/rooms/:roomId/attachments/:file', async (ctx) => {

--- a/packages/server/src/services/app-relay/client.ts
+++ b/packages/server/src/services/app-relay/client.ts
@@ -9,12 +9,20 @@ import {
 } from '../../db/hermes/app-connections-store'
 import { logger } from '../logger'
 import { createDeviceSignature } from '../system-info'
+import {
+  RELAY_DOWNLOAD_CHUNK_BYTES,
+  RelayDownloadSessionError,
+  RelayDownloadSessions,
+  type RelayDownloadDescriptor,
+} from './download-session'
 
 const APP_RELAY_NAMESPACE = '/app-relay'
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
 const MAX_REQUEST_TIMEOUT_MS = 120_000
-const MAX_REQUEST_BODY_BYTES = 20 * 1024 * 1024
-const MAX_RESPONSE_BODY_BYTES = 20 * 1024 * 1024
+const BYTES_PER_MEGABYTE = 1024 * 1024
+const DEFAULT_CLOUD_MEDIA_MAX_BYTES = 30 * BYTES_PER_MEGABYTE
+const MAX_CONTROL_REQUEST_BODY_BYTES = 20 * BYTES_PER_MEGABYTE
+const MAX_CONTROL_RESPONSE_BODY_BYTES = 20 * BYTES_PER_MEGABYTE
 
 const ALLOWED_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD'])
 const ALLOWED_REQUEST_HEADERS = new Set([
@@ -92,6 +100,7 @@ export interface AppRelayHttpRequest {
   bodyBytes?: ArrayBuffer | ArrayBufferView
   bodyBase64?: string
   timeoutMs?: number
+  streamBinary?: boolean
 }
 
 export interface AppRelayHttpResponse {
@@ -102,6 +111,22 @@ export interface AppRelayHttpResponse {
   bodyBytes?: Uint8Array
   bodyBase64?: string
   truncated?: boolean
+  download?: RelayDownloadDescriptor
+  error?: { code: string; message: string }
+}
+
+export interface AppRelayHttpDownloadRequest {
+  id?: string
+  maxBytes?: number
+}
+
+export interface AppRelayHttpDownloadResponse {
+  id?: string
+  status?: number
+  bodyBytes?: Uint8Array
+  receivedBytes?: number
+  totalBytes?: number
+  done?: boolean
   error?: { code: string; message: string }
 }
 
@@ -188,7 +213,10 @@ export class AppRelayClient {
     preconnection: CloudAppPreconnection
   }>()
   private readonly cloudConnectionOnline = new Map<string, boolean>()
+  private readonly downloadSessions = new RelayDownloadSessions()
   private preconnectionExpired = false
+  private cloudMediaMaxBytes = DEFAULT_CLOUD_MEDIA_MAX_BYTES
+  private cloudSupportsChunkedDownloads = false
 
   constructor(private readonly options: Required<Omit<StartAppRelayClientOptions, 'connectionId' | 'machineInfo'>> & {
     machineInfo?: Record<string, unknown>
@@ -244,6 +272,11 @@ export class AppRelayClient {
     this.socket.on('relay.replaced', () => this.stop())
     this.socket.on('relay.ready', (payload: Record<string, unknown> = {}) => {
       this.rememberPairing(payload)
+      this.applyRelayLimits(payload)
+      this.applyRelayCapabilities(payload)
+    })
+    this.socket.on('relay.limits.updated', (payload: Record<string, unknown> = {}) => {
+      this.applyRelayLimits(payload)
     })
     this.socket.on('connection.authorize', (
       request: Record<string, unknown> = {},
@@ -276,6 +309,20 @@ export class AppRelayClient {
       void this.handleHttpRequest(request)
         .then(response => ack?.(response))
         .catch(err => ack?.(httpError(request?.id, 'relay_internal_error', err instanceof Error ? err.message : String(err), 500)))
+    })
+    this.socket.on('app.http.download.chunk', (
+      request: AppRelayHttpDownloadRequest = {},
+      ack?: (response: AppRelayHttpDownloadResponse) => void,
+    ) => {
+      void this.readHttpDownloadChunk(request).then(response => ack?.(response))
+    })
+    this.socket.on('app.http.download.cancel', (
+      request: AppRelayHttpDownloadRequest = {},
+      ack?: (response: AppRelayHttpDownloadResponse) => void,
+    ) => {
+      const id = normalizeBridgeId(request.id)
+      const cancelled = id ? this.downloadSessions.cancel(this.options.machineId, id) : false
+      ack?.(cancelled ? { id, done: true } : downloadError(request.id, 'download_not_found', 'Download session was not found'))
     })
     this.socket.on('app.socket.open', (request: AppRelaySocketOpenRequest, ack?: (response: AppRelaySocketResponse) => void) => {
       ack?.(this.openLocalSocket(request))
@@ -451,7 +498,7 @@ export class AppRelayClient {
       headers.delete('authorization')
       headers.set('x-hermes-app-connection', 'cloud')
     }
-    const normalizedBody = normalizeRequestBody(request, method, headers)
+    const normalizedBody = normalizeRequestBody(request, method, headers, this.cloudMediaMaxBytes)
     if (isHttpErrorResponse(normalizedBody)) return normalizedBody
     if (normalizedBody.contentType) headers.set('content-type', normalizedBody.contentType)
 
@@ -465,11 +512,39 @@ export class AppRelayClient {
         body: normalizedBody.body,
         signal: controller.signal,
       })
+      const textual = isTextualResponse(response)
+      if (!textual && declaredResponseBodyBytes(response) > this.cloudMediaMaxBytes) {
+        await response.body?.cancel()
+        return cloudMediaTooLarge(request.id, this.cloudMediaMaxBytes, 'download')
+      }
+      if (
+        request.streamBinary === true
+        && this.cloudSupportsChunkedDownloads
+        && !textual
+        && response.ok
+        && response.body
+      ) {
+        const download = this.downloadSessions.create(this.options.machineId, response)
+        return {
+          id: request.id,
+          status: response.status,
+          headers: responseHeaders(response),
+          download,
+        }
+      }
+      const responseBody = await readResponseBody(
+        response,
+        textual ? MAX_CONTROL_RESPONSE_BODY_BYTES : this.cloudMediaMaxBytes,
+        textual,
+      )
+      if (!textual && responseBody.truncated) {
+        return cloudMediaTooLarge(request.id, this.cloudMediaMaxBytes, 'download')
+      }
       return {
         id: request.id,
         status: response.status,
         headers: responseHeaders(response),
-        ...(await readResponseBody(response)),
+        ...responseBody,
       }
     } catch (err) {
       const aborted = controller.signal.aborted
@@ -598,10 +673,44 @@ export class AppRelayClient {
   }
 
   private clearRelaySessionState(): void {
+    this.downloadSessions.cancelAll()
+    this.cloudSupportsChunkedDownloads = false
     this.pendingPreconnections.clear()
     this.cloudConnectionOnline.clear()
     this.pairingCode = ''
     this.pairingExpiresAt = 0
+  }
+
+  private applyRelayLimits(payload: Record<string, unknown>): void {
+    const limits = isRecord(payload.limits) ? payload.limits : null
+    const mediaMaxMegabytes = Number(limits?.mediaMaxMegabytes)
+    if (!Number.isSafeInteger(mediaMaxMegabytes) || mediaMaxMegabytes < 1 || mediaMaxMegabytes > 1024) return
+    this.cloudMediaMaxBytes = mediaMaxMegabytes * BYTES_PER_MEGABYTE
+  }
+
+  private applyRelayCapabilities(payload: Record<string, unknown>): void {
+    const capabilities = Array.isArray(payload.capabilities) ? payload.capabilities : []
+    this.cloudSupportsChunkedDownloads = capabilities.includes('http.download.chunked')
+  }
+
+  private async readHttpDownloadChunk(
+    request: AppRelayHttpDownloadRequest,
+  ): Promise<AppRelayHttpDownloadResponse> {
+    const id = normalizeBridgeId(request.id)
+    if (!id) return downloadError(request.id, 'invalid_download_id', 'Download session id is required')
+    try {
+      return await this.downloadSessions.read(
+        this.options.machineId,
+        id,
+        Number(request.maxBytes) || RELAY_DOWNLOAD_CHUNK_BYTES,
+        this.cloudMediaMaxBytes,
+      )
+    } catch (error) {
+      const code = error instanceof RelayDownloadSessionError ? error.code : 'download_failed'
+      return code === 'download_too_large'
+        ? { ...cloudMediaTooLarge(id, this.cloudMediaMaxBytes, 'download'), done: true }
+        : downloadError(id, code, 'Unable to read the next download chunk')
+    }
   }
 
   private async authorizeCloudConnection(request: Record<string, unknown>): Promise<Record<string, unknown>> {
@@ -855,20 +964,36 @@ function normalizeHeaders(input: AppRelayHttpRequest['headers']): Headers {
   return headers
 }
 
-function normalizeRequestBody(request: AppRelayHttpRequest, method: string, headers: Headers): NormalizedBody | AppRelayHttpResponse {
+function normalizeRequestBody(
+  request: AppRelayHttpRequest,
+  method: string,
+  headers: Headers,
+  cloudMediaMaxBytes: number,
+): NormalizedBody | AppRelayHttpResponse {
   if (method === 'GET' || method === 'HEAD') return {}
   let body: BodyInit | undefined
+  let binary = false
   const byteBody = relayByteBuffer(request.bodyBytes)
-  if (byteBody) body = Uint8Array.from(byteBody)
+  if (byteBody) {
+    body = Uint8Array.from(byteBody)
+    binary = true
+  }
   else if (request.bodyBytes != null) return httpError(request.id, 'invalid_binary_body', 'Relay binary request body is invalid', 400)
-  else if (typeof request.bodyBase64 === 'string') body = Buffer.from(request.bodyBase64, 'base64')
+  else if (typeof request.bodyBase64 === 'string') {
+    body = Buffer.from(request.bodyBase64, 'base64')
+    binary = true
+  }
   else if (typeof request.body === 'string') body = request.body
   else if (request.body != null) {
     body = JSON.stringify(request.body)
     if (!headers.has('content-type')) headers.set('content-type', 'application/json')
   }
-  if (body != null && Buffer.byteLength(typeof body === 'string' ? body : Buffer.from(body as any)) > MAX_REQUEST_BODY_BYTES) {
-    return httpError(request.id, 'request_body_too_large', 'Relay request body exceeds the local size limit', 413)
+  const bodyBytes = body == null ? 0 : Buffer.byteLength(typeof body === 'string' ? body : Buffer.from(body as any))
+  if (binary && bodyBytes > cloudMediaMaxBytes) {
+    return cloudMediaTooLarge(request.id, cloudMediaMaxBytes, 'upload')
+  }
+  if (!binary && bodyBytes > MAX_CONTROL_REQUEST_BODY_BYTES) {
+    return httpError(request.id, 'request_body_too_large', 'Relay control request body exceeds the safety limit', 413)
   }
   return { body }
 }
@@ -886,7 +1011,11 @@ function responseHeaders(response: Response): Record<string, string> {
   return headers
 }
 
-async function readResponseBody(response: Response): Promise<Pick<AppRelayHttpResponse, 'body' | 'bodyBytes' | 'truncated'>> {
+async function readResponseBody(
+  response: Response,
+  maxBytes: number,
+  textual = isTextualResponse(response),
+): Promise<Pick<AppRelayHttpResponse, 'body' | 'bodyBytes' | 'truncated'>> {
   if (!response.body) return {}
   const reader = response.body.getReader()
   const chunks: Buffer[] = []
@@ -896,7 +1025,7 @@ async function readResponseBody(response: Response): Promise<Pick<AppRelayHttpRe
     const { done, value } = await reader.read()
     if (done) break
     const chunk = Buffer.from(value)
-    const remaining = MAX_RESPONSE_BODY_BYTES - total
+    const remaining = maxBytes - total
     if (chunk.byteLength > remaining) {
       if (remaining > 0) chunks.push(chunk.subarray(0, remaining))
       truncated = true
@@ -907,9 +1036,35 @@ async function readResponseBody(response: Response): Promise<Pick<AppRelayHttpRe
     total += chunk.byteLength
   }
   const buffer = Buffer.concat(chunks)
-  const contentType = response.headers.get('content-type') || ''
-  const textual = TEXTUAL_RESPONSE_TYPES.some(prefix => contentType.toLowerCase().startsWith(prefix) || contentType.toLowerCase().includes(prefix))
   return textual ? { body: buffer.toString('utf8'), truncated } : { bodyBytes: buffer, truncated }
+}
+
+function isTextualResponse(response: Response): boolean {
+  if ((response.headers.get('content-disposition') || '').toLowerCase().includes('attachment')) return false
+  const contentType = (response.headers.get('content-type') || '').toLowerCase()
+  return TEXTUAL_RESPONSE_TYPES.some(prefix => contentType.startsWith(prefix) || contentType.includes(prefix))
+}
+
+function declaredResponseBodyBytes(response: Response): number {
+  const value = Number(response.headers.get('content-length'))
+  return Number.isSafeInteger(value) && value >= 0 ? value : 0
+}
+
+function cloudMediaTooLarge(
+  id: string | undefined,
+  maxBytes: number,
+  direction: 'upload' | 'download',
+): AppRelayHttpResponse {
+  return httpError(
+    id,
+    `${direction}_too_large`,
+    `Cloud relay media files are limited to ${formatMegabytes(maxBytes)}MB`,
+    413,
+  )
+}
+
+function formatMegabytes(bytes: number): string {
+  return String(Math.max(1, Math.round(bytes / BYTES_PER_MEGABYTE)))
 }
 
 function relayByteBuffer(value: unknown): Buffer | null {
@@ -964,6 +1119,10 @@ function emitLocalSocketWithAck(socket: Socket, event: string, payload: unknown,
 
 function httpError(id: string | undefined, code: string, message: string, status?: number): AppRelayHttpResponse {
   return { id, ...(status ? { status } : {}), error: { code, message } }
+}
+
+function downloadError(id: string | undefined, code: string, message: string): AppRelayHttpDownloadResponse {
+  return { id, error: { code, message } }
 }
 
 function socketError(id: string | undefined, code: string, message: string): AppRelaySocketResponse {

--- a/packages/server/src/services/app-relay/client.ts
+++ b/packages/server/src/services/app-relay/client.ts
@@ -19,6 +19,7 @@ import {
 const APP_RELAY_NAMESPACE = '/app-relay'
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
 const MAX_REQUEST_TIMEOUT_MS = 120_000
+const MAX_MEDIA_REQUEST_TIMEOUT_MS = 5 * 60 * 1000
 const BYTES_PER_MEGABYTE = 1024 * 1024
 const DEFAULT_CLOUD_MEDIA_MAX_BYTES = 30 * BYTES_PER_MEGABYTE
 const MAX_CONTROL_REQUEST_BODY_BYTES = 20 * BYTES_PER_MEGABYTE
@@ -502,7 +503,7 @@ export class AppRelayClient {
     if (isHttpErrorResponse(normalizedBody)) return normalizedBody
     if (normalizedBody.contentType) headers.set('content-type', normalizedBody.contentType)
 
-    const timeoutMs = normalizeTimeout(request.timeoutMs)
+    const timeoutMs = normalizeHttpTimeout(request)
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), timeoutMs)
     try {
@@ -707,6 +708,16 @@ export class AppRelayClient {
       )
     } catch (error) {
       const code = error instanceof RelayDownloadSessionError ? error.code : 'download_failed'
+      logger.warn({
+        err: error,
+        errorCode: code,
+        downloadId: id,
+        machineId: this.options.machineId,
+        ...(error instanceof RelayDownloadSessionError ? error.diagnostic : {}),
+        ...(error instanceof RelayDownloadSessionError && error.causeMessage
+          ? { causeMessage: error.causeMessage }
+          : {}),
+      }, '[app-relay] cloud download chunk read failed')
       return code === 'download_too_large'
         ? { ...cloudMediaTooLarge(id, this.cloudMediaMaxBytes, 'download'), done: true }
         : downloadError(id, code, 'Unable to read the next download chunk')
@@ -1091,6 +1102,23 @@ function normalizeTimeout(value: unknown): number {
   const timeout = Number(value)
   if (!Number.isFinite(timeout) || timeout <= 0) return DEFAULT_REQUEST_TIMEOUT_MS
   return Math.min(Math.floor(timeout), MAX_REQUEST_TIMEOUT_MS)
+}
+
+function normalizeHttpTimeout(request: AppRelayHttpRequest): number {
+  const timeout = Number(request.timeoutMs)
+  if (!Number.isFinite(timeout) || timeout <= 0) return DEFAULT_REQUEST_TIMEOUT_MS
+  const maxTimeout = isMediaHttpRequest(request)
+    ? MAX_MEDIA_REQUEST_TIMEOUT_MS
+    : MAX_REQUEST_TIMEOUT_MS
+  return Math.min(Math.floor(timeout), maxTimeout)
+}
+
+function isMediaHttpRequest(request: AppRelayHttpRequest): boolean {
+  if (request.streamBinary === true || request.bodyBytes != null || request.bodyBase64 != null) return true
+  const path = String(request.path || '').split('?', 1)[0]
+  return path === '/api/hermes/app-uploads'
+    || path.startsWith('/api/hermes/app-uploads/')
+    || /^\/api\/hermes\/group-chat\/rooms\/[^/]+\/attachment-uploads(?:\/|$)/.test(path)
 }
 
 function isAllowedSocketEvent(namespace: string, event: string): boolean {

--- a/packages/server/src/services/app-relay/download-session.ts
+++ b/packages/server/src/services/app-relay/download-session.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from 'crypto'
+import { logger } from '../logger'
 
 export const RELAY_DOWNLOAD_CHUNK_BYTES = 256 * 1024
-const RELAY_DOWNLOAD_SESSION_TTL_MS = 2 * 60 * 1000
+const RELAY_DOWNLOAD_SESSION_TTL_MS = 5 * 60 * 1000
 
 export interface RelayDownloadDescriptor {
   id: string
@@ -26,14 +27,40 @@ interface RelayDownloadSession {
   sourceBytes: number
   receivedBytes: number
   totalBytes: number
+  attemptedChunks: number
+  completedChunks: number
+  createdAt: number
+  lastActivityAt: number
   busy: boolean
   timer: ReturnType<typeof setTimeout> | null
 }
 
+export interface RelayDownloadSessionDiagnostic {
+  downloadId: string
+  ownerId: string
+  sessionFound: boolean
+  receivedBytes: number
+  totalBytes: number
+  sourceBytes: number
+  sourceDone: boolean
+  attemptedChunks: number
+  completedChunks: number
+  busy: boolean
+  ageMs: number
+  idleMs: number
+}
+
 export class RelayDownloadSessionError extends Error {
-  constructor(public readonly code: string) {
+  readonly causeMessage: string
+
+  constructor(
+    public readonly code: string,
+    public readonly diagnostic: RelayDownloadSessionDiagnostic,
+    cause?: unknown,
+  ) {
     super(code)
     this.name = 'RelayDownloadSessionError'
+    this.causeMessage = cause instanceof Error ? cause.message : cause == null ? '' : String(cause)
   }
 }
 
@@ -41,8 +68,11 @@ export class RelayDownloadSessions {
   private readonly sessions = new Map<string, RelayDownloadSession>()
 
   create(ownerId: string, response: Response): RelayDownloadDescriptor {
-    if (!response.body) throw new RelayDownloadSessionError('download_body_missing')
+    if (!response.body) {
+      throw new RelayDownloadSessionError('download_body_missing', missingSessionDiagnostic(ownerId, ''))
+    }
     const id = randomUUID()
+    const now = Date.now()
     const session: RelayDownloadSession = {
       id,
       ownerId,
@@ -53,6 +83,10 @@ export class RelayDownloadSessions {
       sourceBytes: 0,
       receivedBytes: 0,
       totalBytes: declaredResponseBodyBytes(response),
+      attemptedChunks: 0,
+      completedChunks: 0,
+      createdAt: now,
+      lastActivityAt: now,
       busy: false,
       timer: null,
     }
@@ -68,13 +102,19 @@ export class RelayDownloadSessions {
     maxTotalBytes = Number.MAX_SAFE_INTEGER,
   ): Promise<RelayDownloadChunk> {
     const session = this.sessions.get(id)
-    if (!session || session.ownerId !== ownerId) throw new RelayDownloadSessionError('download_not_found')
-    if (session.busy) throw new RelayDownloadSessionError('download_busy')
+    if (!session || session.ownerId !== ownerId) {
+      throw new RelayDownloadSessionError('download_not_found', missingSessionDiagnostic(ownerId, id))
+    }
+    if (session.busy) {
+      throw new RelayDownloadSessionError('download_busy', sessionDiagnostic(session))
+    }
     if (session.totalBytes > maxTotalBytes || session.receivedBytes > maxTotalBytes) {
+      const diagnostic = sessionDiagnostic(session)
       this.cancel(ownerId, id)
-      throw new RelayDownloadSessionError('download_too_large')
+      throw new RelayDownloadSessionError('download_too_large', diagnostic)
     }
 
+    session.attemptedChunks += 1
     session.busy = true
     this.refreshExpiry(session)
     try {
@@ -99,7 +139,14 @@ export class RelayDownloadSessions {
           continue
         }
         if (session.sourceDone) break
-        const next = await session.reader.read()
+        let next: ReadableStreamReadResult<Uint8Array>
+        try {
+          next = await session.reader.read()
+        } catch (error) {
+          const diagnostic = sessionDiagnostic(session)
+          this.finish(session)
+          throw new RelayDownloadSessionError('download_source_read_failed', diagnostic, error)
+        }
         if (next.done) {
           session.sourceDone = true
           break
@@ -107,21 +154,36 @@ export class RelayDownloadSessions {
         if (!next.value?.byteLength) continue
         session.sourceBytes += next.value.byteLength
         if (session.sourceBytes > maxTotalBytes) {
+          const diagnostic = sessionDiagnostic(session)
           this.cancel(ownerId, id)
-          throw new RelayDownloadSessionError('download_too_large')
+          throw new RelayDownloadSessionError('download_too_large', diagnostic)
+        }
+        if (session.totalBytes > 0 && session.sourceBytes > session.totalBytes) {
+          const diagnostic = sessionDiagnostic(session)
+          this.cancel(ownerId, id)
+          throw new RelayDownloadSessionError('download_size_mismatch', diagnostic)
         }
         session.buffered = next.value
         session.bufferedOffset = 0
+        // Content-Length is authoritative for these authenticated local file
+        // responses. Once every declared byte has arrived, do not perform one
+        // extra reader.read() merely to observe EOF: some native/HTTP bridges
+        // report the closing stream as an error after delivering all bytes.
+        if (session.totalBytes > 0 && session.sourceBytes === session.totalBytes) {
+          session.sourceDone = true
+        }
       }
 
       session.receivedBytes += outputBytes
       const declaredComplete = session.totalBytes > 0 && session.receivedBytes >= session.totalBytes
       if (session.totalBytes > 0 && session.receivedBytes > session.totalBytes) {
+        const diagnostic = sessionDiagnostic(session)
         this.cancel(ownerId, id)
-        throw new RelayDownloadSessionError('download_size_mismatch')
+        throw new RelayDownloadSessionError('download_size_mismatch', diagnostic)
       }
       const done = declaredComplete || (session.sourceDone && !session.buffered)
       const bodyBytes = Uint8Array.from(Buffer.concat(output, outputBytes))
+      session.completedChunks += 1
       if (done) this.finish(session)
       return {
         id,
@@ -155,13 +217,17 @@ export class RelayDownloadSessions {
 
   private refreshExpiry(session: RelayDownloadSession): void {
     if (session.timer) clearTimeout(session.timer)
+    session.lastActivityAt = Date.now()
     session.timer = this.expiryTimer(session.id)
   }
 
   private expiryTimer(id: string): ReturnType<typeof setTimeout> {
     const timer = setTimeout(() => {
       const session = this.sessions.get(id)
-      if (session) this.finish(session)
+      if (session) {
+        logger.warn(sessionDiagnostic(session), '[app-relay] download session expired')
+        this.finish(session)
+      }
     }, RELAY_DOWNLOAD_SESSION_TTL_MS)
     timer.unref?.()
     return timer
@@ -171,6 +237,41 @@ export class RelayDownloadSessions {
     if (session.timer) clearTimeout(session.timer)
     this.sessions.delete(session.id)
     void session.reader.cancel().catch(() => undefined)
+  }
+}
+
+function sessionDiagnostic(session: RelayDownloadSession): RelayDownloadSessionDiagnostic {
+  const now = Date.now()
+  return {
+    downloadId: session.id,
+    ownerId: session.ownerId,
+    sessionFound: true,
+    receivedBytes: session.receivedBytes,
+    totalBytes: session.totalBytes,
+    sourceBytes: session.sourceBytes,
+    sourceDone: session.sourceDone,
+    attemptedChunks: session.attemptedChunks,
+    completedChunks: session.completedChunks,
+    busy: session.busy,
+    ageMs: Math.max(0, now - session.createdAt),
+    idleMs: Math.max(0, now - session.lastActivityAt),
+  }
+}
+
+function missingSessionDiagnostic(ownerId: string, id: string): RelayDownloadSessionDiagnostic {
+  return {
+    downloadId: id,
+    ownerId,
+    sessionFound: false,
+    receivedBytes: 0,
+    totalBytes: 0,
+    sourceBytes: 0,
+    sourceDone: false,
+    attemptedChunks: 0,
+    completedChunks: 0,
+    busy: false,
+    ageMs: 0,
+    idleMs: 0,
   }
 }
 

--- a/packages/server/src/services/app-relay/download-session.ts
+++ b/packages/server/src/services/app-relay/download-session.ts
@@ -1,0 +1,180 @@
+import { randomUUID } from 'crypto'
+
+export const RELAY_DOWNLOAD_CHUNK_BYTES = 256 * 1024
+const RELAY_DOWNLOAD_SESSION_TTL_MS = 2 * 60 * 1000
+
+export interface RelayDownloadDescriptor {
+  id: string
+  totalBytes: number
+}
+
+export interface RelayDownloadChunk {
+  id: string
+  bodyBytes: Uint8Array
+  receivedBytes: number
+  totalBytes: number
+  done: boolean
+}
+
+interface RelayDownloadSession {
+  id: string
+  ownerId: string
+  reader: ReadableStreamDefaultReader<Uint8Array>
+  buffered: Uint8Array | null
+  bufferedOffset: number
+  sourceDone: boolean
+  sourceBytes: number
+  receivedBytes: number
+  totalBytes: number
+  busy: boolean
+  timer: ReturnType<typeof setTimeout> | null
+}
+
+export class RelayDownloadSessionError extends Error {
+  constructor(public readonly code: string) {
+    super(code)
+    this.name = 'RelayDownloadSessionError'
+  }
+}
+
+export class RelayDownloadSessions {
+  private readonly sessions = new Map<string, RelayDownloadSession>()
+
+  create(ownerId: string, response: Response): RelayDownloadDescriptor {
+    if (!response.body) throw new RelayDownloadSessionError('download_body_missing')
+    const id = randomUUID()
+    const session: RelayDownloadSession = {
+      id,
+      ownerId,
+      reader: response.body.getReader(),
+      buffered: null,
+      bufferedOffset: 0,
+      sourceDone: false,
+      sourceBytes: 0,
+      receivedBytes: 0,
+      totalBytes: declaredResponseBodyBytes(response),
+      busy: false,
+      timer: null,
+    }
+    session.timer = this.expiryTimer(id)
+    this.sessions.set(id, session)
+    return { id, totalBytes: session.totalBytes }
+  }
+
+  async read(
+    ownerId: string,
+    id: string,
+    maxChunkBytes = RELAY_DOWNLOAD_CHUNK_BYTES,
+    maxTotalBytes = Number.MAX_SAFE_INTEGER,
+  ): Promise<RelayDownloadChunk> {
+    const session = this.sessions.get(id)
+    if (!session || session.ownerId !== ownerId) throw new RelayDownloadSessionError('download_not_found')
+    if (session.busy) throw new RelayDownloadSessionError('download_busy')
+    if (session.totalBytes > maxTotalBytes || session.receivedBytes > maxTotalBytes) {
+      this.cancel(ownerId, id)
+      throw new RelayDownloadSessionError('download_too_large')
+    }
+
+    session.busy = true
+    this.refreshExpiry(session)
+    try {
+      const chunkLimit = Math.max(1, Math.min(RELAY_DOWNLOAD_CHUNK_BYTES, Math.floor(maxChunkBytes)))
+      const output: Buffer[] = []
+      let outputBytes = 0
+      while (outputBytes < chunkLimit) {
+        if (session.buffered && session.bufferedOffset < session.buffered.byteLength) {
+          const remaining = chunkLimit - outputBytes
+          const take = Math.min(remaining, session.buffered.byteLength - session.bufferedOffset)
+          output.push(Buffer.from(
+            session.buffered.buffer,
+            session.buffered.byteOffset + session.bufferedOffset,
+            take,
+          ))
+          session.bufferedOffset += take
+          outputBytes += take
+          if (session.bufferedOffset >= session.buffered.byteLength) {
+            session.buffered = null
+            session.bufferedOffset = 0
+          }
+          continue
+        }
+        if (session.sourceDone) break
+        const next = await session.reader.read()
+        if (next.done) {
+          session.sourceDone = true
+          break
+        }
+        if (!next.value?.byteLength) continue
+        session.sourceBytes += next.value.byteLength
+        if (session.sourceBytes > maxTotalBytes) {
+          this.cancel(ownerId, id)
+          throw new RelayDownloadSessionError('download_too_large')
+        }
+        session.buffered = next.value
+        session.bufferedOffset = 0
+      }
+
+      session.receivedBytes += outputBytes
+      const declaredComplete = session.totalBytes > 0 && session.receivedBytes >= session.totalBytes
+      if (session.totalBytes > 0 && session.receivedBytes > session.totalBytes) {
+        this.cancel(ownerId, id)
+        throw new RelayDownloadSessionError('download_size_mismatch')
+      }
+      const done = declaredComplete || (session.sourceDone && !session.buffered)
+      const bodyBytes = Uint8Array.from(Buffer.concat(output, outputBytes))
+      if (done) this.finish(session)
+      return {
+        id,
+        bodyBytes,
+        receivedBytes: session.receivedBytes,
+        totalBytes: session.totalBytes,
+        done,
+      }
+    } finally {
+      const current = this.sessions.get(id)
+      if (current) current.busy = false
+    }
+  }
+
+  cancel(ownerId: string, id: string): boolean {
+    const session = this.sessions.get(id)
+    if (!session || session.ownerId !== ownerId) return false
+    this.finish(session)
+    return true
+  }
+
+  cancelOwner(ownerId: string): void {
+    for (const session of Array.from(this.sessions.values())) {
+      if (session.ownerId === ownerId) this.finish(session)
+    }
+  }
+
+  cancelAll(): void {
+    for (const session of Array.from(this.sessions.values())) this.finish(session)
+  }
+
+  private refreshExpiry(session: RelayDownloadSession): void {
+    if (session.timer) clearTimeout(session.timer)
+    session.timer = this.expiryTimer(session.id)
+  }
+
+  private expiryTimer(id: string): ReturnType<typeof setTimeout> {
+    const timer = setTimeout(() => {
+      const session = this.sessions.get(id)
+      if (session) this.finish(session)
+    }, RELAY_DOWNLOAD_SESSION_TTL_MS)
+    timer.unref?.()
+    return timer
+  }
+
+  private finish(session: RelayDownloadSession): void {
+    if (session.timer) clearTimeout(session.timer)
+    this.sessions.delete(session.id)
+    void session.reader.cancel().catch(() => undefined)
+  }
+}
+
+function declaredResponseBodyBytes(response: Response): number {
+  const value = Number(response.headers.get('content-length'))
+  return Number.isSafeInteger(value) && value >= 0 ? value : 0
+}

--- a/packages/server/src/services/app-relay/server.ts
+++ b/packages/server/src/services/app-relay/server.ts
@@ -13,12 +13,19 @@ import {
 } from '../app-entitlement'
 import type {
   AppRelayHttpRequest,
+  AppRelayHttpDownloadRequest,
+  AppRelayHttpDownloadResponse,
   AppRelayHttpResponse,
   AppRelaySocketCloseRequest,
   AppRelaySocketEventRequest,
   AppRelaySocketOpenRequest,
   AppRelaySocketResponse,
 } from './client'
+import {
+  RELAY_DOWNLOAD_CHUNK_BYTES,
+  RelayDownloadSessionError,
+  RelayDownloadSessions,
+} from './download-session'
 
 const APP_RELAY_NAMESPACE = '/app-relay'
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
@@ -130,6 +137,7 @@ export class LocalAppRelayServer {
   private readonly namespace: ReturnType<SocketIoServer['of']>
   private readonly bridges = new Map<string, LocalSocketBridge>()
   private readonly appSockets = new Map<string, Socket>()
+  private readonly downloadSessions = new RelayDownloadSessions()
   private readonly localBaseUrl: string
   private readonly fetchImpl: typeof fetch
   private readonly configuredMachineId: string
@@ -295,13 +303,27 @@ export class LocalAppRelayServer {
       role: 'app',
       machineId,
       hostConnected: true,
-      capabilities: ['http.request', 'socket.chat-run', 'socket.group-chat', 'socket.workflow', 'app.entitlement'],
+      capabilities: ['http.request', 'http.download.chunked', 'socket.chat-run', 'socket.group-chat', 'socket.workflow', 'app.entitlement'],
     })
     if (socket.data.localUserToken) this.scheduleTokenExpiry(socket)
     if (socket.data.appEntitlement) this.scheduleEntitlementExpiry(socket)
 
     socket.on('http.request', (request: AppRelayHttpRequest = {}, ack?: (response: AppRelayHttpResponse) => void) => {
       void this.handleHttpRequest(socket, request).then(response => ack?.(response))
+    })
+    socket.on('http.download.chunk', (
+      request: AppRelayHttpDownloadRequest = {},
+      ack?: (response: AppRelayHttpDownloadResponse) => void,
+    ) => {
+      void this.readHttpDownloadChunk(socket, request).then(response => ack?.(response))
+    })
+    socket.on('http.download.cancel', (
+      request: AppRelayHttpDownloadRequest = {},
+      ack?: (response: AppRelayHttpDownloadResponse) => void,
+    ) => {
+      const id = normalizeBridgeId(request.id)
+      const cancelled = id ? this.downloadSessions.cancel(socket.id, id) : false
+      ack?.(cancelled ? { id, done: true } : downloadError(request.id, 'download_not_found', 'Download session was not found'))
     })
     socket.on('socket.open', (request: AppRelaySocketOpenRequest = {}, ack?: (response: AppRelaySocketResponse) => void) => {
       void this.openSocket(socket, request).then(response => ack?.(response))
@@ -314,6 +336,7 @@ export class LocalAppRelayServer {
     })
     socket.on('disconnect', () => {
       this.appSockets.delete(socket.id)
+      this.downloadSessions.cancelOwner(socket.id)
       this.closeOwnerBridges(socket.id)
     })
   }
@@ -360,6 +383,19 @@ export class LocalAppRelayServer {
         body: normalizedBody.body,
         signal: controller.signal,
       })
+      if (
+        request.streamBinary === true
+        && !isTextualResponse(response)
+        && response.ok
+        && response.body
+      ) {
+        return {
+          id: request.id,
+          status: response.status,
+          headers: responseHeaders(response),
+          download: this.downloadSessions.create(socket.id, response),
+        }
+      }
       const responseBody = await readResponseBody(response)
       if (loginRequest && response.ok && typeof responseBody.body === 'string') {
         await this.promoteLogin(socket, responseBody.body)
@@ -380,6 +416,27 @@ export class LocalAppRelayServer {
       )
     } finally {
       clearTimeout(timer)
+    }
+  }
+
+  private async readHttpDownloadChunk(
+    socket: Socket,
+    request: AppRelayHttpDownloadRequest,
+  ): Promise<AppRelayHttpDownloadResponse> {
+    if (!await this.authorized(socket)) {
+      return downloadError(request.id, 'app_relay_unauthorized', 'The App relay session is no longer authorized', 401)
+    }
+    const id = normalizeBridgeId(request.id)
+    if (!id) return downloadError(request.id, 'invalid_download_id', 'Download session id is required')
+    try {
+      return await this.downloadSessions.read(
+        socket.id,
+        id,
+        Number(request.maxBytes) || RELAY_DOWNLOAD_CHUNK_BYTES,
+      )
+    } catch (error) {
+      const code = error instanceof RelayDownloadSessionError ? error.code : 'download_failed'
+      return downloadError(id, code, 'Unable to read the next download chunk')
     }
   }
 
@@ -840,13 +897,16 @@ async function readResponseBody(
     total += chunk.byteLength
   }
   const buffer = Buffer.concat(chunks)
-  const contentType = response.headers.get('content-type') || ''
-  const textual = TEXTUAL_RESPONSE_TYPES.some(prefix => (
-    contentType.toLowerCase().startsWith(prefix) || contentType.toLowerCase().includes(prefix)
-  ))
+  const textual = isTextualResponse(response)
   return textual
     ? { body: buffer.toString('utf8'), truncated }
     : { bodyBytes: buffer, truncated }
+}
+
+function isTextualResponse(response: Response): boolean {
+  if ((response.headers.get('content-disposition') || '').toLowerCase().includes('attachment')) return false
+  const contentType = (response.headers.get('content-type') || '').toLowerCase()
+  return TEXTUAL_RESPONSE_TYPES.some(prefix => contentType.startsWith(prefix) || contentType.includes(prefix))
 }
 
 function relayByteBuffer(value: unknown): Buffer | null {
@@ -913,6 +973,15 @@ function httpError(
   message: string,
   status?: number,
 ): AppRelayHttpResponse {
+  return { id, ...(status ? { status } : {}), error: { code, message } }
+}
+
+function downloadError(
+  id: string | undefined,
+  code: string,
+  message: string,
+  status?: number,
+): AppRelayHttpDownloadResponse {
   return { id, ...(status ? { status } : {}), error: { code, message } }
 }
 

--- a/packages/server/src/services/app-relay/server.ts
+++ b/packages/server/src/services/app-relay/server.ts
@@ -30,6 +30,7 @@ import {
 const APP_RELAY_NAMESPACE = '/app-relay'
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
 const MAX_REQUEST_TIMEOUT_MS = 120_000
+const MAX_MEDIA_REQUEST_TIMEOUT_MS = 5 * 60 * 1000
 const MAX_REQUEST_BODY_BYTES = 20 * 1024 * 1024
 const MAX_RESPONSE_BODY_BYTES = 20 * 1024 * 1024
 
@@ -373,7 +374,7 @@ export class LocalAppRelayServer {
     if (isHttpErrorResponse(normalizedBody)) return normalizedBody
     if (normalizedBody.contentType) headers.set('content-type', normalizedBody.contentType)
 
-    const timeoutMs = normalizeTimeout(request.timeoutMs)
+    const timeoutMs = normalizeHttpTimeout(request)
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), timeoutMs)
     try {
@@ -436,6 +437,15 @@ export class LocalAppRelayServer {
       )
     } catch (error) {
       const code = error instanceof RelayDownloadSessionError ? error.code : 'download_failed'
+      logger.warn({
+        err: error,
+        errorCode: code,
+        downloadId: id,
+        ...(error instanceof RelayDownloadSessionError ? error.diagnostic : {}),
+        ...(error instanceof RelayDownloadSessionError && error.causeMessage
+          ? { causeMessage: error.causeMessage }
+          : {}),
+      }, '[app-relay:lan] download chunk read failed')
       return downloadError(id, code, 'Unable to read the next download chunk')
     }
   }
@@ -937,6 +947,23 @@ function normalizeTimeout(value: unknown): number {
   const timeout = Number(value)
   if (!Number.isFinite(timeout) || timeout <= 0) return DEFAULT_REQUEST_TIMEOUT_MS
   return Math.min(Math.floor(timeout), MAX_REQUEST_TIMEOUT_MS)
+}
+
+function normalizeHttpTimeout(request: AppRelayHttpRequest): number {
+  const timeout = Number(request.timeoutMs)
+  if (!Number.isFinite(timeout) || timeout <= 0) return DEFAULT_REQUEST_TIMEOUT_MS
+  const maxTimeout = isMediaHttpRequest(request)
+    ? MAX_MEDIA_REQUEST_TIMEOUT_MS
+    : MAX_REQUEST_TIMEOUT_MS
+  return Math.min(Math.floor(timeout), maxTimeout)
+}
+
+function isMediaHttpRequest(request: AppRelayHttpRequest): boolean {
+  if (request.streamBinary === true || request.bodyBytes != null || request.bodyBase64 != null) return true
+  const path = String(request.path || '').split('?', 1)[0]
+  return path === '/api/hermes/app-uploads'
+    || path.startsWith('/api/hermes/app-uploads/')
+    || /^\/api\/hermes\/group-chat\/rooms\/[^/]+\/attachment-uploads(?:\/|$)/.test(path)
 }
 
 function isAllowedSocketEvent(namespace: string, event: string): boolean {

--- a/packages/server/src/services/hermes/app-upload.ts
+++ b/packages/server/src/services/hermes/app-upload.ts
@@ -5,7 +5,7 @@ import { getProfileUploadDir } from './upload-paths'
 
 export const APP_UPLOAD_MAX_BYTES = 50 * 1024 * 1024
 export const APP_UPLOAD_CHUNK_BYTES = 256 * 1024
-const APP_UPLOAD_SESSION_TTL_MS = 10 * 60 * 1000
+const APP_UPLOAD_SESSION_TTL_MS = 5 * 60 * 1000
 const UPLOAD_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/
 
 interface AppUploadSession {

--- a/packages/server/src/services/hermes/group-chat/chunked-upload.ts
+++ b/packages/server/src/services/hermes/group-chat/chunked-upload.ts
@@ -13,7 +13,7 @@ import {
 } from './attachments'
 
 export const GROUP_CHAT_UPLOAD_CHUNK_BYTES = 256 * 1024
-const GROUP_CHAT_UPLOAD_SESSION_TTL_MS = 10 * 60 * 1000
+const GROUP_CHAT_UPLOAD_SESSION_TTL_MS = 5 * 60 * 1000
 const UPLOAD_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/
 
 interface GroupChatUploadSession {

--- a/packages/server/src/services/hermes/group-chat/chunked-upload.ts
+++ b/packages/server/src/services/hermes/group-chat/chunked-upload.ts
@@ -1,0 +1,243 @@
+import { randomBytes } from 'node:crypto'
+import { constants as fsConstants } from 'node:fs'
+import { appendFile, chmod, copyFile, mkdir, rm, stat, writeFile } from 'node:fs/promises'
+import { basename, extname, resolve } from 'node:path'
+import { config } from '../../../config'
+import {
+    getGroupChatAttachmentBytes,
+    getGroupChatAttachmentDir,
+    getGroupChatAttachmentPath,
+    MAX_GROUP_CHAT_ATTACHMENT_SIZE,
+    MAX_GROUP_CHAT_ROOM_ATTACHMENT_BYTES,
+    withGroupChatAttachmentWriteLock,
+} from './attachments'
+
+export const GROUP_CHAT_UPLOAD_CHUNK_BYTES = 256 * 1024
+const GROUP_CHAT_UPLOAD_SESSION_TTL_MS = 10 * 60 * 1000
+const UPLOAD_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/
+
+interface GroupChatUploadSession {
+    id: string
+    owner: string
+    roomId: string
+    name: string
+    size: number
+    receivedBytes: number
+    partPath: string
+    timer: ReturnType<typeof setTimeout>
+    writing: boolean
+}
+
+export class GroupChatUploadError extends Error {
+    readonly code: string
+    readonly status: number
+
+    constructor(code: string, message: string, status = 400) {
+        super(message)
+        this.name = 'GroupChatUploadError'
+        this.code = code
+        this.status = status
+    }
+}
+
+const sessions = new Map<string, GroupChatUploadSession>()
+
+export async function openGroupChatUpload(input: {
+    id: unknown
+    owner: string
+    roomId: string
+    name: unknown
+    size: unknown
+}): Promise<{ id: string; nextOffset: number; maxChunkBytes: number }> {
+    const id = String(input.id || '').trim()
+    if (!UPLOAD_ID_PATTERN.test(id)) throw new GroupChatUploadError('invalid_upload_id', 'Invalid upload id')
+    if (sessions.has(id)) throw new GroupChatUploadError('upload_exists', 'Upload id is already active', 409)
+    const name = safeDisplayName(input.name)
+    const size = Number(input.size)
+    if (!Number.isSafeInteger(size) || size <= 0) {
+        throw new GroupChatUploadError('invalid_upload_size', 'Invalid upload size')
+    }
+    if (size > MAX_GROUP_CHAT_ATTACHMENT_SIZE) {
+        throw new GroupChatUploadError('upload_too_large', 'Group chat attachment is too large (max 20MB)', 413)
+    }
+
+    const existingBytes = await getGroupChatAttachmentBytes(input.roomId)
+    if (existingBytes + size > MAX_GROUP_CHAT_ROOM_ATTACHMENT_BYTES) {
+        throw new GroupChatUploadError(
+            'attachment_quota_exceeded',
+            'Group chat attachment storage quota exceeded',
+            413,
+        )
+    }
+
+    const stagingDir = resolve(config.appHome, 'group-chat', 'upload-sessions')
+    await mkdir(stagingDir, { recursive: true, mode: 0o700 })
+    const partPath = resolve(stagingDir, `${randomBytes(16).toString('hex')}.part`)
+    await writeFile(partPath, new Uint8Array(), { flag: 'wx', mode: 0o600 })
+    const session: GroupChatUploadSession = {
+        id,
+        owner: input.owner,
+        roomId: input.roomId,
+        name,
+        size,
+        receivedBytes: 0,
+        partPath,
+        timer: setTimeout(() => undefined, 1),
+        writing: false,
+    }
+    clearTimeout(session.timer)
+    session.timer = expiryTimer(session)
+    sessions.set(id, session)
+    return { id, nextOffset: 0, maxChunkBytes: GROUP_CHAT_UPLOAD_CHUNK_BYTES }
+}
+
+export async function appendGroupChatUploadChunk(input: {
+    id: unknown
+    owner: string
+    roomId: string
+    offset: unknown
+    bytes: Uint8Array
+}): Promise<{ id: string; nextOffset: number; done: boolean }> {
+    const session = ownedSession(input.id, input.owner, input.roomId)
+    const offset = Number(input.offset)
+    if (!Number.isSafeInteger(offset) || offset !== session.receivedBytes) {
+        throw new GroupChatUploadError('invalid_upload_offset', `Expected upload offset ${session.receivedBytes}`, 409)
+    }
+    if (!(input.bytes instanceof Uint8Array) || input.bytes.byteLength === 0) {
+        throw new GroupChatUploadError('invalid_upload_chunk', 'Upload chunk is empty')
+    }
+    if (input.bytes.byteLength > GROUP_CHAT_UPLOAD_CHUNK_BYTES) {
+        throw new GroupChatUploadError(
+            'upload_chunk_too_large',
+            `Upload chunks are limited to ${GROUP_CHAT_UPLOAD_CHUNK_BYTES} bytes`,
+            413,
+        )
+    }
+    if (session.receivedBytes + input.bytes.byteLength > session.size) {
+        throw new GroupChatUploadError('upload_size_mismatch', 'Upload exceeds its declared size', 409)
+    }
+    if (session.writing) throw new GroupChatUploadError('upload_busy', 'Another upload chunk is still being written', 409)
+
+    session.writing = true
+    try {
+        await appendFile(session.partPath, input.bytes)
+        session.receivedBytes += input.bytes.byteLength
+        refreshExpiry(session)
+        return {
+            id: session.id,
+            nextOffset: session.receivedBytes,
+            done: session.receivedBytes === session.size,
+        }
+    } finally {
+        session.writing = false
+    }
+}
+
+export async function completeGroupChatUpload(input: {
+    id: unknown
+    owner: string
+    roomId: string
+}): Promise<{ name: string; path: string }> {
+    const session = ownedSession(input.id, input.owner, input.roomId)
+    if (session.writing) throw new GroupChatUploadError('upload_busy', 'An upload chunk is still being written', 409)
+    if (session.receivedBytes !== session.size) {
+        throw new GroupChatUploadError(
+            'upload_incomplete',
+            `Upload is incomplete (${session.receivedBytes}/${session.size})`,
+            409,
+        )
+    }
+    const info = await stat(session.partPath)
+    if (!info.isFile() || info.size !== session.size) {
+        await discardSession(session)
+        throw new GroupChatUploadError('upload_size_mismatch', 'Stored upload size does not match the declaration', 409)
+    }
+
+    return withGroupChatAttachmentWriteLock(session.roomId, async () => {
+        const existingBytes = await getGroupChatAttachmentBytes(session.roomId)
+        if (existingBytes + session.size > MAX_GROUP_CHAT_ROOM_ATTACHMENT_BYTES) {
+            await discardSession(session)
+            throw new GroupChatUploadError(
+                'attachment_quota_exceeded',
+                'Group chat attachment storage quota exceeded',
+                413,
+            )
+        }
+
+        const uploadDir = getGroupChatAttachmentDir(session.roomId)
+        await mkdir(uploadDir, { recursive: true, mode: 0o700 })
+        const extension = safeUploadExtension(session.name)
+        for (let attempt = 0; attempt < 3; attempt += 1) {
+            const storedName = `${randomBytes(16).toString('hex')}${extension}`
+            const savedPath = getGroupChatAttachmentPath(session.roomId, storedName)
+            if (!savedPath) continue
+            try {
+                await copyFile(session.partPath, savedPath, fsConstants.COPYFILE_EXCL)
+                await chmod(savedPath, 0o600)
+                await rm(session.partPath, { force: true })
+                forgetSession(session)
+                return { name: session.name, path: storedName }
+            } catch (error: any) {
+                if (error?.code === 'EEXIST' && attempt < 2) continue
+                await rm(savedPath, { force: true }).catch(() => undefined)
+                throw error
+            }
+        }
+        throw new GroupChatUploadError('upload_store_failed', 'Failed to store group chat attachment', 500)
+    })
+}
+
+export async function abortGroupChatUpload(input: {
+    id: unknown
+    owner: string
+    roomId: string
+}): Promise<void> {
+    await discardSession(ownedSession(input.id, input.owner, input.roomId))
+}
+
+function ownedSession(idInput: unknown, owner: string, roomId: string): GroupChatUploadSession {
+    const id = String(idInput || '').trim()
+    const session = sessions.get(id)
+    if (!session) throw new GroupChatUploadError('upload_not_found', 'Upload session was not found', 404)
+    if (session.owner !== owner || session.roomId !== roomId) {
+        throw new GroupChatUploadError('upload_forbidden', 'Upload session does not belong to this room member', 403)
+    }
+    return session
+}
+
+function safeDisplayName(value: unknown): string {
+    const name = basename(String(value || '').replace(/\0/g, '')).trim().slice(0, 255)
+    if (!name || name === '.' || name === '..') {
+        throw new GroupChatUploadError('invalid_upload_name', 'Invalid upload name')
+    }
+    return name
+}
+
+function safeUploadExtension(name: string): string {
+    const extension = extname(name).toLowerCase()
+    return /^\.[a-z0-9]{1,12}$/.test(extension) ? extension : ''
+}
+
+function refreshExpiry(session: GroupChatUploadSession): void {
+    clearTimeout(session.timer)
+    session.timer = expiryTimer(session)
+}
+
+function expiryTimer(session: GroupChatUploadSession): ReturnType<typeof setTimeout> {
+    const timer = setTimeout(() => {
+        if (sessions.get(session.id) !== session) return
+        void discardSession(session)
+    }, GROUP_CHAT_UPLOAD_SESSION_TTL_MS)
+    timer.unref()
+    return timer
+}
+
+function forgetSession(session: GroupChatUploadSession): void {
+    clearTimeout(session.timer)
+    if (sessions.get(session.id) === session) sessions.delete(session.id)
+}
+
+async function discardSession(session: GroupChatUploadSession): Promise<void> {
+    forgetSession(session)
+    await rm(session.partPath, { force: true }).catch(() => undefined)
+}

--- a/packages/server/src/services/hermes/run-chat/content-blocks.ts
+++ b/packages/server/src/services/hermes/run-chat/content-blocks.ts
@@ -32,7 +32,10 @@ export function convertContentBlocksForCodingAgent(input: string | ContentBlock[
       continue
     }
     if (block.type === 'image') {
-      textParts.push(`[Attached image: ${block.name || block.path}]\nLocal image path for tools: ${block.path}`)
+      const label = block.video_frame
+        ? `Representative frame extracted from the attached video: ${block.name || block.path}`
+        : `Attached image: ${block.name || block.path}`
+      textParts.push(`[${label}]\nLocal image path for tools: ${block.path}`)
       images.push({
         name: block.name || block.path,
         path: block.path,
@@ -78,6 +81,12 @@ export async function convertContentBlocks(blocks: ContentBlock[]): Promise<Resp
     } else if (block.type === 'image') {
       const dataUri = await imageBlockToDataUri(block)
       if (dataUri) {
+        if (block.video_frame) {
+          parts.push({
+            type: 'input_text',
+            text: `[Representative frame extracted from the attached video: ${block.name || block.path}]`,
+          })
+        }
         parts.push({ type: 'input_image', image_url: dataUri })
       } else {
         parts.push({ type: 'input_text', text: `[Image: ${block.path}]` })
@@ -100,9 +109,12 @@ export async function convertContentBlocksForAgent(blocks: ContentBlock[]): Prom
     if (block.type === 'text') {
       parts.push({ type: 'text', text: block.text || '' })
     } else if (block.type === 'image') {
+      const label = block.video_frame
+        ? `Representative frame extracted from the attached video: ${block.name || block.path}`
+        : `Attached image: ${block.name || block.path}`
       parts.push({
         type: 'text',
-        text: `[Attached image: ${block.name || block.path}]\nLocal image path for tools: ${block.path}`,
+        text: `[${label}]\nLocal image path for tools: ${block.path}`,
       })
       const dataUri = await imageBlockToDataUri(block)
       if (dataUri) {

--- a/packages/server/src/services/hermes/run-chat/types.ts
+++ b/packages/server/src/services/hermes/run-chat/types.ts
@@ -25,7 +25,7 @@ export type BackgroundContinuationContext =
  */
 export type ContentBlock =
   | { type: 'text'; text: string }
-  | { type: 'image'; name: string; path: string; media_type: string; context?: string }
+  | { type: 'image'; name: string; path: string; media_type: string; context?: string; video_frame?: boolean }
   | { type: 'file'; name: string; path: string; media_type?: string; context?: string }
 
 export interface SessionMessage {

--- a/packages/server/src/services/workflow-manager.ts
+++ b/packages/server/src/services/workflow-manager.ts
@@ -845,12 +845,24 @@ export function compileWorkflowGraphPreflight(
   return { nodes, edges, loops, startNodeIds }
 }
 
-function imageMediaType(path: string): string {
-  const lower = path.toLowerCase()
-  if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg'
-  if (lower.endsWith('.gif')) return 'image/gif'
-  if (lower.endsWith('.webp')) return 'image/webp'
-  return 'image/png'
+function workflowAttachmentBlock(path: string): ContentBlock {
+  const name = path.split(/[\\/]/).pop() || path
+  const extension = name.split('.').pop()?.toLowerCase() || ''
+  const mediaTypes: Record<string, string> = {
+    png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif', webp: 'image/webp',
+    pdf: 'application/pdf', json: 'application/json', txt: 'text/plain', md: 'text/markdown',
+    csv: 'text/csv', zip: 'application/zip', doc: 'application/msword',
+    docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    xls: 'application/vnd.ms-excel',
+    xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    ppt: 'application/vnd.ms-powerpoint',
+    pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    mp4: 'video/mp4', mov: 'video/quicktime', m4v: 'video/x-m4v', webm: 'video/webm',
+  }
+  const mediaType = mediaTypes[extension] || 'application/octet-stream'
+  return mediaType.startsWith('image/')
+    ? { type: 'image', name, path, media_type: mediaType }
+    : { type: 'file', name, path, media_type: mediaType }
 }
 
 function lastAssistantOutput(sessionId: string, fallback?: string | null): string {
@@ -2415,12 +2427,7 @@ export class WorkflowManager extends EventEmitter<WorkflowManagerEvents> {
     if (args.node.data.images.length === 0) return text
     return [
       { type: 'text', text },
-      ...args.node.data.images.map(path => ({
-        type: 'image' as const,
-        name: path.split(/[\\/]/).pop() || path,
-        path,
-        media_type: imageMediaType(path),
-      })),
+      ...args.node.data.images.map(workflowAttachmentBlock),
     ]
   }
 }

--- a/tests/client/browser-attachment-content.test.ts
+++ b/tests/client/browser-attachment-content.test.ts
@@ -24,6 +24,27 @@ describe('browser selection attachment context', () => {
     })
   })
 
+  it('marks derived video frames so they stay out of the visible attachment list', async () => {
+    const frame: Attachment = {
+      id: 'video-frame-1',
+      name: 'demo-video-frame-01.jpg',
+      type: 'image/jpeg',
+      size: 5,
+      url: 'blob:video-frame',
+      file: new File(['frame'], 'demo-video-frame-01.jpg', { type: 'image/jpeg' }),
+      videoFrameFor: 'video-1',
+    }
+
+    await expect(buildContentBlocks('', [frame], [{ name: frame.name, path: '/tmp/frame.jpg' }]))
+      .resolves.toEqual([{
+        type: 'image',
+        name: frame.name,
+        path: '/tmp/frame.jpg',
+        media_type: 'image/jpeg',
+        video_frame: true,
+      }])
+  })
+
   it('keeps expandable metadata on display input but omits the hidden model text block', async () => {
     const blocks = await buildContentBlocks('Make this clearer', [attachment], uploaded, false)
 

--- a/tests/client/chat-input-draft.test.ts
+++ b/tests/client/chat-input-draft.test.ts
@@ -11,6 +11,7 @@ const fetchSkillsMock = vi.hoisted(() => vi.fn())
 const fetchSkillBundlesMock = vi.hoisted(() => vi.fn())
 const deleteSkillBundleApiMock = vi.hoisted(() => vi.fn())
 const dialogWarningMock = vi.hoisted(() => vi.fn())
+const extractRepresentativeVideoFramesMock = vi.hoisted(() => vi.fn())
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({ t: (key: string) => key }),
@@ -76,6 +77,14 @@ vi.mock('@/composables/useToolTraceVisibility', () => ({
   useToolTraceVisibility: () => ({ toolTraceVisible: { value: true }, toggleToolTraceVisible: vi.fn() }),
 }))
 
+vi.mock('@/utils/video-frame-extraction', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/utils/video-frame-extraction')>()
+  return {
+    ...original,
+    extractRepresentativeVideoFrames: extractRepresentativeVideoFramesMock,
+  }
+})
+
 function mountForSession(
   sessionId: string,
   sessionOverrides: Partial<ReturnType<typeof useChatStore>['sessions'][number]> = {},
@@ -104,6 +113,8 @@ describe('ChatInput draft persistence', () => {
     deleteSkillBundleApiMock.mockReset()
     deleteSkillBundleApiMock.mockResolvedValue(undefined)
     dialogWarningMock.mockReset()
+    extractRepresentativeVideoFramesMock.mockReset()
+    extractRepresentativeVideoFramesMock.mockResolvedValue([])
     Object.defineProperty(URL, 'createObjectURL', {
       configurable: true,
       value: vi.fn(() => 'blob:chat-attachment'),
@@ -130,6 +141,40 @@ describe('ChatInput draft persistence', () => {
 
     expect(paste.defaultPrevented).toBe(true)
     expect(wrapper.get('.attachment-file').text()).toContain('notes.txt')
+  })
+
+  it('sends extracted video frames to the model without showing them as separate attachments', async () => {
+    const wrapper = mountForSession('session-video')
+    const chatStore = useChatStore()
+    const sendMessage = vi.spyOn(chatStore, 'sendMessage').mockResolvedValue(undefined)
+    const video = new File(['video'], 'demo.mp4', { type: 'video/mp4' })
+    const frame = new File(['frame'], 'demo-video-frame-01.jpg', { type: 'image/jpeg' })
+    let resolveFrames!: (frames: File[]) => void
+    extractRepresentativeVideoFramesMock.mockReturnValue(new Promise<File[]>((resolve) => {
+      resolveFrames = resolve
+    }))
+    const input = wrapper.get('input[type="file"]')
+    Object.defineProperty(input.element, 'files', { configurable: true, value: [video] })
+
+    await input.trigger('change')
+    await nextTick()
+
+    expect(wrapper.findAll('.attachment-preview')).toHaveLength(1)
+    expect(wrapper.get('.attachment-preview').text()).toContain('demo.mp4')
+
+    await wrapper.get('.send-button').trigger('click')
+    expect(sendMessage).not.toHaveBeenCalled()
+    resolveFrames([frame])
+    await flushPromises()
+
+    expect(sendMessage).toHaveBeenCalledWith('', [
+      expect.objectContaining({ name: 'demo.mp4', type: 'video/mp4' }),
+      expect.objectContaining({
+        name: 'demo-video-frame-01.jpg',
+        type: 'image/jpeg',
+        videoFrameFor: expect.any(String),
+      }),
+    ])
   })
 
   it('restores unsent text for the active session after the chat view is remounted', async () => {

--- a/tests/client/file-preview-formats.test.ts
+++ b/tests/client/file-preview-formats.test.ts
@@ -64,11 +64,15 @@ describe('generated file preview formats', () => {
     expect(getFilePreviewKind('deck.pptx')).toBe('presentation')
     expect(getFilePreviewKind('metrics.xlsx')).toBe('spreadsheet')
     expect(getFilePreviewKind('metrics.csv')).toBe('csv')
+    expect(getFilePreviewKind('recording.mp4')).toBe('video')
+    expect(getFilePreviewKind('recording.MOV')).toBe('video')
     expect(getFilePreviewKind('legacy.xls')).toBeNull()
     expect(previewMimeMatches('pdf', 'application/pdf')).toBe(true)
     expect(previewMimeMatches('pdf', 'text/html')).toBe(false)
     expect(previewMimeMatches('presentation', 'application/vnd.openxmlformats-officedocument.presentationml.presentation')).toBe(true)
     expect(previewMimeMatches('csv', 'text/csv; charset=utf-8')).toBe(true)
+    expect(previewMimeMatches('video', 'video/mp4')).toBe(true)
+    expect(previewMimeMatches('video', 'application/octet-stream')).toBe(false)
   })
 
   it('renders HTML in a restrictive iframe and strips active content and URLs', async () => {
@@ -114,6 +118,15 @@ describe('generated file preview formats', () => {
     expect(htmlPreviewSource).not.toContain('min-height: 420px')
     expect(filePreviewSource).toMatch(/\.file-preview\s*\{[\s\S]*height: 100%;[\s\S]*width: 100%;[\s\S]*min-height: 0;/)
     expect(filePreviewSource).toMatch(/\.preview-content\s*\{[\s\S]*width: 100%;[\s\S]*height: 100%;[\s\S]*min-height: 0;/)
+    expect(filePreviewSource).toMatch(/<video[\s\S]*class="preview-video"[\s\S]*controls/)
+  })
+
+  it('renders only user video attachments inline in single chat', () => {
+    const messageItemSource = readFileSync('packages/client/src/components/hermes/chat/MessageItem.vue', 'utf8')
+
+    expect(messageItemSource).toMatch(/message\.role === 'user' && isVideo\(att\.type, att\.name\)/)
+    expect(messageItemSource).toMatch(/file\.type === 'video'[\s\S]*class="msg-attachment-video"/)
+    expect(messageItemSource).toMatch(/class="msg-attachment-video"[\s\S]*controls[\s\S]*playsinline/)
   })
 
   it('parses quoted CSV cells and enforces table and cell limits', () => {

--- a/tests/client/group-chat-workspace-diff.test.ts
+++ b/tests/client/group-chat-workspace-diff.test.ts
@@ -306,4 +306,111 @@ describe('group chat workspace diff client rendering', () => {
       window.removeEventListener('hermes:preview-workspace-file', handlePreview)
     }
   })
+
+  it('renders stored user videos inline through the authenticated group attachment route', async () => {
+    const wrapper = mount(GroupMessageItem, {
+      props: {
+        message: {
+          id: 'video-1',
+          roomId: 'room-1',
+          senderId: 'user-1',
+          senderName: 'User',
+          content: JSON.stringify([{
+            type: 'file',
+            name: 'recording.mp4',
+            path: '3bcfe4f3a97cc6fa202849b0fed2fad8.mp4',
+            media_type: 'video/mp4',
+          }]),
+          timestamp: 1,
+          role: 'user',
+        },
+        agents: [],
+        members: [],
+        currentUserId: 'user-1',
+      },
+      global: { stubs: { MarkdownRenderer: true, ProfileAvatar: true } },
+    })
+
+    try {
+      const video = wrapper.get('video.msg-attachment-video')
+      expect(video.attributes('controls')).toBeDefined()
+      expect(video.attributes('src')).toContain('/api/hermes/group-chat/rooms/room-1/attachments/3bcfe4f3a97cc6fa202849b0fed2fad8.mp4')
+      expect(wrapper.find('.msg-attachment-file').exists()).toBe(false)
+    } finally {
+      wrapper.unmount()
+    }
+  })
+
+  it('keeps agent videos as file attachments', () => {
+    const wrapper = mount(GroupMessageItem, {
+      props: {
+        message: {
+          id: 'agent-video-1',
+          roomId: 'room-1',
+          senderId: 'agent-1',
+          senderName: 'Worker',
+          content: JSON.stringify([{
+            type: 'file',
+            name: 'agent-recording.mp4',
+            path: '3bcfe4f3a97cc6fa202849b0fed2fad8.mp4',
+            media_type: 'video/mp4',
+          }]),
+          timestamp: 1,
+          role: 'assistant',
+        },
+        agents: [{ id: 'a1', roomId: 'room-1', agentId: 'agent-1', profile: 'default', name: 'Worker', description: '', invited: 0 }],
+        members: [],
+        currentUserId: 'user-1',
+      },
+      global: { stubs: { MarkdownRenderer: true, ProfileAvatar: true } },
+    })
+
+    expect(wrapper.find('video.msg-attachment-video').exists()).toBe(false)
+    expect(wrapper.get('.msg-attachment-file').text()).toContain('agent-recording.mp4')
+    wrapper.unmount()
+  })
+
+  it('previews stored non-video files through the group attachment route', () => {
+    const previewRequests: Array<{ sourceUrl: string; fileName: string; size: number }> = []
+    const handlePreview = (event: Event) => {
+      const customEvent = event as CustomEvent<{ sourceUrl: string; fileName: string; size: number }>
+      previewRequests.push(customEvent.detail)
+      customEvent.preventDefault()
+    }
+    window.addEventListener('hermes:preview-group-attachment', handlePreview)
+    const wrapper = mount(GroupMessageItem, {
+      props: {
+        message: {
+          id: 'xml-1',
+          roomId: 'room-1',
+          senderId: 'user-1',
+          senderName: 'User',
+          content: JSON.stringify([{
+            type: 'file',
+            name: 'report.xml',
+            path: '3bcfe4f3a97cc6fa202849b0fed2fad8.xml',
+            media_type: 'application/xml',
+          }]),
+          timestamp: 1,
+          role: 'user',
+        },
+        agents: [],
+        members: [],
+        currentUserId: 'user-1',
+      },
+      global: { stubs: { MarkdownRenderer: true, ProfileAvatar: true } },
+    })
+
+    try {
+      const click = new MouseEvent('click', { bubbles: true, cancelable: true })
+      wrapper.get('.msg-attachment-file').element.dispatchEvent(click)
+      expect(click.defaultPrevented).toBe(true)
+      expect(previewRequests).toHaveLength(1)
+      expect(previewRequests[0]).toMatchObject({ fileName: 'report.xml', size: 0 })
+      expect(previewRequests[0].sourceUrl).toContain('/api/hermes/group-chat/rooms/room-1/attachments/3bcfe4f3a97cc6fa202849b0fed2fad8.xml')
+    } finally {
+      wrapper.unmount()
+      window.removeEventListener('hermes:preview-group-attachment', handlePreview)
+    }
+  })
 })

--- a/tests/client/video-frame-extraction.test.ts
+++ b/tests/client/video-frame-extraction.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { isVideoFile, representativeVideoFrameTimes } from '@/utils/video-frame-extraction'
+
+describe('video frame extraction helpers', () => {
+  it('recognizes videos by MIME type or common file extension', () => {
+    expect(isVideoFile(new File([], 'clip.bin', { type: 'video/mp4' }))).toBe(true)
+    expect(isVideoFile(new File([], 'clip.MOV'))).toBe(true)
+    expect(isVideoFile(new File([], 'notes.txt', { type: 'text/plain' }))).toBe(false)
+  })
+
+  it('samples representative points without seeking beyond the video', () => {
+    expect(representativeVideoFrameTimes(100)).toEqual([10, 50, 90])
+    expect(representativeVideoFrameTimes(0)).toEqual([])
+    expect(representativeVideoFrameTimes(Number.POSITIVE_INFINITY)).toEqual([])
+    expect(representativeVideoFrameTimes(0.05)).toEqual([0])
+  })
+})

--- a/tests/server/app-relay-client.test.ts
+++ b/tests/server/app-relay-client.test.ts
@@ -194,6 +194,125 @@ describe('AppRelayClient', () => {
     expect(Buffer.from(binaryResponse)).toEqual(Buffer.from([7, 8, 9]))
   })
 
+  it('uses the cloud media limit for downloads and applies live limit updates before reading the body', async () => {
+    const apkBytes = new Uint8Array(23 * 1024 * 1024)
+    const fetchImpl = vi.fn(async () => new Response(apkBytes, {
+      status: 200,
+      headers: {
+        'content-type': 'application/vnd.android.package-archive',
+        'content-length': String(apkBytes.byteLength),
+      },
+    }))
+    const { startAppRelayClient } = await import('../../packages/server/src/services/app-relay/client')
+    const client = startAppRelayClient({
+      relayUrl: 'https://relay.example.com',
+      machineId: 'hwui_machine_1234567890',
+      publicKey: 'machine-public-key',
+      localBaseUrl: 'http://127.0.0.1:8648',
+      fetchImpl: fetchImpl as any,
+    })!
+    const remote = sockets[0]
+    remote.__handlers.get('relay.ready')?.({
+      limits: {
+        mediaMaxMegabytes: 30,
+        mediaTransferMegabytesPerSecond: 2,
+        controlTransferMegabytesPerSecond: 2,
+      },
+    })
+
+    const allowed = await client.handleHttpRequest({
+      id: 'apk-allowed',
+      method: 'GET',
+      path: '/api/hermes/download?path=test.apk',
+    })
+    expect(allowed.error).toBeUndefined()
+    expect(allowed.bodyBytes?.byteLength).toBe(apkBytes.byteLength)
+
+    remote.__handlers.get('relay.limits.updated')?.({
+      limits: {
+        mediaMaxMegabytes: 20,
+        mediaTransferMegabytesPerSecond: 2,
+        controlTransferMegabytesPerSecond: 2,
+      },
+    })
+    const rejected = await client.handleHttpRequest({
+      id: 'apk-rejected',
+      method: 'GET',
+      path: '/api/hermes/download?path=test.apk',
+    })
+    expect(rejected).toMatchObject({
+      id: 'apk-rejected',
+      status: 413,
+      error: {
+        code: 'download_too_large',
+        message: 'Cloud relay media files are limited to 20MB',
+      },
+    })
+    expect(rejected.bodyBytes).toBeUndefined()
+  })
+
+  it('streams opted-in binary downloads in bounded chunks when the cloud advertises support', async () => {
+    const fetchImpl = vi.fn(async () => new Response(Uint8Array.from([1, 2, 3, 4, 5]), {
+      status: 200,
+      headers: {
+        'content-type': 'application/octet-stream',
+        'content-length': '5',
+      },
+    }))
+    const { startAppRelayClient } = await import('../../packages/server/src/services/app-relay/client')
+    startAppRelayClient({
+      relayUrl: 'https://relay.example.com',
+      machineId: 'hwui_machine_1234567890',
+      publicKey: 'machine-public-key',
+      localBaseUrl: 'http://127.0.0.1:8648',
+      fetchImpl: fetchImpl as any,
+    })
+    const remote = sockets[0]
+    remote.__handlers.get('relay.ready')?.({
+      capabilities: ['http.request', 'http.download.chunked'],
+      limits: {
+        mediaMaxMegabytes: 30,
+        mediaTransferMegabytesPerSecond: 2,
+        controlTransferMegabytesPerSecond: 2,
+      },
+    })
+
+    const openAck = vi.fn()
+    remote.__handlers.get('app.http.request')({
+      id: 'chunked-open',
+      method: 'GET',
+      path: '/api/hermes/download?path=test.bin',
+      streamBinary: true,
+    }, openAck)
+    await vi.waitFor(() => expect(openAck).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'chunked-open',
+      status: 200,
+      download: { id: expect.any(String), totalBytes: 5 },
+    })))
+    expect(openAck.mock.calls[0][0].bodyBytes).toBeUndefined()
+    const downloadId = openAck.mock.calls[0][0].download.id
+
+    const firstAck = vi.fn()
+    remote.__handlers.get('app.http.download.chunk')({ id: downloadId, maxBytes: 3 }, firstAck)
+    await vi.waitFor(() => expect(firstAck).toHaveBeenCalledWith(expect.objectContaining({
+      id: downloadId,
+      receivedBytes: 3,
+      totalBytes: 5,
+      done: false,
+    })))
+    expect(Array.from(firstAck.mock.calls[0][0].bodyBytes)).toEqual([1, 2, 3])
+
+    const secondAck = vi.fn()
+    remote.__handlers.get('app.http.download.chunk')({ id: downloadId, maxBytes: 3 }, secondAck)
+    await vi.waitFor(() => expect(secondAck).toHaveBeenCalledWith(expect.objectContaining({
+      id: downloadId,
+      receivedBytes: 5,
+      totalBytes: 5,
+      done: true,
+    })))
+    expect(Array.from(secondAck.mock.calls[0][0].bodyBytes)).toEqual([4, 5])
+  })
+
   it('marks App authorization-code login as a cloud connection', async () => {
     const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ token: 'app-token' }), {
       status: 200,

--- a/tests/server/app-relay-download-session.test.ts
+++ b/tests/server/app-relay-download-session.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import {
+  RelayDownloadSessionError,
+  RelayDownloadSessions,
+} from '../../packages/server/src/services/app-relay/download-session'
+
+describe('RelayDownloadSessions diagnostics', () => {
+  it('finishes at the declared byte length without requiring an extra EOF read', async () => {
+    let pullCount = 0
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pullCount += 1
+        if (pullCount === 1) {
+          controller.enqueue(Uint8Array.from([1, 2, 3, 4, 5, 6]))
+          return
+        }
+        controller.error(new Error('closing stream reported as failed'))
+      },
+    })
+    const sessions = new RelayDownloadSessions()
+    const download = sessions.create('owner-complete', new Response(body, {
+      headers: { 'content-length': '6' },
+    }))
+
+    await expect(sessions.read('owner-complete', download.id)).resolves.toMatchObject({
+      bodyBytes: Uint8Array.from([1, 2, 3, 4, 5, 6]),
+      receivedBytes: 6,
+      totalBytes: 6,
+      done: true,
+    })
+    expect(pullCount).toBe(1)
+  })
+
+  it('preserves source read failures with the last confirmed progress', async () => {
+    let pullCount = 0
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pullCount += 1
+        if (pullCount === 1) {
+          controller.enqueue(Uint8Array.from([1, 2, 3]))
+          return
+        }
+        controller.error(new Error('source connection reset'))
+      },
+    })
+    const sessions = new RelayDownloadSessions()
+    const download = sessions.create('owner-1', new Response(body, {
+      headers: { 'content-length': '6' },
+    }))
+
+    await expect(sessions.read('owner-1', download.id, 3)).resolves.toMatchObject({
+      receivedBytes: 3,
+      totalBytes: 6,
+      done: false,
+    })
+
+    try {
+      await sessions.read('owner-1', download.id, 3)
+      throw new Error('expected the source read to fail')
+    } catch (error) {
+      expect(error).toBeInstanceOf(RelayDownloadSessionError)
+      expect(error).toMatchObject({
+        code: 'download_source_read_failed',
+        causeMessage: 'source connection reset',
+        diagnostic: {
+          downloadId: download.id,
+          ownerId: 'owner-1',
+          sessionFound: true,
+          receivedBytes: 3,
+          totalBytes: 6,
+          sourceBytes: 3,
+          attemptedChunks: 2,
+          completedChunks: 1,
+          busy: true,
+        },
+      })
+    }
+  })
+
+  it('distinguishes a missing download session from a zero-byte session', async () => {
+    const sessions = new RelayDownloadSessions()
+
+    await expect(sessions.read('owner-2', 'missing-download')).rejects.toMatchObject({
+      code: 'download_not_found',
+      diagnostic: {
+        downloadId: 'missing-download',
+        ownerId: 'owner-2',
+        sessionFound: false,
+      },
+    })
+  })
+})

--- a/tests/server/app-relay-server.test.ts
+++ b/tests/server/app-relay-server.test.ts
@@ -548,6 +548,65 @@ describe('LocalAppRelayServer', () => {
     expect(Buffer.from(binaryResponse)).toEqual(Buffer.from([7, 8, 9]))
   })
 
+  it('streams opted-in LAN downloads in bounded chunks while preserving legacy responses', async () => {
+    const namespace = createMockNamespace()
+    const io = { of: vi.fn(() => namespace) }
+    const fetchImpl = vi.fn(async () => new Response(Uint8Array.from([1, 2, 3, 4, 5]), {
+      status: 200,
+      headers: {
+        'content-type': 'application/octet-stream',
+        'content-length': '5',
+      },
+    }))
+    const { LocalAppRelayServer } = await import('../../packages/server/src/services/app-relay/server')
+    const server = new LocalAppRelayServer(io as any, {
+      machineId: 'hwui_local_machine_1234567890',
+      localBaseUrl: 'http://127.0.0.1:8748',
+      fetchImpl: fetchImpl as any,
+    })
+    server.init()
+
+    const app = createMockAppSocket('app-download', {
+      role: 'app',
+      token: 'local-user-token',
+      machineId: 'hwui_local_machine_1234567890',
+    })
+    await connectApp(namespace, app)
+    expect(app.emit).toHaveBeenCalledWith('relay.ready', expect.objectContaining({
+      capabilities: expect.arrayContaining(['http.download.chunked']),
+    }))
+
+    const openAck = vi.fn()
+    app.__handlers.get('http.request')({
+      id: 'download-open',
+      method: 'GET',
+      path: '/api/hermes/download?path=test.bin',
+      streamBinary: true,
+    }, openAck)
+    await vi.waitFor(() => expect(openAck).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'download-open',
+      status: 200,
+      download: { id: expect.any(String), totalBytes: 5 },
+    })))
+    const downloadId = openAck.mock.calls[0][0].download.id
+
+    const firstAck = vi.fn()
+    app.__handlers.get('http.download.chunk')({ id: downloadId, maxBytes: 3 }, firstAck)
+    await vi.waitFor(() => expect(firstAck).toHaveBeenCalledWith(expect.objectContaining({
+      receivedBytes: 3,
+      done: false,
+    })))
+    expect(Array.from(firstAck.mock.calls[0][0].bodyBytes)).toEqual([1, 2, 3])
+
+    const secondAck = vi.fn()
+    app.__handlers.get('http.download.chunk')({ id: downloadId, maxBytes: 3 }, secondAck)
+    await vi.waitFor(() => expect(secondAck).toHaveBeenCalledWith(expect.objectContaining({
+      receivedBytes: 5,
+      done: true,
+    })))
+    expect(Array.from(secondAck.mock.calls[0][0].bodyBytes)).toEqual([4, 5])
+  })
+
   it('bridges /chat-run directly with the same App socket events as the cloud relay', async () => {
     const namespace = createMockNamespace()
     const io = { of: vi.fn(() => namespace) }

--- a/tests/server/group-chat-chunked-upload.test.ts
+++ b/tests/server/group-chat-chunked-upload.test.ts
@@ -1,0 +1,80 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+let appHome = ''
+
+vi.mock('../../packages/server/src/config', () => ({
+  config: {
+    get appHome() {
+      return appHome
+    },
+  },
+}))
+
+describe('group chat chunked uploads', () => {
+  beforeEach(async () => {
+    appHome = await mkdtemp(join(tmpdir(), 'hermes-group-upload-'))
+  })
+
+  afterEach(async () => {
+    await rm(appHome, { recursive: true, force: true })
+  })
+
+  it('writes ordered chunks and completes into the private room attachment store', async () => {
+    const {
+      appendGroupChatUploadChunk,
+      completeGroupChatUpload,
+      openGroupChatUpload,
+    } = await import('../../packages/server/src/services/hermes/group-chat/chunked-upload')
+    const { getGroupChatAttachmentPath } = await import(
+      '../../packages/server/src/services/hermes/group-chat/attachments'
+    )
+    const id = 'group_upload_test_1234'
+    await openGroupChatUpload({ id, owner: '7', roomId: 'room-1', name: 'clip.mp4', size: 5 })
+    await expect(appendGroupChatUploadChunk({
+      id,
+      owner: '7',
+      roomId: 'room-1',
+      offset: 0,
+      bytes: Uint8Array.from([1, 2, 3]),
+    })).resolves.toMatchObject({ nextOffset: 3, done: false })
+    await expect(appendGroupChatUploadChunk({
+      id,
+      owner: '7',
+      roomId: 'room-1',
+      offset: 3,
+      bytes: Uint8Array.from([4, 5]),
+    })).resolves.toMatchObject({ nextOffset: 5, done: true })
+
+    const completed = await completeGroupChatUpload({ id, owner: '7', roomId: 'room-1' })
+    expect(completed.name).toBe('clip.mp4')
+    expect(completed.path).toMatch(/^[a-f0-9]{32}\.mp4$/)
+    const storedPath = getGroupChatAttachmentPath('room-1', completed.path)
+    expect(storedPath).toBeTruthy()
+    expect(await readFile(storedPath!)).toEqual(Buffer.from([1, 2, 3, 4, 5]))
+  })
+
+  it('rejects another member and out-of-order chunks', async () => {
+    const { appendGroupChatUploadChunk, openGroupChatUpload } = await import(
+      '../../packages/server/src/services/hermes/group-chat/chunked-upload'
+    )
+    const id = 'group_upload_owner_1234'
+    await openGroupChatUpload({ id, owner: '7', roomId: 'room-1', name: 'clip.mp4', size: 2 })
+    await expect(appendGroupChatUploadChunk({
+      id,
+      owner: '8',
+      roomId: 'room-1',
+      offset: 0,
+      bytes: Uint8Array.from([1]),
+    })).rejects.toMatchObject({ code: 'upload_forbidden', status: 403 })
+    await expect(appendGroupChatUploadChunk({
+      id,
+      owner: '7',
+      roomId: 'room-1',
+      offset: 1,
+      bytes: Uint8Array.from([1]),
+    })).rejects.toMatchObject({ code: 'invalid_upload_offset', status: 409 })
+  })
+})

--- a/tests/server/run-chat-content-blocks.test.ts
+++ b/tests/server/run-chat-content-blocks.test.ts
@@ -74,4 +74,34 @@ describe('run chat content blocks', () => {
       }],
     })
   })
+
+  it('labels representative video frames for API, bridge, and coding-agent inputs', async () => {
+    const framePath = join(tempDir, 'clip-video-frame-01.jpg')
+    await writeFile(framePath, Buffer.from([1, 2, 3]))
+    const block = {
+      type: 'image' as const,
+      name: 'clip-video-frame-01.jpg',
+      path: framePath,
+      media_type: 'image/jpeg',
+      video_frame: true,
+    }
+    const label = '[Representative frame extracted from the attached video: clip-video-frame-01.jpg]'
+
+    const apiParts = await convertContentBlocks([block])
+    expect(apiParts).toHaveLength(2)
+    expect(apiParts[0]).toEqual({ type: 'input_text', text: label })
+    expect(apiParts[1].type).toBe('input_image')
+
+    const agentParts = await convertContentBlocksForAgent([block])
+    expect(agentParts[0]).toEqual({
+      type: 'text',
+      text: `${label}\nLocal image path for tools: ${framePath}`,
+    })
+    expect(agentParts[1].type).toBe('image_url')
+
+    expect(convertContentBlocksForCodingAgent([block])).toMatchObject({
+      text: `${label}\nLocal image path for tools: ${framePath}`,
+      images: [{ path: framePath, mediaType: 'image/jpeg' }],
+    })
+  })
 })

--- a/tests/server/workflow-manager.test.ts
+++ b/tests/server/workflow-manager.test.ts
@@ -434,6 +434,39 @@ describe('workflow manager', () => {
     } finally { await manager.delete(workflow.id) }
   })
 
+  it('forwards workflow files as file ContentBlocks instead of mislabeled images', async () => {
+    const { initAllStores } = await import('../../packages/server/src/db/hermes/init')
+    const { WorkflowManager } = await import('../../packages/server/src/services/workflow-manager')
+    initAllStores()
+    chatRunMock.runAndWait.mockReset().mockResolvedValue({ ok: true, output: 'done' })
+    const manager = new WorkflowManager()
+    const filePath = '/tmp/workflow-reference.pdf'
+    const workflow = manager.create({
+      name: `Coding Agent file input ${Date.now()}`,
+      profile: 'default',
+      nodes: [{ id: 'agent', type: 'agent', data: {
+        title: 'Agent', agent: 'codex', provider: 'custom:test', model: 'model-a',
+        apiMode: 'codex_responses', input: 'inspect the reference', images: [filePath],
+      } }],
+      edges: [],
+    })
+    try {
+      await manager.runNow(workflow.id)
+      expect(chatRunMock.runAndWait).toHaveBeenCalledWith(expect.objectContaining({
+        coding_agent_id: 'codex',
+        input: [
+          { type: 'text', text: '[Current task]\ninspect the reference' },
+          {
+            type: 'file',
+            name: 'workflow-reference.pdf',
+            path: filePath,
+            media_type: 'application/pdf',
+          },
+        ],
+      }), expect.any(Object))
+    } finally { await manager.delete(workflow.id) }
+  })
+
   it('rejects unsupported execution tuples before persisting a run', async () => {
     const { initAllStores } = await import('../../packages/server/src/db/hermes/init')
     const { listWorkflowRuns } = await import('../../packages/server/src/db/hermes/workflow-run-store')


### PR DESCRIPTION
## Summary
- send workflow attachments with the correct image or file content block type
- add chunked group-chat attachment uploads with progress and safe cross-platform filenames
- preview user-sent videos in direct and group chats with generated thumbnails and contained playback
- add chunked App relay downloads with cancellation, legacy fallback, and download-session cleanup
- improve attachment draft handling and file preview format detection

## Validation
- npm run test (535 files passed, 2 skipped; 4469 tests passed, 6 skipped)
- npm run build
- git diff --check