### PR TITLE
[codex] preserve legacy MCU API routes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,7 +46,7 @@ ownership decisions, allowed dependency matrix, and migration rules.
 - Module `controllers/` handle request-level behavior.
 - Module `services/` own reusable IO, domain behavior, processes, and integrations.
 - Studio `repositories/` and `infrastructure/` own application persistence.
-- Studio `middleware/legacy-app-api.ts` is the only old-App URL compatibility map.
+- Studio `middleware/legacy-app-api.ts` is the only released App and MCU firmware URL compatibility map.
 
 Architecture rules:
 

--- a/docs/harness/server-module-boundaries.md
+++ b/docs/harness/server-module-boundaries.md
@@ -5,7 +5,7 @@ separates Studio-owned capabilities from the three agent families while
 preserving request/response semantics and persisted data. Studio-owned HTTP
 operations use `/api/studio/*`; Hermes-owned operations use `/api/hermes/*`.
 Old server source trees are not retained. The only old Studio URL aliases are
-the centralized compatibility mappings for already-released App versions in
+the centralized compatibility mappings for already-released App and MCU firmware versions in
 `modules/studio/middleware/legacy-app-api.ts`.
 
 All server TypeScript source lives under `modules/` or `bootstrap/`, except the
@@ -76,7 +76,7 @@ packages/server/src/
       middleware/
         auth.ts
         errors.ts
-        legacy-app-api.ts          # temporary old-App URL mapping only
+        legacy-app-api.ts          # temporary released App and MCU firmware URL mapping only
         request-context.ts
       http/
         body.ts
@@ -387,7 +387,7 @@ Preserve behavior while moving ownership:
    repository/adapter, socket, Client API, and focused tests.
 5. Do not add compatibility re-exports or legacy source trees. Old HTTP aliases
    are allowed only in `modules/studio/middleware/legacy-app-api.ts` for released
-   App versions; current clients must migrate to canonical URLs in the same change.
+   App and MCU firmware versions; current clients must migrate to canonical URLs in the same change.
 
 ## Mechanical Harness
 

--- a/packages/server/src/modules/studio/middleware/legacy-app-api.ts
+++ b/packages/server/src/modules/studio/middleware/legacy-app-api.ts
@@ -3,9 +3,10 @@ import type { Middleware } from 'koa'
 type LegacyAppApiPrefix = readonly [legacy: string, canonical: string]
 
 /**
- * Compatibility for App versions released before Studio-owned APIs moved out
- * of /api/hermes. Keep every legacy App alias in this table; new callers must
- * use the canonical /api/studio paths directly.
+ * Compatibility for released clients that predate Studio-owned APIs moving
+ * out of /api/hermes. This includes old App versions and MCU firmware that
+ * must still reach its legacy OTA manifest. New callers must use canonical
+ * /api/studio paths directly.
  */
 export const LEGACY_APP_API_PREFIXES: readonly LegacyAppApiPrefix[] = Object.freeze([
   ['/api/hermes/session-categories', '/api/studio/session-categories'],
@@ -21,6 +22,7 @@ export const LEGACY_APP_API_PREFIXES: readonly LegacyAppApiPrefix[] = Object.fre
   ['/api/hermes/files', '/api/studio/files'],
   ['/api/hermes/usage', '/api/studio/usage'],
   ['/api/hermes/logs', '/api/studio/logs'],
+  ['/api/hermes/mcu', '/api/studio/mcu'],
   ['/api/hermes/stt', '/api/studio/stt'],
   ['/api/hermes/tts', '/api/studio/tts'],
 ])

--- a/scripts/server-module-boundaries.mjs
+++ b/scripts/server-module-boundaries.mjs
@@ -35,6 +35,7 @@ const LEGACY_STUDIO_API_PREFIXES = [
   '/api/hermes/files',
   '/api/hermes/usage',
   '/api/hermes/logs',
+  '/api/hermes/mcu',
   '/api/hermes/stt',
   '/api/hermes/tts',
 ]
