### PR TITLE
docs: refresh Hermes Studio README architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 </p>
 
 <p align="center">
-  A desktop app, local runtime, and web console for <a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a>.<br/>
-  Chat with agents, build visual workflows, manage models and profiles,<br/>
-  browse the web, run coding agents, and keep everything local.
+  A multi-agent desktop app, local runtime, and web console for<br/>
+  <a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a>, Ekko, Claude Code, Codex, and Pi.<br/>
+  Run chats, groups, workflows, coding tasks, voice, files, and devices from one local-first workspace.
 </p>
 
 <p align="center">
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <img src="https://github.com/EKKOLearnAI/hermes-studio/blob/main/packages/client/src/assets/image.gif" alt="Hermes Web UI Demo" width="680"/>
+  <img src="https://github.com/EKKOLearnAI/hermes-studio/blob/main/packages/client/src/assets/image.gif" alt="Hermes Studio Demo" width="680"/>
 </p>
 
 <p align="center">
@@ -31,19 +31,39 @@
 
 | Area | What Hermes Studio does |
 | --- | --- |
-| Agent chat | Runs Hermes Agent conversations with streaming responses, tool traces, generated-file previews, persistent local sessions, and standalone desktop chat windows. |
-| Local control plane | Manages profiles, providers, models, credentials, memory, skills, plugins, logs, and runtime settings from one dashboard. |
-| Automation | Builds executable visual workflows and configures platform channels, cron jobs, Kanban tasks, group-chat rooms, and MCP servers around the same Hermes profiles. |
+| Multi-agent runtime | Runs Hermes, Ekko, Claude Code, Codex, and Pi with streaming responses, tool traces, generated-file previews, persistent sessions, and standalone desktop chat windows. |
+| Studio workspace | Provides shared chats, group chat, global-agent runs, workflows, files, voice, media, devices, themes, logs, usage, and App connectivity across agent runtimes. |
+| Agent control planes | Keeps Hermes profiles, providers, models, memory, skills, plugins, jobs, Kanban, channels, and runtime management in their owning agent module. |
+| Automation | Builds executable visual workflows and connects the five runtimes through schedules, approval gates, group-chat rooms, platform channels, and MCP servers. |
 | Workspace tools | Provides a file browser, web terminal, Desktop Agent Browser, voice input/output, coding-agent runners, device discovery, Journey graph, and performance views. |
 | Distribution | Ships as a desktop app for Windows/macOS/Linux, an npm CLI package, and a Docker image. |
+
+## Agent and Platform Boundaries
+
+Hermes Studio is the shared product platform, not a sixth agent. It coordinates
+five concrete runtimes grouped into three agent families:
+
+| Agent family | Runtime | Owned behavior |
+| --- | --- | --- |
+| Hermes | Hermes | Profiles, providers, models, skills, plugins, memory, jobs, Kanban, channels, MCP, terminal, and Hermes runtime integration. |
+| Ekko | Ekko | Ekko execution, approvals, clarifications, memory, MCP, and provider runtime behavior. |
+| Coding | Claude Code, Codex, Pi | Coding-agent installation, configuration, proxies, sessions, and process execution. |
+
+Studio owns capabilities shared by those families: single chat, group chat,
+global-agent orchestration, workflows, webhooks, sessions, files and uploads,
+TTS/STT, media, pets, themes, devices, networking, logs, usage, authentication,
+and App connectivity. Studio-owned HTTP APIs use `/api/studio/*`; Hermes-owned
+control-plane APIs use `/api/hermes/*`. Already-released mobile App paths are
+handled by one centralized compatibility layer instead of duplicate legacy
+controllers.
 
 ## Features
 
 ### AI Chat
 
-- Real-time chat streaming over Socket.IO `/chat-run`; chat runs execute through the Hermes agent bridge
+- Real-time chat streaming over Socket.IO `/chat-run`; Studio dispatches each run to Hermes, Ekko, Claude Code, Codex, or Pi through runtime adapters
 - Multi-session management — create, rename, delete, switch between sessions
-- **Self-built session database** — local SQLite storage for Web UI sessions; Hermes state.db remains a read-only source for Hermes history APIs
+- **Self-built session database** — local SQLite storage for Studio sessions; Hermes state.db remains a read-only source for Hermes history APIs
 - Session grouping by source (Telegram, Discord, Slack, etc.) with collapsible accordion
 - Active session indicator — live sessions pin to top with spinner icon
 - Sessions sorted by latest message time
@@ -52,7 +72,7 @@
 - Profile-scoped file uploads, clipboard image/file paste, and workspace attachments
 - File download support — download uploaded files and agent-generated files by resolved path across local, Docker, SSH, and Singularity backends
 - Inline previews for generated HTML, PDF, DOCX, PPTX, XLSX, CSV, images, Markdown, and source files
-- Session search — Ctrl+K search across the Web UI local session database; read-only Hermes history sessions are not included
+- Session search — Ctrl+K search across the Studio local session database; read-only Hermes history sessions are not included
 - Session categories, message references, compression progress, and durable background delegation results
 - Profile-aware model selector — discovers models available to the signed-in account through authorized Hermes profiles
 - Per-session model display badge and context token usage
@@ -96,11 +116,11 @@ Unified configuration for **10 platforms** in one page:
 
 - Profile-aware Kanban board for planning and tracking agent work
 - Task creation, updates, and status movement from the dashboard
-- Shared with the same local Web UI state and authentication model
+- Shared with the same local Studio state and authentication model
 
 ### Visual Workflows
 
-- Vue Flow canvas for Hermes, Codex, and Claude Code nodes with file/image attachments
+- Vue Flow canvas for Hermes, Ekko, Claude Code, Codex, and Pi nodes with file/image attachments
 - Directed edges, structured conditions, success/failure routes, loops, and approval gates
 - Import/export for portable workflow definitions and profile-aware workspaces
 - Run budgets, deadlines, stop/rerun controls, and persisted execution history
@@ -145,7 +165,7 @@ Unified configuration for **10 platforms** in one page:
 
 ### Coding Agents
 
-- Install, configure, launch, and monitor Claude Code and Codex from the dashboard
+- Install, configure, launch, and monitor Claude Code, Codex, and Pi from the dashboard
 - Built-in coding-agent terminal, session history, workspace selection, images, and file diffs
 - Dedicated proxy routes and API modes for provider/model compatibility
 - Standalone desktop chat windows and persisted output/reasoning metadata
