### PR TITLE
fix(chat): preserve category collapse from Recent

### DIFF
--- a/docs/chat-chain-changes/2026-08-26-recent-session-category-collapse.md
+++ b/docs/chat-chain-changes/2026-08-26-recent-session-category-collapse.md
@@ -1,0 +1,10 @@
+---
+date: 2026-08-26
+pr: pending
+feature: Recent session category collapse preservation
+impact: Selecting a direct-chat session from Recent no longer expands its real category or overwrites the saved collapsed state.
+---
+
+Recent remains a shortcut that can highlight the active session without changing
+the user's category-collapse choices. Direct URL and ordinary navigation can
+still reveal the active category.

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -340,6 +340,12 @@ async function handleSessionClick(sessionId: string) {
   if (mobileQuery?.matches) showSessions.value = false;
 }
 
+async function handleRecentSessionClick(sessionId: string) {
+  // Recent is a shortcut; selecting it must not overwrite the real category's saved collapse state.
+  categoryRevealSuppressedSessionId.value = sessionId;
+  await handleSessionClick(sessionId);
+}
+
 function handleMobileChange(e: MediaQueryListEvent | MediaQueryList) {
   isMobile.value = e.matches;
   if (e.matches && showSessions.value) {
@@ -534,6 +540,7 @@ function loadCollapsedCategories(): Set<string> {
 }
 
 const collapsedCategories = ref<Set<string>>(loadCollapsedCategories());
+const categoryRevealSuppressedSessionId = ref<string | null>(null);
 
 function persistCollapsedCategories() {
   localStorage.setItem(
@@ -638,6 +645,8 @@ watch(
   () => {
     if (!sessionCategoriesLoaded.value || categorizedSessions.value.length === 0) return;
     const activeSession = chatStore.sessions.find((session) => session.id === chatStore.activeSessionId);
+    if (categoryRevealSuppressedSessionId.value === activeSession?.id) return;
+    categoryRevealSuppressedSessionId.value = null;
     const activeKey = activeSession?.categoryId == null
       ? "category-none"
       : `category-${activeSession.categoryId}`;
@@ -2109,7 +2118,7 @@ async function handleSessionModelCustomSubmit() {
               :category-label="recentCategoryLabel(s)"
               :to="sessionHref(s.id)"
               :intercept-modified-navigation="desktopChatWindowAvailable"
-              @select="handleSessionClick(s.id)"
+              @select="handleRecentSessionClick(s.id)"
               @open-new="openSessionInNewTab(s.id)"
               @contextmenu="handleContextMenu($event, s.id)"
               @delete="handleDeleteSession(s.id)"

--- a/tests/e2e/session-categories.spec.ts
+++ b/tests/e2e/session-categories.spec.ts
@@ -108,6 +108,39 @@ test('groups sessions by category and persists collapsed groups', async ({ page 
   await expect(recentHeader.locator('.session-group-count')).toHaveText('2')
 })
 
+test('selects a recent session without expanding its collapsed category', async ({ page }) => {
+  await authenticate(page, TEST_ACCESS_KEY, 'research')
+  await mockHermesApi(page, {
+    sessionCategories: [{ id: 1, name: 'Work' }],
+    sessions: [
+      sessionSummary('work-session', 'Project Alpha', 1, 200),
+      sessionSummary('uncategorized-session', 'General Notes', null, 100),
+    ],
+  })
+  await mockChatSocket(page)
+
+  await page.goto('/#/hermes/chat')
+
+  const workHeader = page.locator('.session-group-header').filter({ hasText: 'Work' })
+  const recentSession = page.getByRole('link', { name: /Project Alpha/ }).first()
+  await page.getByRole('link', { name: /General Notes/ }).first().click()
+  await expect(page).toHaveURL(/\/hermes\/session\/uncategorized-session$/)
+
+  await expect(workHeader).toBeVisible()
+  await workHeader.click()
+  await expect(page.getByRole('link', { name: /Project Alpha/ })).toHaveCount(1)
+  await expect.poll(() => page.evaluate(() => localStorage.getItem('hermes_chat_collapsed_categories')))
+    .toContain('category-1')
+
+  await recentSession.click()
+
+  await expect(page).toHaveURL(/\/hermes\/session\/work-session$/)
+  await expect(recentSession).toHaveClass(/active/)
+  await expect(page.getByRole('link', { name: /Project Alpha/ })).toHaveCount(1)
+  await expect.poll(() => page.evaluate(() => localStorage.getItem('hermes_chat_collapsed_categories')))
+    .toContain('category-1')
+})
+
 test('persists the collapsed recent group across reloads without changing the active session', async ({ page }) => {
   await authenticate(page, TEST_ACCESS_KEY, 'research')
   await mockHermesApi(page, {


### PR DESCRIPTION
## Summary

- treat **Recent** as a shortcut when selecting a session
- preserve the saved collapsed state of the session's real category
- keep existing category auto-reveal behavior for direct URLs, refreshes, and ordinary navigation
- keep modified-click/new-window routing unchanged

## Root cause

The active-session watcher auto-expanded the active session's real category without knowing whether the selection originated from the Recent shortcut. As a result, selecting a Recent item overwrote the user's collapsed category state and rendered the same active session in both places.

## Tests

- Added a regression E2E that failed before the fix because `Project Alpha` appeared twice after selection (`expected 1, received 2`).
- `NODE_ENV=test npx playwright test tests/e2e/session-categories.spec.ts` — 9 passed
- `NODE_ENV=test npx vitest run tests/client/session-category-groups.test.ts` — 5 passed
- `NODE_ENV=development npm run harness:check` — passed
- `NODE_ENV=development npm run build` — passed

Closes #2741

This PR is intentionally left unmerged pending LPK installation acceptance.
