### PR TITLE
修复：Node.js 22.5+ 可用时仍提示升级到 23 的误报

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
         "ws": "^8.20.0"
       },
       "engines": {
-        "node": ">=23.0.0"
+        "node": ">=22.5.0"
       },
       "optionalDependencies": {
         "sherpa-onnx-darwin-arm64": "1.13.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://hermes-studio.ai",
   "license": "BSL-1.1",
   "engines": {
-    "node": ">=23.0.0"
+    "node": ">=22.5.0"
   },
   "keywords": [
     "hermes",

--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -50,9 +50,8 @@ const showAppSidebar = computed(() => !isLoginPage.value && !isStandaloneChatPag
 const showMobileMenuButton = computed(() => !isLoginPage.value && !isStandaloneChatPage.value && (showAppSidebar.value || usesPageSidebar.value))
 
 const nodeVersionLow = computed(() => {
-  const v = appStore.nodeVersion
-  const major = parseInt(v.split('.')[0], 10)
-  return !isNaN(major) && major < 23
+  const [major, minor] = appStore.nodeVersion.split('.').map(Number)
+  return Number.isFinite(major) && Number.isFinite(minor) && (major < 22 || (major === 22 && minor < 5))
 })
 
 const isDesktopShell = computed(() => desktopBridge()?.isDesktop === true)

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -251,7 +251,7 @@ export default {
     updateSuccess: 'Update successful. Please refresh the page shortly. If it does not start after a while, start it manually.',
     updateFailed: 'Update failed',
     logout: 'Sign Out',
-    nodeVersionWarning: 'Detected Node.js v{version}. Please upgrade to version 23 or later.',
+    nodeVersionWarning: 'Detected Node.js v{version}. Please upgrade to version 22.5 or later.',
     changelog: 'Changelog',
     noChangelog: 'No changelog available',
     versionManagement: 'Version Management',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -251,7 +251,7 @@ export default {
     updateSuccess: '更新成功，請稍後重新整理頁面，如長時間未啟動，請手動啟動',
     updateFailed: '更新失敗',
     logout: '登出',
-    nodeVersionWarning: '偵測到 Node.js v{version}，請升級至 23 以上版本。',
+    nodeVersionWarning: '偵測到 Node.js v{version}，請升級至 22.5 以上版本。',
     changelog: '更新日誌',
     noChangelog: '目前無更新日誌',
     versionManagement: '版本管理',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -251,7 +251,7 @@ export default {
     updateSuccess: '更新成功，请稍后刷新页面，如长时间未启动，请手动启动',
     updateFailed: '更新失败',
     logout: '退出登录',
-    nodeVersionWarning: '检测到 Node.js v{version}，请升级到23以上版本。',
+    nodeVersionWarning: '检测到 Node.js v{version}，请升级到 22.5 以上版本。',
     changelog: '更新日志',
     noChangelog: '暂无更新日志',
     versionManagement: '版本管理',


### PR DESCRIPTION
## 摘要

修正 Hermes Studio 对 Node.js 版本的最低要求：支持 `node:sqlite` 所需的 Node.js `22.5+`，避免已经满足运行时需求的 Node.js 22.x 用户被错误提示必须升级到 Node.js 23。

## 修改

- 将 `package.json` 与 lockfile 的 engine 从 `>=23.0.0` 调整为 `>=22.5.0`。
- UI 以 major/minor 进行判断：22.5 以下才显示升级提示。
- 同步更新英文、简体中文与繁体中文提示文案。

## 验证

- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npx vue-tsc -b`
- `npx vite build`
- 在 Node.js `22.22.0` 下启动已构建的 server bundle，`/health` 正常返回。