@@ -195,14 +215,14 @@ CLI maintenance commands:
 # Delete persisted login IP lock records
 hermes-web-ui clear-login-locks
 
-# Delete login locks and restart the running Web UI process
+# Delete login locks and restart the running Studio server
 hermes-web-ui clear-login-locks --restart
 
 # Create or reset the default super administrator login to admin / 123456
 hermes-web-ui reset-default-login
 ```
 
-`clear-login-locks` removes `${HERMES_WEB_UI_HOME:-~/.hermes-web-ui}/.login-lock.json`. If the server is running, restart it to clear in-memory lock state. `reset-default-login` updates the Web UI account database; if an `admin` user already exists, its password is reset to `123456` and the account is enabled as a super administrator.
+`clear-login-locks` removes `${HERMES_WEB_UI_HOME:-~/.hermes-web-ui}/.login-lock.json`. If the server is running, restart it to clear in-memory lock state. `reset-default-login` updates the Studio account database; if an `admin` user already exists, its password is reset to `123456` and the account is enabled as a super administrator.
 
 ### Settings
 
@@ -235,7 +255,7 @@ hermes-web-ui reset-default-login
 ### Desktop App & Updates
 
 - Native Electron shell for Windows, macOS, and Linux
-- Bundles the Web UI runtime and starts the local Hermes Studio server automatically
+- Bundles the Studio runtime and starts the local server automatically
 - Uses Cloudflare download endpoints for desktop auto-update metadata and assets first
 - Falls back to GitHub Releases `latest` assets if the Cloudflare update feed is unavailable
 - Windows upgrades attempt to close an existing Hermes Studio process before replacing files
@@ -250,17 +270,17 @@ Download the latest **Hermes Studio** desktop installer from
 [GitHub Releases](https://github.com/EKKOLearnAI/hermes-studio/releases/latest).
 
 Desktop builds are published for macOS, Windows, and Linux, with separate
-architecture assets where applicable. The desktop app bundles the Web UI
+architecture assets where applicable. The desktop app bundles the Studio
 runtime and stores Hermes Agent data in the native Hermes location:
 
 - Windows: `%LOCALAPPDATA%\hermes` (falls back to `%APPDATA%\hermes`)
 - macOS/Linux: `~/.hermes`
 
-The desktop wrapper stores its own Web UI state separately in
+The desktop wrapper stores its own Studio state separately in
 `~/.hermes-web-ui` unless `HERMES_WEB_UI_HOME` is set.
 
 After the packaged desktop app starts, it installs managed command shims so the
-desktop app, bundled Hermes Agent CLI, and bundled Web UI CLI do not conflict:
+desktop app, bundled Hermes Agent CLI, and bundled server CLI do not conflict:
 
 | Command | Description |
 | --- | --- |
@@ -268,10 +288,10 @@ desktop app, bundled Hermes Agent CLI, and bundled Web UI CLI do not conflict:
 | `hermes-studio cli ...` | Run the bundled Hermes Agent CLI |
 | `hermes-studio web ...` | Run the bundled `hermes-web-ui` command |
 | `hermes-studio -h` | Show wrapper help |
-| `hermes-studio-mcp [api\|browser\|devices\|use]` | Run one managed Web UI MCP toolset |
+| `hermes-studio-mcp [api\|browser\|devices\|use]` | Run one managed Studio MCP toolset |
 
 Use `hermes-studio cli -h` for Hermes Agent CLI help and
-`hermes-studio web -h` for Web UI CLI help. `hermes-studio-mcp` defaults to the
+`hermes-studio web -h` for server CLI help. `hermes-studio-mcp` defaults to the
 `api` toolset; choose `browser`, `devices`, or `use` to keep the exposed MCP
 surface focused on the current task.
 
@@ -306,7 +326,7 @@ docker compose logs -f hermes-webui
 Open **http://localhost:6060**
 
 - Persistent Hermes data is stored in `./hermes_data`
-- Web UI auth token is stored in `./hermes_data/hermes-web-ui/.token`
+- Studio auth token is stored in `./hermes_data/hermes-web-ui/.token`
 - On first run with auth enabled, the token is printed to container logs
 - All runtime settings are environment-variable driven in `docker-compose.yml`
 
@@ -314,30 +334,30 @@ For detailed notes and troubleshooting, see [`docs/docker.md`](./docs/docker.md)
 
 ### Hermes Agent Runtime Discovery
 
-When Web UI starts backend chat features, it prefers a source checkout that
+When Studio starts backend chat features, it prefers a source checkout that
 contains `run_agent.py` such as `~/.hermes/hermes-agent`. If no source checkout
 is found, it falls back to the Python environment used by the installed
 `hermes` command, then the system Python. This supports both source installs
 and package installs such as `pip install hermes-agent`.
 
-## Web UI Environment Variables
+## Studio Environment Variables
 
-These variables configure Hermes Web UI, its local Hermes runtime integration, and development/preview helpers. Provider API keys and Hermes Agent settings are normally managed through Hermes profiles; environment variables here are process-level overrides.
+These variables configure Hermes Studio, its local Hermes runtime integration, and development/preview helpers. Provider API keys and Hermes Agent settings are normally managed through Hermes profiles; environment variables here are process-level overrides.
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `PORT` | `8648` | Web UI listen port. |
-| `BIND_HOST` | `0.0.0.0` | Web UI bind host. Set `::` explicitly for IPv6. |
+| `PORT` | `8648` | Studio server listen port. |
+| `BIND_HOST` | `0.0.0.0` | Studio server bind host. Set `::` explicitly for IPv6. |
 | `HERMES_LAN_ADVERTISE_URL` | unset | Reachable Studio origin used in App LAN QR codes. Set this to the Docker host's LAN URL when Studio is opened through `localhost`, for example `http://192.168.1.20:6060`. |
 | `HERMES_APP_ENTITLEMENT_REQUIRED` | `true` | Require a valid cloud-signed App entitlement before accepting a LAN App relay connection. Set `false` only for temporary compatibility diagnostics. |
 | `HERMES_APP_ENTITLEMENT_PUBLIC_KEY` | built in | Optional PEM public-key override for RS256 App entitlements. The expected issuer is `hermes-studio-server` and audience is `ekko-studio`. |
