### PR TITLE
[codex] preserve global coding agent context after stop

### DIFF
--- a/docs/chat-chain-changes/2026-08-25-global-coding-agent-stop-resume.md
+++ b/docs/chat-chain-changes/2026-08-25-global-coding-agent-stop-resume.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-08-25
-pr: pending
+pr: 2735
 feature: Global Coding Agent stop and resume continuity
 impact: Stopping a global Claude, Codex, or Pi run and then continuing the same Studio chat now resumes its stored native agent session instead of starting a context-free thread.
 ---

--- a/docs/chat-chain-changes/2026-08-25-global-coding-agent-stop-resume.md
+++ b/docs/chat-chain-changes/2026-08-25-global-coding-agent-stop-resume.md
@@ -1,0 +1,11 @@
+---
+date: 2026-08-25
+pr: pending
+feature: Global Coding Agent stop and resume continuity
+impact: Stopping a global Claude, Codex, or Pi run and then continuing the same Studio chat now resumes its stored native agent session instead of starting a context-free thread.
+---
+
+Global Coding Agent sessions use the CLI's own provider and model configuration,
+so continuation compatibility is determined by the stored agent type and global
+mode. Scoped sessions continue to require matching provider, model, and API
+protocol before their native session is resumed.

--- a/packages/server/src/services/coding-agents/index.ts
+++ b/packages/server/src/services/coding-agents/index.ts
@@ -2724,9 +2724,11 @@ export async function startCodingAgentRun(
   const canResumeNativeSession = existingSession
     ? storedCodingAgentMode(existingSession) === requestedMode &&
       (existingSession.agent === persistedAgentId(id) || !existingSession.agent) &&
-      String(existingSession.provider || '').trim() === String(resolvedInput.provider || '').trim() &&
-      String(existingSession.model || '').trim() === String(resolvedInput.model || '').trim() &&
-      (!String(existingSession.api_mode || '').trim() || String(existingSession.api_mode || '').trim() === String(resolvedInput.apiMode || '').trim())
+      (requestedMode === 'global' || (
+        String(existingSession.provider || '').trim() === String(resolvedInput.provider || '').trim() &&
+        String(existingSession.model || '').trim() === String(resolvedInput.model || '').trim() &&
+        (!String(existingSession.api_mode || '').trim() || String(existingSession.api_mode || '').trim() === String(resolvedInput.apiMode || '').trim())
+      ))
     : false
   const existingNativeSessionId = canResumeNativeSession ? existingSession?.agent_native_session_id || '' : ''
   const agentNativeSessionId = resolvedInput.agentNativeSessionId || existingNativeSessionId || (id === 'claude-code' || id === 'pi' ? randomUUID() : '')

--- a/tests/server/coding-agent-resume-config.test.ts
+++ b/tests/server/coding-agent-resume-config.test.ts
@@ -243,6 +243,38 @@ describe('coding agent resumed session config', () => {
     }))
   })
 
+  it('resumes a global Codex native thread after the active runner is stopped', async () => {
+    makeHome()
+    getSessionMock.mockReturnValue({
+      id: 'session-1',
+      profile: 'default',
+      source: 'coding_agent',
+      agent: 'codex',
+      agent_mode: 'global',
+      agent_session_id: 'agent-session-1',
+      agent_native_session_id: 'global-codex-thread-1',
+      provider: 'global',
+      model: '',
+      api_mode: '',
+      workspace: '/tmp/existing-workspace',
+    })
+
+    const { startCodingAgentRun } = await import('../../packages/server/src/services/coding-agents')
+    await startCodingAgentRun('codex', {
+      sessionId: 'session-1',
+      mode: 'global',
+      workspace: '/tmp/existing-workspace',
+    })
+
+    expect(startRunMock).toHaveBeenCalledWith(expect.objectContaining({
+      agentNativeSessionId: 'global-codex-thread-1',
+      nativeResume: true,
+    }))
+    expect(updateSessionMock).toHaveBeenCalledWith('session-1', expect.objectContaining({
+      agent_native_session_id: 'global-codex-thread-1',
+    }))
+  })
+
   it('passes the stored native session id to Pi so its RPC process resumes after restart', async () => {
     const home = makeHome()
     installPiMcpAdapter(home)


### PR DESCRIPTION
## Summary
- reuse the persisted native agent session when a global Coding Agent runner is recreated after stop, idle cleanup, or server restart
- keep scoped Coding Agent resume compatibility checks for provider, model, and API protocol
- add a regression test covering global Codex continuation from the stored native thread

## Root cause
Global runs omit provider and model fields from continuation requests because the native CLI owns that configuration. The resume gate compared the omitted provider against the stored `global` provider, rejected the persisted native thread, and started a context-free thread.

## Validation
- `npm run test -- tests/server/coding-agent-resume-config.test.ts tests/server/handle-coding-agent-run.test.ts tests/server/coding-agent-queue-insertion.test.ts tests/server/run-chat-abort-goal.test.ts`
- `npm run harness:check`
- `npm run build`