@@ -102,7 +103,7 @@ export function legacyAppAliasFailure(file, source) {
   if (normalized === LEGACY_APP_COMPATIBILITY_FILE) return null
   const legacyPrefix = LEGACY_STUDIO_API_PREFIXES.find(prefix => source.includes(prefix))
   if (!legacyPrefix) return null
-  return `${normalized} declares legacy Studio API ${legacyPrefix}; keep App aliases in ${LEGACY_APP_COMPATIBILITY_FILE}`
+  return `${normalized} declares legacy Studio API ${legacyPrefix}; keep released-client aliases in ${LEGACY_APP_COMPATIBILITY_FILE}`
 }
 
 export function collectModuleSpecifiers(source, fileName = 'source.ts') {

--- a/tests/server/legacy-app-api.test.ts
+++ b/tests/server/legacy-app-api.test.ts
@@ -19,6 +19,17 @@ describe('legacy App API compatibility', () => {
       .toBe('/api/studio/files/download?path=%2Ftmp%2Fa.png&profile=default')
   })
 
+  it('keeps released MCU firmware on voice, audio, and OTA endpoints', () => {
+    expect(canonicalLegacyAppPath('/api/hermes/mcu/voice-turn'))
+      .toBe('/api/studio/mcu/voice-turn')
+    expect(canonicalLegacyAppPath('/api/hermes/mcu/audio/token-invalid-24k.s16le.pcm'))
+      .toBe('/api/studio/mcu/audio/token-invalid-24k.s16le.pcm')
+    expect(canonicalLegacyAppPath('/api/hermes/mcu/firmware/v1/manifest'))
+      .toBe('/api/studio/mcu/firmware/v1/manifest')
+    expect(canonicalLegacyAppPath('/api/hermes/mcu/firmware.bin'))
+      .toBe('/api/studio/mcu/firmware.bin')
+  })
+
   it('does not rewrite capabilities still owned by Hermes', () => {
     for (const path of [
       '/api/hermes/jobs',

--- a/tests/server/server-module-boundaries.test.ts
+++ b/tests/server/server-module-boundaries.test.ts
@@ -77,11 +77,11 @@ describe('server module boundary harness', () => {
     expect(studioOwnershipFailure('modules/hermes/services/profiles/app-profile-avatar.ts')).toBeNull()
   })
 
-  it('keeps legacy App aliases in the single Studio compatibility middleware', () => {
+  it('keeps released-client aliases in the single Studio compatibility middleware', () => {
     expect(legacyAppAliasFailure(
       'modules/studio/routes/sessions.ts',
       "routes.get('/api/hermes/sessions', controller)",
-    )).toContain('keep App aliases in modules/studio/middleware/legacy-app-api.ts')
+    )).toContain('keep released-client aliases in modules/studio/middleware/legacy-app-api.ts')
     expect(legacyAppAliasFailure(
       'modules/studio/middleware/legacy-app-api.ts',
       "['/api/hermes/sessions', '/api/studio/sessions']",
@@ -90,6 +90,10 @@ describe('server module boundary harness', () => {
       'modules/hermes/routes/jobs.ts',
       "routes.get('/api/hermes/jobs', controller)",
     )).toBeNull()
+    expect(legacyAppAliasFailure(
+      'modules/studio/routes/mcu-firmware.ts',
+      "routes.get('/api/hermes/mcu/firmware.bin', controller)",
+    )).toContain('keep released-client aliases in modules/studio/middleware/legacy-app-api.ts')
   })
 
   it('keeps controllers and services pointed down the layer graph', () => {


### PR DESCRIPTION
## Summary
- map legacy `/api/hermes/mcu/*` requests to canonical `/api/studio/mcu/*` routes
- keep already-flashed MCU firmware able to use voice, prompt audio, and OTA endpoints
- extend the module-boundary harness so released-client aliases remain centralized

## Impact
Existing MCU firmware can continue operating and can reach its legacy OTA manifest to upgrade. Current firmware continues using canonical Studio routes.

## Validation
- `npm run test -- tests/server/legacy-app-api.test.ts tests/server/server-module-boundaries.test.ts`
- `npm run harness:check`
- `npm run build`