-| `HERMES_WEB_UI_HOME` | `~/.hermes-web-ui` | Web UI data home for auth token, credentials, logs, DB, and default uploads. `HERMES_WEBUI_STATE_DIR` is also supported as a compatibility alias. |
+| `HERMES_WEB_UI_HOME` | `~/.hermes-web-ui` | Studio data home for auth token, credentials, logs, DB, and default uploads. `HERMES_WEBUI_STATE_DIR` is also supported as a compatibility alias. |
 | `HERMES_WEBUI_STATE_DIR` | unset | Compatibility alias for `HERMES_WEB_UI_HOME`. |
 | `HERMES_WEB_UI_DISABLE_MCP_AUTOINJECT` | unset | Disable startup injection of the managed `hermes-studio` MCP server into Hermes profile configs. |
 | `HERMES_WEB_UI_ALLOW_TRANSIENT_MCP_AUTOINJECT` | unset | Allow managed MCP injection when `HERMES_WEB_UI_HOME` is under a temporary directory, such as Version Preview runtimes. |
 | `UPLOAD_DIR` | `$HERMES_WEB_UI_HOME/upload` | Upload root override. Files are stored below profile-scoped subdirectories. |
 | `CORS_ORIGINS` | same host only | Comma- or space-separated cross-origin allowlist for HTTP, Socket.IO, and WebSocket requests. Set `*` only when you intentionally need legacy wildcard CORS. |
-| `AUTH_TOKEN` | auto-generated | Explicit bearer token. If unset, Web UI creates one under `HERMES_WEB_UI_HOME`. |
+| `AUTH_TOKEN` | auto-generated | Explicit bearer token. If unset, Studio creates one under `HERMES_WEB_UI_HOME`. |
 | `AUTH_JWT_SECRET` | `AUTH_TOKEN` | JWT signing secret override for username/password sessions. |
 | `HERMES_WEB_UI_AUTH_JWT_EXPIRES_IN` | `30d` | Username/password session JWT lifetime. Accepts seconds or `s`/`m`/`h`/`d` suffixes, for example `12h` or `7d`. |
 | `PROFILE` | `default` | Startup/default Hermes profile. Runtime requests use the profile selected by the frontend and authorized for the current account. |
@@ -357,7 +377,7 @@ These variables configure Hermes Web UI, its local Hermes runtime integration, a
 | `HERMES_AGENT_BRIDGE_TIMEOUT_MS` | `120000` | Timeout for Node requests to the bridge broker. |
 | `HERMES_AGENT_BRIDGE_CONNECT_RETRY_MS` | `5000` | Short retry window for connecting to the bridge socket. |
 | `HERMES_AGENT_BRIDGE_STARTUP_TIMEOUT_MS` | `120000` | Timeout while waiting for the Python bridge to become ready. |
-| `HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN` | enabled | Stop the bridge broker during Web UI shutdown and restart. Set `0`, `false`, `no`, or `off` to keep the bridge across restarts. |
+| `HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN` | enabled | Stop the bridge broker during Studio shutdown and restart. Set `0`, `false`, `no`, or `off` to keep the bridge across restarts. |
 | `HERMES_AGENT_BRIDGE_AUTO_RESTART` | enabled | Auto-restart the bridge broker after unexpected exit. Set `0`, `false`, `no`, or `off` to disable. |
 | `HERMES_AGENT_BRIDGE_RESTART_DELAY_MS` | `1000` | Base delay for bridge auto-restart backoff. |
 | `HERMES_AGENT_BRIDGE_PLATFORM` | `cli` | Platform identity passed to Hermes Agent. |
@@ -368,12 +388,12 @@ These variables configure Hermes Web UI, its local Hermes runtime integration, a
 | `HERMES_BRIDGE_MAX_TURNS` | profile/default | Maximum turn override for bridge runs. |
 | `HERMES_BRIDGE_SUPPRESS_PLATFORM_HINT` | `cli` | Controls bridge platform hint suppression passed to Hermes Agent. |
 | `HERMES_OPENROUTER_APP_REFERER` | `https://hermes-studio.ai` | OpenRouter attribution referer sent by bridge runs. |
-| `HERMES_OPENROUTER_APP_TITLE` | `Hermes Web UI` | OpenRouter attribution title sent by bridge runs. |
+| `HERMES_OPENROUTER_APP_TITLE` | `Hermes Studio` | OpenRouter attribution title sent by bridge runs. |
 | `HERMES_OPENROUTER_APP_CATEGORIES` | `cli-agent,personal-agent` | OpenRouter attribution categories sent by bridge runs. |
-| `HERMES_WEB_UI_MANAGED_GATEWAY` | enabled | Controls Web UI-managed Hermes gateway process handling. Set `0`, `false`, `no`, or `off` to use `hermes gateway start` instead. |
+| `HERMES_WEB_UI_MANAGED_GATEWAY` | enabled | Controls Studio-managed Hermes gateway process handling. Set `0`, `false`, `no`, or `off` to use `hermes gateway start` instead. |
 | `HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART` | unset | Skip startup gateway checks/autostart. Set `1`, `true`, `yes`, or `on` for dashboard-only deployments where another service owns Hermes gateway lifecycle. |
-| `HERMES_WEB_UI_DISABLE_SKILL_INJECTION` | unset | Skip startup bundled skill injection. Set `1`, `true`, `yes`, or `on` when bundled skills are managed outside Hermes Web UI. When injection is enabled, Web UI updates only skills it previously installed or identical existing bundled copies; local edits and user-owned same-name skills are skipped. |
-| `HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN` | enabled in production | Controls whether Web UI shutdown also stops managed gateway processes. Set `0` or `false` to detach them. |
+| `HERMES_WEB_UI_DISABLE_SKILL_INJECTION` | unset | Skip startup bundled skill injection. Set `1`, `true`, `yes`, or `on` when bundled skills are managed outside Studio. When injection is enabled, Studio updates only skills it previously installed or identical existing bundled copies; local edits and user-owned same-name skills are skipped. |
+| `HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN` | enabled in production | Controls whether Studio shutdown also stops managed gateway processes. Set `0` or `false` to detach them. |
 | `HERMES_GATEWAY_URL` / `GATEWAY_URL` | unset | Explicit Hermes gateway upstream URL for proxy routes. |
 | `GATEWAY_HOST` | `127.0.0.1` | Default Hermes gateway upstream host for proxy routes. |
 | `GATEWAY_PORT` | `8642` | Default Hermes gateway upstream port for proxy routes. |
@@ -397,7 +417,7 @@ These variables configure Hermes Web UI, its local Hermes runtime integration, a
 | `hermes-web-ui update` / `upgrade` | Update to the latest version and restart |
 | `hermes-web-ui version` / `-v` | Show the version |
 | `hermes-web-ui -h` | Show help |
-| `hermes-web-ui-mcp [api\|browser\|devices\|use]` | Run one managed Web UI MCP toolset (same as `hermes-studio-mcp`) |
+| `hermes-web-ui-mcp [api\|browser\|devices\|use]` | Run one managed Studio MCP toolset (same as `hermes-studio-mcp`) |
 
 Add `--no-open` to `start` or `client` when no browser should open.
 
@@ -409,7 +429,7 @@ Add `--no-open` to `start` or `client` when no browser should open.
 
 On startup the BFF server automatically:
 
-- Initializes Web UI data directories, local databases, and bundled skills
+- Initializes Studio data directories, local databases, and bundled skills
 - Starts the Hermes agent bridge used by `/chat-run`
 - Opens a browser on successful startup unless `--no-open` is set
 
@@ -419,7 +439,7 @@ On startup the BFF server automatically:
 
 ```bash
 git clone https://github.com/EKKOLearnAI/hermes-studio.git
-cd hermes-web-ui
+cd hermes-studio
 npm install
 npm run dev
 ```
@@ -428,38 +448,52 @@ npm run dev
 - BFF Server: http://localhost:8647
 
 ```bash
+npm run harness:check
+npm run test
 npm run build   # outputs to dist/
 ```
 
-See [DEVELOPMENT.md](./DEVELOPMENT.md) for project development guidelines.
+See [DEVELOPMENT.md](./DEVELOPMENT.md) for contributor commands and
+[ARCHITECTURE.md](./ARCHITECTURE.md) for the complete package and state model.
 
 ## Architecture
 
-```
-Browser → BFF (Koa, :8648) → Socket.IO /chat-run
-                ↓
-        Hermes agent bridge → Hermes Agent runtime
-                ↓
-           Hermes CLI / profiles
-           profile config.yaml    (channel/provider behavior)
-           profile auth.json      (credential pool)
-           Tencent iLink API      (WeChat QR login)
+```text
+Browser / Desktop / App
+          │ HTTP + Socket.IO
+          ▼
+Koa bootstrap (composition only)
+          │
+          ├─ Studio platform ── chat, groups, global agent, workflows,
+          │                    sessions, files, voice, devices, webhooks
+          ├─ Hermes family ─── profiles, models, skills, memory, jobs,
+          │                    Kanban, channels, terminal, Hermes bridge
+          ├─ Ekko family ───── Ekko runtime and agent-owned services
+          └─ Coding family ─── Claude Code, Codex, and Pi adapters
 ```
 
-The frontend is designed with **multi-agent extensibility** — all Hermes-specific code is namespaced under `hermes/` directories (API, components, views, stores), making it straightforward to add new agent integrations alongside.
+The server is organized by business ownership under
+`packages/server/src/modules/{studio,hermes,ekko,coding-agents}`. Routes stay
+thin, controllers own HTTP concerns, services own reusable behavior, and only
+`packages/server/src/bootstrap` may compose concrete modules and adapters.
+Cross-agent code belongs to Studio; an agent module must not absorb a shared
+product surface merely because it uses that agent today.
 
-The BFF layer handles Socket.IO chat streaming, the Hermes agent bridge, profile-aware file upload and path-based download (multi-backend: local/Docker/SSH/Singularity), session CRUD, account- and profile-scoped management, config/credential management, WeChat QR login, model discovery, skills/memory/plugin management, TTS/STT, coding-agent proxies, MCP/runtime management, log reading, and static file serving.
+Studio state and Hermes Agent state remain separate. Studio defaults to
+`~/.hermes-web-ui`; Hermes profile data remains under the Hermes home. For the
+full ownership tree, dependency rules, and API migration contract, see
+[`docs/harness/server-module-boundaries.md`](./docs/harness/server-module-boundaries.md).
 
 ## Tech Stack
 
 **Frontend:** Vue 3 + TypeScript + Vite + Naive UI + Pinia + Vue Router + vue-i18n + SCSS + markdown-it + highlight.js
 
-**Backend:** Koa 2 (BFF server) + node-pty (web terminal)
+**Backend:** Koa 2 + Socket.IO + SQLite + node-pty
 
 ## License
 
 [BSL-1.1](./LICENSE)
 
-The license covers Hermes Studio, the former Hermes Web UI name, the
-`hermes-web-ui` npm package and CLI, desktop applications, firmware, release
+The license covers Hermes Studio, the `hermes-web-ui` npm package and CLI,
+desktop applications, firmware, release
 artifacts, documentation, and associated files in this repository.

--- a/README_zh.md
+++ b/README_zh.md
@@ -4,9 +4,9 @@
 </p>
 
 <p align="center">
-  面向 <a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a> 的桌面应用、本地运行时和 Web 控制台。<br/>
-  Agent 对话、可视化工作流、模型与 Profile 管理、网页浏览、<br/>
-  Coding Agent 和本地运行环境都在一个界面中完成。
+  面向 <a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a>、Ekko、Claude Code、Codex 和 Pi 的<br/>
+  多 Agent 桌面应用、本地运行时和 Web 控制台。<br/>
+  在一个本地优先的工作区中完成聊天、群聊、工作流、编码任务、语音、文件和设备管理。
 </p>
 
 <p align="center">
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <img src="https://github.com/EKKOLearnAI/hermes-studio/blob/main/packages/client/src/assets/image.gif" alt="Hermes Web UI 演示" width="680"/>
+  <img src="https://github.com/EKKOLearnAI/hermes-studio/blob/main/packages/client/src/assets/image.gif" alt="Hermes Studio 演示" width="680"/>
 </p>
 
 <p align="center">
@@ -39,19 +39,37 @@
 
 | 模块 | Hermes Studio 能做什么 |
 |---|---|
-| Agent 聊天 | 运行 Hermes Agent 对话，支持流式回复、工具调用轨迹、生成文件预览、本地持久化会话和桌面独立聊天窗口。 |
-| 本地控制台 | 在一个仪表盘中管理 Profile、Provider、模型、凭证、记忆、技能、插件、日志和运行时设置。 |
-| 自动化 | 构建可执行的可视化工作流，并围绕同一套 Hermes Profile 配置平台渠道、Cron 任务、Kanban 任务、群聊房间和 MCP Server。 |
+| 多 Agent 运行时 | 运行 Hermes、Ekko、Claude Code、Codex 和 Pi，支持流式回复、工具调用轨迹、生成文件预览、持久化会话和桌面独立聊天窗口。 |
+| Studio 工作区 | 为不同 Agent 运行时提供统一的单聊、群聊、Global Agent、工作流、文件、语音、媒体、设备、主题、日志、用量和 App 连接能力。 |
+| Agent 控制面 | 将 Hermes 的 Profile、Provider、模型、记忆、技能、插件、任务、Kanban、渠道和运行时管理保留在对应的 Agent 模块内。 |
+| 自动化 | 构建可执行的可视化工作流，通过定时任务、审批节点、群聊房间、平台渠道和 MCP Server 连接五种运行时。 |
 | 工作区工具 | 提供文件浏览器、Web 终端、桌面 Agent 浏览器、语音输入输出、Coding Agent、设备发现、学习轨迹和性能视图。 |
 | 分发形态 | 支持 Windows/macOS/Linux 桌面应用、npm CLI 包和 Docker 镜像。 |
+
+## Agent 与平台边界
+
+Hermes Studio 是所有 Agent 共用的产品平台，不是第六种 Agent。当前五种
+具体运行时归入三个 Agent Family：
+
+| Agent Family | 运行时 | 负责的能力 |
+|---|---|---|
+| Hermes | Hermes | Profile、Provider、模型、技能、插件、记忆、任务、Kanban、渠道、MCP、终端和 Hermes Runtime 集成。 |
+| Ekko | Ekko | Ekko 执行、审批、澄清、记忆、MCP 和 Provider Runtime。 |
+| Coding | Claude Code、Codex、Pi | Coding Agent 的安装、配置、代理、会话和进程执行。 |
+
+Studio 负责三个 Family 共用的能力：单聊、群聊、Global Agent 编排、工作流、
+Webhook、会话、文件与上传、TTS/STT、媒体、宠物、主题、设备、网络、日志、
+用量、认证和 App 连接。Studio 所有的 HTTP API 使用 `/api/studio/*`，
+Hermes 控制面 API 使用 `/api/hermes/*`。已经发布的旧版移动 App 路径由
+一个集中兼容层处理，不再保留重复的旧 Controller。
 
 ## 功能特性
 
 ### AI 聊天
 
-- 聊天前端通过 Socket.IO `/chat-run` 实时流式更新；聊天运行通过 Hermes agent bridge 执行
+- 聊天前端通过 Socket.IO `/chat-run` 实时流式更新；Studio 通过运行时适配器将任务分发给 Hermes、Ekko、Claude Code、Codex 或 Pi
 - 多会话管理 — 创建、重命名、删除、切换会话
-- **自建会话数据库** — Web UI 会话使用本地 SQLite；Hermes state.db 仅作为只读来源用于 Hermes 历史 API
+- **自建会话数据库** — Studio 会话使用本地 SQLite；Hermes state.db 仅作为只读来源用于 Hermes 历史 API
 - 按来源分组会话（Telegram、Discord、Slack 等），可折叠手风琴面板
 - 活跃会话实时指示器 — 正在进行的会话置顶并显示旋转图标
 - 按最新消息时间排序会话列表
@@ -60,7 +78,7 @@
 - 按 Profile 隔离的文件上传、剪贴板图片/文件粘贴和工作区附件
 - 文件下载支持 — 按解析后的路径下载用户上传文件和 Agent 生成文件，兼容 local、Docker、SSH、Singularity 等多种 terminal backend
 - 可直接预览 Agent 生成的 HTML、PDF、DOCX、PPTX、XLSX、CSV、图片、Markdown 和源码文件
-- 会话搜索 — Ctrl+K 搜索 Web UI 本地会话库；不包含只读 Hermes 历史会话
+- 会话搜索 — Ctrl+K 搜索 Studio 本地会话库；不包含只读 Hermes 历史会话
 - 会话分类、消息引用、压缩进度和可持久恢复的后台委派结果
 - 按账号授权 Profile 汇总模型选择器 — 只展示当前账号可访问的 Hermes Profile 中可用的模型
 - 每个会话显示模型标签和上下文 Token 用量
@@ -104,11 +122,11 @@
 
 - 按 Profile 管理的 Kanban 看板，用于规划和跟踪 Agent 工作
 - 可在仪表盘中创建任务、更新任务并移动状态
-- 复用 Web UI 本地状态和认证体系
+- 复用 Studio 本地状态和认证体系
 
 ### 可视化工作流
 
-- 基于 Vue Flow 的画布，支持 Hermes、Codex 和 Claude Code 节点以及文件/图片附件
+- 基于 Vue Flow 的画布，支持 Hermes、Ekko、Claude Code、Codex、Pi 节点以及文件/图片附件
 - 支持有向连线、结构化条件、成功/失败路由、循环和审批门
 - 工作流定义可导入/导出，并支持按 Profile 管理工作区
 - 支持运行预算、截止时间、停止、重跑和持久化执行历史
@@ -153,7 +171,7 @@
 
 ### Coding Agents
 
-- 在仪表盘中安装、配置、启动和监控 Claude Code 与 Codex
+- 在仪表盘中安装、配置、启动和监控 Claude Code、Codex 与 Pi
 - 内置 Coding Agent 终端、会话历史、工作区选择、图片输入和文件 Diff
 - 提供独立代理路由和 API 模式，适配不同 Provider/模型
 - 支持桌面独立聊天窗口，并持久化输出和 reasoning 元数据
@@ -203,14 +221,14 @@ CLI 维护命令：
 # 删除持久化的登录 IP 锁记录
 hermes-web-ui clear-login-locks
 
-# 删除登录锁并重启正在运行的 Web UI 进程
+# 删除登录锁并重启正在运行的 Studio 服务
 hermes-web-ui clear-login-locks --restart
 
 # 创建或重置默认超级管理员登录名/密码为 admin / 123456
 hermes-web-ui reset-default-login
 ```
 
-`clear-login-locks` 会删除 `${HERMES_WEB_UI_HOME:-~/.hermes-web-ui}/.login-lock.json`。如果服务正在运行，需要重启服务才能清理内存中的锁定状态。`reset-default-login` 会更新 Web UI 账户数据库；如果已存在 `admin` 用户，则会把密码重置为 `123456`，并启用为超级管理员账户。
+`clear-login-locks` 会删除 `${HERMES_WEB_UI_HOME:-~/.hermes-web-ui}/.login-lock.json`。如果服务正在运行，需要重启服务才能清理内存中的锁定状态。`reset-default-login` 会更新 Studio 账户数据库；如果已存在 `admin` 用户，则会把密码重置为 `123456`，并启用为超级管理员账户。
 
 ### 设置
 
@@ -243,7 +261,7 @@ hermes-web-ui reset-default-login
 ### 桌面应用与自动更新
 
 - Windows、macOS 和 Linux 原生 Electron 桌面壳
-- 内置 Web UI 运行时，并自动启动本地 Hermes Studio 服务
+- 内置 Studio 运行时，并自动启动本地服务
 - 桌面自动更新优先使用 Cloudflare 下载端点获取更新元数据和安装包
 - 如果 Cloudflare 更新源不可用，会回退到 GitHub Releases `latest` 资源
 - Windows 升级时会先尝试关闭已有 Hermes Studio 进程，再替换文件
@@ -258,16 +276,16 @@ hermes-web-ui reset-default-login
 下载最新的 **Hermes Studio** 桌面安装包。
 
 桌面版会发布 macOS、Windows 和 Linux 构建；适用时会区分不同 CPU 架构。
-桌面应用内置 Web UI 运行时，Hermes Agent 数据会保存到原生 Hermes 目录：
+桌面应用内置 Studio 运行时，Hermes Agent 数据会保存到原生 Hermes 目录：
 
 - Windows：`%LOCALAPPDATA%\hermes`（找不到时回退到 `%APPDATA%\hermes`）
 - macOS/Linux：`~/.hermes`
 
-桌面壳自身的 Web UI 状态会单独保存到 `~/.hermes-web-ui`，除非设置了
+桌面壳自身的 Studio 状态会单独保存到 `~/.hermes-web-ui`，除非设置了
 `HERMES_WEB_UI_HOME`。
 
 打包后的桌面应用启动后，会安装受管命令 shim，避免桌面应用、内置 Hermes Agent CLI
-和内置 Web UI CLI 的命令互相冲突：
+和内置服务端 CLI 的命令互相冲突：
 
 | 命令 | 说明 |
 |---|---|
@@ -275,10 +293,10 @@ hermes-web-ui reset-default-login
 | `hermes-studio cli ...` | 运行内置 Hermes Agent CLI |
 | `hermes-studio web ...` | 运行内置 `hermes-web-ui` 命令 |
 | `hermes-studio -h` | 显示 wrapper 帮助 |
-| `hermes-studio-mcp [api\|browser\|devices\|use]` | 运行指定的受管 Web UI MCP 工具集 |
+| `hermes-studio-mcp [api\|browser\|devices\|use]` | 运行指定的受管 Studio MCP 工具集 |
 
 使用 `hermes-studio cli -h` 查看 Hermes Agent CLI 帮助，使用
-`hermes-studio web -h` 查看 Web UI CLI 帮助。`hermes-studio-mcp` 默认暴露
+`hermes-studio web -h` 查看服务端 CLI 帮助。`hermes-studio-mcp` 默认暴露
 `api` 工具集；按任务选择 `browser`、`devices` 或 `use`，可以缩小 MCP 暴露面。
 
 桌面自动更新会优先读取 `https://download.ekkolearnai.com/latest`。
@@ -311,7 +329,7 @@ docker compose logs -f hermes-webui
 打开 **http://localhost:6060**
 
 - Hermes 持久化数据目录：`./hermes_data`
-- Web UI 认证 Token 存储在 `./hermes_data/hermes-web-ui/.token`
+- Studio 认证 Token 存储在 `./hermes_data/hermes-web-ui/.token`
 - 首次启动并开启认证时，Token 会打印到容器日志中
 - 运行参数全部由 `docker-compose.yml` 环境变量驱动
 
@@ -319,29 +337,29 @@ docker compose logs -f hermes-webui
 
 ### Hermes Agent 运行时发现
 
-Web UI 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源码目录，例如
+Studio 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源码目录，例如
 `~/.hermes/hermes-agent`。如果找不到源码目录，会退回到已安装 `hermes` 命令所使用
 的 Python 环境，再退到系统 Python。因此源码安装和 `pip install hermes-agent` 这类
 包安装方式都可以兼容。
 
-## Web UI 环境变量
+## Studio 环境变量
 
-这些变量用于配置 Hermes Web UI、本地 Hermes runtime 集成以及开发/预览辅助能力。Provider API Key 和 Hermes Agent 相关设置通常仍通过 Hermes profile 管理；这里列出的变量是进程级覆盖项。
+这些变量用于配置 Hermes Studio、本地 Hermes Runtime 集成以及开发/预览辅助能力。Provider API Key 和 Hermes Agent 相关设置通常仍通过 Hermes Profile 管理；这里列出的变量是进程级覆盖项。
 
 | 变量 | 默认值 | 说明 |
 |---|---|---|
-| `PORT` | `8648` | Web UI 监听端口。 |
-| `BIND_HOST` | `0.0.0.0` | Web UI 绑定地址。如需 IPv6，可显式设置为 `::`。 |
+| `PORT` | `8648` | Studio 服务监听端口。 |
+| `BIND_HOST` | `0.0.0.0` | Studio 服务绑定地址。如需 IPv6，可显式设置为 `::`。 |
 | `HERMES_LAN_ADVERTISE_URL` | 未设置 | App 局域网二维码使用的可访问 Studio 地址。Docker 中若通过 `localhost` 打开，请设置为宿主机局域网 URL，例如 `http://192.168.1.20:6060`。 |
 | `HERMES_APP_ENTITLEMENT_REQUIRED` | `true` | App 局域网 Relay 必须携带有效的云端签名。仅在临时兼容排查时设置为 `false`。 |
 | `HERMES_APP_ENTITLEMENT_PUBLIC_KEY` | 内置 | 可选的 RS256 App 签名 PEM 公钥覆盖。签名 issuer 为 `hermes-studio-server`，audience 为 `ekko-studio`。 |
-| `HERMES_WEB_UI_HOME` | `~/.hermes-web-ui` | Web UI 数据目录，用于认证 token、登录凭据、日志、数据库和默认上传目录。兼容支持 `HERMES_WEBUI_STATE_DIR` 作为别名。 |
+| `HERMES_WEB_UI_HOME` | `~/.hermes-web-ui` | Studio 数据目录，用于认证 Token、登录凭据、日志、数据库和默认上传目录。兼容支持 `HERMES_WEBUI_STATE_DIR` 作为别名。 |
 | `HERMES_WEBUI_STATE_DIR` | 未设置 | `HERMES_WEB_UI_HOME` 的兼容别名。 |
 | `HERMES_WEB_UI_DISABLE_MCP_AUTOINJECT` | 未设置 | 关闭启动时向 Hermes profile 配置自动注入托管的 `hermes-studio` MCP server。 |
 | `HERMES_WEB_UI_ALLOW_TRANSIENT_MCP_AUTOINJECT` | 未设置 | 当 `HERMES_WEB_UI_HOME` 位于临时目录（例如 Version Preview runtime）时，仍允许托管 MCP 自动注入。 |
 | `UPLOAD_DIR` | `$HERMES_WEB_UI_HOME/upload` | 覆盖上传根目录。文件会保存在按 Profile 隔离的子目录下。 |
 | `CORS_ORIGINS` | 仅同 host | HTTP、Socket.IO、WebSocket 跨源 allowlist，支持逗号或空格分隔。只有明确需要旧版 wildcard CORS 时才设置为 `*`。 |
-| `AUTH_TOKEN` | 自动生成 | 显式指定 bearer token。未设置时，Web UI 会在 `HERMES_WEB_UI_HOME` 下自动生成。 |
+| `AUTH_TOKEN` | 自动生成 | 显式指定 Bearer Token。未设置时，Studio 会在 `HERMES_WEB_UI_HOME` 下自动生成。 |
 | `AUTH_JWT_SECRET` | `AUTH_TOKEN` | 用户名/密码会话的 JWT 签名密钥覆盖。 |
 | `HERMES_WEB_UI_AUTH_JWT_EXPIRES_IN` | `30d` | 用户名/密码会话 JWT 有效期。支持秒数或 `s`/`m`/`h`/`d` 后缀，例如 `12h` 或 `7d`。 |
 | `PROFILE` | `default` | 启动/默认 Hermes profile。运行时请求使用前端当前选择且当前账号有权限访问的 Profile。 |
@@ -361,7 +379,7 @@ Web UI 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源
 | `HERMES_AGENT_BRIDGE_TIMEOUT_MS` | `120000` | Node 请求 bridge broker 的响应超时。 |
 | `HERMES_AGENT_BRIDGE_CONNECT_RETRY_MS` | `5000` | 连接 bridge socket 失败时的短重试窗口。 |
 | `HERMES_AGENT_BRIDGE_STARTUP_TIMEOUT_MS` | `120000` | 等待 Python bridge ready 的超时。 |
-| `HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN` | 开启 | Web UI 关闭和重启时是否停止 bridge broker；设为 `0`、`false`、`no` 或 `off` 才会在重启时保留 broker。 |
+| `HERMES_AGENT_BRIDGE_STOP_ON_SHUTDOWN` | 开启 | Studio 关闭和重启时是否停止 Bridge Broker；设为 `0`、`false`、`no` 或 `off` 才会在重启时保留 Broker。 |
 | `HERMES_AGENT_BRIDGE_AUTO_RESTART` | 开启 | bridge broker 意外退出后是否自动重启；设为 `0`、`false`、`no` 或 `off` 可关闭。 |
 | `HERMES_AGENT_BRIDGE_RESTART_DELAY_MS` | `1000` | bridge 自动重启退避的基础延迟。 |
 | `HERMES_AGENT_BRIDGE_PLATFORM` | `cli` | 传给 Hermes Agent 的 platform 标识。 |
@@ -372,12 +390,12 @@ Web UI 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源
 | `HERMES_BRIDGE_MAX_TURNS` | profile/默认值 | bridge 运行时的最大轮数覆盖。 |
 | `HERMES_BRIDGE_SUPPRESS_PLATFORM_HINT` | `cli` | 控制传给 Hermes Agent 的 bridge platform hint suppression。 |
 | `HERMES_OPENROUTER_APP_REFERER` | `https://hermes-studio.ai` | bridge 运行发送给 OpenRouter 的 attribution referer。 |
-| `HERMES_OPENROUTER_APP_TITLE` | `Hermes Web UI` | bridge 运行发送给 OpenRouter 的 attribution title。 |
+| `HERMES_OPENROUTER_APP_TITLE` | `Hermes Studio` | Bridge 运行发送给 OpenRouter 的 Attribution Title。 |
 | `HERMES_OPENROUTER_APP_CATEGORIES` | `cli-agent,personal-agent` | bridge 运行发送给 OpenRouter 的 attribution categories。 |
-| `HERMES_WEB_UI_MANAGED_GATEWAY` | 默认开启 | 控制 Web UI 托管 Hermes gateway 进程；设为 `0`、`false`、`no` 或 `off` 时改用 `hermes gateway start`。 |
+| `HERMES_WEB_UI_MANAGED_GATEWAY` | 默认开启 | 控制 Studio 托管 Hermes Gateway 进程；设为 `0`、`false`、`no` 或 `off` 时改用 `hermes gateway start`。 |
 | `HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART` | 未设置 | 跳过启动时的 gateway 检查/自动启动；dashboard-only 部署中如果由其它服务管理 Hermes gateway，可设为 `1`、`true`、`yes` 或 `on`。 |
-| `HERMES_WEB_UI_DISABLE_SKILL_INJECTION` | 未设置 | 跳过启动时的内置 skill 注入；如果内置 skills 由 Hermes Web UI 外部管理，可设为 `1`、`true`、`yes` 或 `on`。启用注入时，Web UI 只更新自己此前安装的 skills 或内容完全相同的既有内置副本；本地修改和用户拥有的同名 skills 会跳过。 |
-| `HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN` | 生产环境默认开启 | Web UI 关闭时是否同时停止托管的 gateway 进程；设为 `0` 或 `false` 可让 gateway 分离运行。 |
+| `HERMES_WEB_UI_DISABLE_SKILL_INJECTION` | 未设置 | 跳过启动时的内置 Skill 注入；如果内置 Skills 由 Studio 外部管理，可设为 `1`、`true`、`yes` 或 `on`。启用注入时，Studio 只更新自己此前安装的 Skills 或内容完全相同的既有内置副本；本地修改和用户拥有的同名 Skills 会跳过。 |
+| `HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN` | 生产环境默认开启 | Studio 关闭时是否同时停止托管的 Gateway 进程；设为 `0` 或 `false` 可让 Gateway 分离运行。 |
 | `GATEWAY_HOST` | `127.0.0.1` | 旧 gateway 兼容配置中写入 profile 的默认 gateway host。 |
 | `HERMES_WEB_UI_PREVIEW_REPO` | package repository | Version Preview 使用的 GitHub 仓库。 |
 | `HERMES_WEB_UI_PREVIEW_AGENT_BRIDGE_TRANSPORT` | 平台默认值 | Version Preview broker transport。设为 `tcp` 可让预览环境在 macOS/Linux 上也使用 loopback TCP；未设置时会跟随 `HERMES_AGENT_BRIDGE_WORKER_TRANSPORT=tcp`。 |
@@ -399,7 +417,7 @@ Web UI 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源
 | `hermes-web-ui update` / `upgrade` | 更新到最新版本并重启 |
 | `hermes-web-ui version` / `-v` | 显示版本号 |
 | `hermes-web-ui -h` | 显示帮助信息 |
-| `hermes-web-ui-mcp [api\|browser\|devices\|use]` | 运行一个受管 Web UI MCP 工具集（等同于 `hermes-studio-mcp`） |
+| `hermes-web-ui-mcp [api\|browser\|devices\|use]` | 运行一个受管 Studio MCP 工具集（等同于 `hermes-studio-mcp`） |
 
 如不希望自动打开浏览器，可在 `start` 或 `client` 后添加 `--no-open`。
 
@@ -411,7 +429,7 @@ Web UI 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源
 
 启动时 BFF 服务器会自动：
 
-- 初始化 Web UI 数据目录、本地数据库和内置技能
+- 初始化 Studio 数据目录、本地数据库和内置技能
 - 启动 `/chat-run` 使用的 Hermes agent bridge
 - 启动成功后自动打开浏览器；设置 `--no-open` 时跳过
 
@@ -421,7 +439,7 @@ Web UI 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源
 
 ```bash
 git clone https://github.com/EKKOLearnAI/hermes-studio.git
-cd hermes-web-ui
+cd hermes-studio
 npm install
 npm run dev
 ```
@@ -430,37 +448,50 @@ npm run dev
 - BFF 服务器：http://localhost:8647
 
 ```bash
+npm run harness:check
+npm run test
 npm run build   # 构建输出到 dist/
 ```
 
-项目开发规范见：[DEVELOPMENT.md](./DEVELOPMENT.md)。
+贡献命令见 [DEVELOPMENT.md](./DEVELOPMENT.md)，完整的 Package 与状态模型见
+[ARCHITECTURE.md](./ARCHITECTURE.md)。
 
 ## 架构
 
-```
-浏览器 → BFF (Koa, :8648) → Socket.IO /chat-run
-                ↓
-        Hermes agent bridge → Hermes Agent runtime
-                ↓
-           Hermes CLI / profiles
-           profile config.yaml    (渠道/Provider 配置)
-           profile auth.json      (凭证池)
-           腾讯 iLink API         (微信扫码登录)
+```text
+浏览器 / Desktop / App
+          │ HTTP + Socket.IO
+          ▼
+Koa Bootstrap（仅负责组装）
+          │
+          ├─ Studio 平台 ── 单聊、群聊、Global Agent、工作流、
+          │                 会话、文件、语音、设备、Webhook
+          ├─ Hermes Family ─ Profile、模型、技能、记忆、任务、
+          │                  Kanban、渠道、终端、Hermes Bridge
+          ├─ Ekko Family ─── Ekko Runtime 与 Agent 自有服务
+          └─ Coding Family ─ Claude Code、Codex、Pi 适配器
 ```
 
-前端采用 **多 Agent 可扩展架构** — 所有 Hermes 相关代码都按命名空间组织在 `hermes/` 目录下（API、组件、视图、Store），可以方便地并行接入新的 Agent。
+服务端按业务归属组织在
+`packages/server/src/modules/{studio,hermes,ekko,coding-agents}`。Route 保持轻量，
+Controller 处理 HTTP 关注点，Service 负责可复用业务行为，只有
+`packages/server/src/bootstrap` 可以组装具体模块和 Adapter。跨 Agent 的能力归
+Studio；不能因为某项公共功能当前使用 Hermes，就把它放进 Hermes 模块。
 
-BFF 层负责：Socket.IO 聊天流式推送、Hermes agent bridge、按 Profile 隔离的上传和按路径解析的下载（多 Backend 支持：local/Docker/SSH/Singularity）、会话 CRUD、分账户分 Profile 管理、配置/凭证管理、微信扫码登录、模型发现、技能/记忆/插件管理、TTS/STT、Coding Agent 代理、MCP/Runtime 管理、日志读取和静态文件服务。
+Studio 状态与 Hermes Agent 状态彼此独立。Studio 默认使用
+`~/.hermes-web-ui`，Hermes Profile 数据仍保存在 Hermes Home 下。完整目录归属、
+依赖规则和 API 迁移约束见
+[`docs/harness/server-module-boundaries.md`](./docs/harness/server-module-boundaries.md)。
 
 ## 技术栈
 
 **前端：** Vue 3 + TypeScript + Vite + Naive UI + Pinia + Vue Router + vue-i18n + SCSS + markdown-it + highlight.js
 
-**后端：** Koa 2（BFF 服务器）+ node-pty（Web 终端）
+**后端：** Koa 2 + Socket.IO + SQLite + node-pty
 
 ## 许可证
 
 [BSL-1.1](./LICENSE)
 
-该许可证覆盖 Hermes Studio、原 Hermes Web UI 名称、`hermes-web-ui` npm 包和
-CLI、桌面应用、固件、发布产物、文档以及本仓库内的关联文件。
+该许可证覆盖 Hermes Studio、`hermes-web-ui` npm 包和 CLI、桌面应用、
+固件、发布产物、文档以及本仓库内的关联文件。


### PR DESCRIPTION
## Summary

- rewrite the English and Chinese introductions around Hermes Studio as a five-runtime, three-family multi-agent platform
- document the Studio/Hermes/Ekko/Coding ownership boundary and canonical `/api/studio/*` versus `/api/hermes/*` API split
- replace the outdated single-Hermes BFF diagram with the current module/bootstrap architecture
- remove the old “Hermes Web UI” / “Web UI” product wording while retaining real compatibility identifiers such as the `hermes-web-ui` npm package, CLI, data directory, and `HERMES_WEB_UI_*` environment variables
- refresh workflow, coding-agent, development, validation, and technology descriptions in both README files

## Impact

Documentation only. Runtime behavior, APIs, package names, CLI commands, and environment-variable names are unchanged.

## Validation

- `npm run harness:check`
- `git diff --check`
- verified that `README.md` and `README_zh.md` contain no old `Hermes Web UI` or generic `Web UI` product descriptions
