### PR TITLE
Fix shutdown cleanup for Studio-owned process trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,9 @@ These variables configure Hermes Studio, its local Hermes runtime integration, a
 | `HERMES_WEB_UI_MANAGED_GATEWAY` | enabled | Controls Studio-managed Hermes gateway process handling. Set `0`, `false`, `no`, or `off` to use `hermes gateway start` instead. |
 | `HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART` | unset | Skip startup gateway checks/autostart. Set `1`, `true`, `yes`, or `on` for dashboard-only deployments where another service owns Hermes gateway lifecycle. |
 | `HERMES_WEB_UI_DISABLE_SKILL_INJECTION` | unset | Skip startup bundled skill injection. Set `1`, `true`, `yes`, or `on` when bundled skills are managed outside Studio. When injection is enabled, Studio updates only skills it previously installed or identical existing bundled copies; local edits and user-owned same-name skills are skipped. |
-| `HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN` | enabled in production | Controls whether Studio shutdown also stops managed gateway processes. Set `0` or `false` to detach them. |
+| `HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN` | enabled | Controls whether Studio shutdown also stops only the gateway processes started and tracked by this Studio process. Set `0` or `false` to detach them; externally discovered gateways are never adopted or stopped. |
+| `HERMES_WEB_UI_SHUTDOWN_FORCE_EXIT_MS` | `10000` | Short cleanup budget before Studio force-stops its owned process trees and exits. |
+| `HERMES_DESKTOP_STOP_TIMEOUT_MS` | `20000` | Desktop host's existing outer deadline before it force-stops the complete Web UI process tree; independent from the Web UI's 10-second cleanup budget. |
 | `HERMES_GATEWAY_URL` / `GATEWAY_URL` | unset | Explicit Hermes gateway upstream URL for proxy routes. |
 | `GATEWAY_HOST` | `127.0.0.1` | Default Hermes gateway upstream host for proxy routes. |
 | `GATEWAY_PORT` | `8642` | Default Hermes gateway upstream port for proxy routes. |

--- a/README_zh.md
+++ b/README_zh.md
@@ -395,7 +395,9 @@ Studio 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源
 | `HERMES_WEB_UI_MANAGED_GATEWAY` | 默认开启 | 控制 Studio 托管 Hermes Gateway 进程；设为 `0`、`false`、`no` 或 `off` 时改用 `hermes gateway start`。 |
 | `HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART` | 未设置 | 跳过启动时的 gateway 检查/自动启动；dashboard-only 部署中如果由其它服务管理 Hermes gateway，可设为 `1`、`true`、`yes` 或 `on`。 |
 | `HERMES_WEB_UI_DISABLE_SKILL_INJECTION` | 未设置 | 跳过启动时的内置 Skill 注入；如果内置 Skills 由 Studio 外部管理，可设为 `1`、`true`、`yes` 或 `on`。启用注入时，Studio 只更新自己此前安装的 Skills 或内容完全相同的既有内置副本；本地修改和用户拥有的同名 Skills 会跳过。 |
-| `HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN` | 生产环境默认开启 | Studio 关闭时是否同时停止托管的 Gateway 进程；设为 `0` 或 `false` 可让 Gateway 分离运行。 |
+| `HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN` | 默认开启 | Studio 关闭时仅停止由当前 Studio 进程启动并登记的 Gateway；设为 `0` 或 `false` 可让它们分离运行。外部探测到的 Gateway 不会被收编或关闭。 |
+| `HERMES_WEB_UI_SHUTDOWN_FORCE_EXIT_MS` | `10000` | Studio 的短暂资源清理窗口；超时后会强制结束自己持有的进程树再退出。 |
+| `HERMES_DESKTOP_STOP_TIMEOUT_MS` | `20000` | Desktop 宿主原有的整树强制结束期限，独立于 Web UI 的 10 秒清理预算。 |
 | `GATEWAY_HOST` | `127.0.0.1` | 旧 gateway 兼容配置中写入 profile 的默认 gateway host。 |
 | `HERMES_WEB_UI_PREVIEW_REPO` | package repository | Version Preview 使用的 GitHub 仓库。 |
 | `HERMES_WEB_UI_PREVIEW_AGENT_BRIDGE_TRANSPORT` | 平台默认值 | Version Preview broker transport。设为 `tcp` 可让预览环境在 macOS/Linux 上也使用 loopback TCP；未设置时会跟随 `HERMES_AGENT_BRIDGE_WORKER_TRANSPORT=tcp`。 |

--- a/packages/server/src/bootstrap/http.ts
+++ b/packages/server/src/bootstrap/http.ts
@@ -8,7 +8,7 @@ import { mkdir } from 'fs/promises'
 import { readFileSync } from 'fs'
 import { config, shouldCreateWebUiDataDir } from '../modules/studio/public/config'
 import { initLoginLimiter } from '../modules/studio/services/auth/login-limiter'
-import { bindShutdown } from './lifecycle'
+import { createShutdownHandler } from './lifecycle'
 import { setupTerminalWebSocket } from '../modules/hermes/sockets/terminal'
 import { setupKanbanEventsWebSocket } from '../modules/hermes/sockets/kanban-events'
 import { startVersionCheck } from './health'
@@ -28,7 +28,12 @@ import { HermesSkillInjector } from '../modules/hermes/services/skills/injector'
 import { injectBundledMcpServer } from '../modules/hermes/services/mcp/studio-autoinject'
 import { ensureProfileGatewaysRunning } from '../modules/hermes/services/gateway/autostart'
 import { refreshConfiguredProviderModelCatalogsInBackground } from '../modules/hermes/services/providers/model-catalog-cache'
-import { scanLanDevices, selectLanIPv4Address, startLanDiscoveryResponder } from './lan-discovery'
+import {
+  scanLanDevices,
+  selectLanIPv4Address,
+  startLanDiscoveryResponder,
+  stopLanDiscoveryResponder,
+} from './lan-discovery'
 import { getLanPeerSocketManager, getLanPeerSocketPath } from './lan-peer'
 import { startGlobalAgentServer } from '../modules/studio/public/global-agent'
 import { startLocalAppRelayServer } from '../modules/studio/services/app-relay/server'
@@ -45,7 +50,7 @@ import { createStaticCompressionMiddleware } from '../modules/studio/middleware/
 import { getStaticCacheControl, SPA_ENTRY_CACHE_CONTROL } from '../modules/studio/middleware/static-cache'
 import { requireUserJwt, resolveUserProfile } from '../modules/studio/middleware/auth'
 import { createCorsOriginResolver, securityHeaders } from '../modules/studio/middleware/security'
-import type { ShutdownHandler } from './lifecycle'
+import type { AdditionalShutdownStep, ShutdownHandler } from './lifecycle'
 import { createRequestBodyParser } from '../modules/studio/middleware/request-body-parser'
 import {
   migratePersistedPiRuntimeMcpConfigs,
@@ -58,12 +63,53 @@ const APP_VERSION = typeof __APP_VERSION__ !== 'undefined'
   ? __APP_VERSION__
   : (() => { try { return JSON.parse(readFileSync(resolve(__dirname, '../../package.json'), 'utf-8')).version } catch { return 'dev' } })()
 
-// Global error handlers
+let server: any = null
+const servers: any[] = []
+let groupChatServer: GroupChatServer | null = null
+let chatRunServer: any = null
+let workflowSocketServer: WorkflowSocketServer | null = null
+let petStateSocketServer: PetStateSocketServer | null = null
+let groupAgentRelayServer: GroupAgentRelayServer | null = null
+let agentBridgeManager: any = null
+let desktopShutdownHandler: ShutdownHandler | null = null
+let shutdownRequested = false
+const additionalShutdownSteps: AdditionalShutdownStep[] = []
+
+function getShutdownHandler(): ShutdownHandler {
+  shutdownRequested = true
+  if (!desktopShutdownHandler) {
+    desktopShutdownHandler = createShutdownHandler(
+      servers,
+      groupChatServer,
+      chatRunServer,
+      agentBridgeManager,
+      additionalShutdownSteps,
+    )
+  }
+  return desktopShutdownHandler
+}
+
+async function shutdownAfterFatal(signal: string): Promise<void> {
+  try {
+    await getShutdownHandler()(signal, 1)
+  } catch (shutdownError) {
+    logger.fatal(shutdownError, 'Fatal error while cleaning up after %s', signal)
+    process.exit(1)
+  }
+}
+
+// Install signal/error handling before bootstrap starts spawning managed
+// process trees. The shutdown handler itself is created lazily so it captures
+// every runtime that has been initialized at the point of failure.
+process.once('SIGUSR2', signal => { void getShutdownHandler()(signal) })
+process.on('SIGINT', signal => { void getShutdownHandler()(signal) })
+process.on('SIGTERM', signal => { void getShutdownHandler()(signal) })
+
 process.on('uncaughtException', (err) => {
   console.error('FATAL: Uncaught exception')
   console.error(err)
   logger.fatal(err, 'Uncaught exception')
-  process.exit(1)
+  void shutdownAfterFatal('uncaught-exception')
 })
 
 process.on('unhandledRejection', (reason) => {
@@ -71,15 +117,6 @@ process.on('unhandledRejection', (reason) => {
   console.error(reason)
   logger.error(reason, 'Unhandled rejection')
 })
-
-let server: any = null
-let servers: any[] = []
-let chatRunServer: any = null
-let workflowSocketServer: WorkflowSocketServer | null = null
-let petStateSocketServer: PetStateSocketServer | null = null
-let groupAgentRelayServer: GroupAgentRelayServer | null = null
-let agentBridgeManager: any = null
-let desktopShutdownHandler: ShutdownHandler | null = null
 
 interface ListenResult {
   primary: any
@@ -183,14 +220,16 @@ async function startRuntimeServicesBeforeListen(): Promise<void> {
   if (gatewayAutostartDisabled()) {
     console.log('[bootstrap] profile gateway check disabled by HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART')
   } else {
-    void ensureProfileGatewaysRunning()
-      .then(() => console.log('[bootstrap] profile gateways checked'))
-      .catch((err) => {
-        logger.warn(err, '[bootstrap] failed to ensure profile gateways')
-        console.warn('[bootstrap] failed to ensure profile gateways:', err instanceof Error ? err.message : err)
-      })
+    try {
+      await ensureProfileGatewaysRunning()
+      console.log('[bootstrap] profile gateways checked')
+    } catch (err) {
+      logger.warn(err, '[bootstrap] failed to ensure profile gateways')
+      console.warn('[bootstrap] failed to ensure profile gateways:', err instanceof Error ? err.message : err)
+    }
   }
 
+  if (shutdownRequested) return
   try {
     agentBridgeManager = await startAgentBridgeManager()
     console.log('[bootstrap] agent bridge started')
@@ -200,31 +239,27 @@ async function startRuntimeServicesBeforeListen(): Promise<void> {
   }
 }
 
-function startRuntimeServicesAfterListen(): void {
+async function startRuntimeServicesAfterListen(): Promise<void> {
   if (gatewayAutostartDisabled()) {
     console.log('[bootstrap] profile gateway check disabled by HERMES_WEB_UI_DISABLE_GATEWAY_AUTOSTART')
   } else {
-    void (async () => {
-      try {
-        await ensureProfileGatewaysRunning()
-        console.log('[bootstrap] profile gateways checked')
-      } catch (err) {
-        logger.warn(err, '[bootstrap] failed to ensure profile gateways')
-        console.warn('[bootstrap] failed to ensure profile gateways:', err instanceof Error ? err.message : err)
-      }
-    })()
+    try {
+      await ensureProfileGatewaysRunning()
+      console.log('[bootstrap] profile gateways checked')
+    } catch (err) {
+      logger.warn(err, '[bootstrap] failed to ensure profile gateways')
+      console.warn('[bootstrap] failed to ensure profile gateways:', err instanceof Error ? err.message : err)
+    }
   }
 
-  void (async () => {
-    try {
-      agentBridgeManager = await startAgentBridgeManager()
-      console.log('[bootstrap] agent bridge started')
-    } catch (err) {
-      logger.warn(err, '[bootstrap] agent bridge failed to start')
-      console.warn('[bootstrap] agent bridge failed to start:', err instanceof Error ? err.message : err)
-      return
-    }
-  })()
+  if (shutdownRequested) return
+  try {
+    agentBridgeManager = await startAgentBridgeManager()
+    console.log('[bootstrap] agent bridge started')
+  } catch (err) {
+    logger.warn(err, '[bootstrap] agent bridge failed to start')
+    console.warn('[bootstrap] agent bridge failed to start:', err instanceof Error ? err.message : err)
+  }
 }
 
 function startLanDiscovery(): void {
@@ -305,9 +340,11 @@ export async function bootstrap() {
   setupGlobalEkkoAgent()
   console.log('[bootstrap] ekko-agent setup complete')
 
+  agentBridgeManager = getAgentBridgeManager()
   if (!isDesktopRuntime()) {
     await startRuntimeServicesBeforeListen()
   }
+  if (shutdownRequested) return
 
   const app = new Koa()
   // Initialize all web-ui SQLite tables
@@ -351,27 +388,50 @@ export async function bootstrap() {
   // Start server using the configured bind host. Default is IPv4 for WSL stability.
   const listenResult = await listenWithFallback(app, config.port, config.host)
   server = listenResult.primary
-  servers = listenResult.servers
+  servers.splice(0, servers.length, ...listenResult.servers)
   console.log('[bootstrap] app.listen called')
 
-  setupTerminalWebSocket(servers)
-  setupKanbanEventsWebSocket(servers)
-  getLanPeerSocketManager().setupServer(servers)
+  const terminalWebSocket = setupTerminalWebSocket(servers)
+  if (terminalWebSocket) {
+    additionalShutdownSteps.push({
+      name: 'Terminal WebSocket and PTY sessions',
+      close: () => terminalWebSocket.close(),
+      forceClose: () => terminalWebSocket.forceClose(),
+    })
+  }
+  const kanbanEventsWebSocket = setupKanbanEventsWebSocket(servers)
+  additionalShutdownSteps.push({
+    name: 'Kanban event WebSocket and watchers',
+    close: () => kanbanEventsWebSocket.close(),
+    forceClose: () => kanbanEventsWebSocket.forceClose(),
+  })
+  const lanPeerSocketManager = getLanPeerSocketManager()
+  lanPeerSocketManager.setupServer(servers)
+  additionalShutdownSteps.push({
+    name: 'LAN peer WebSocket and child runtimes',
+    close: () => lanPeerSocketManager.shutdown(),
+    forceClose: () => lanPeerSocketManager.forceClose(),
+  })
   console.log('[bootstrap] terminal + kanban + LAN peer websocket setup')
 
   const loopbackBaseUrl = getLoopbackBaseUrl(server)
 
   // Group chat Socket.IO (must be after server is created)
-  const groupChatServer = new GroupChatServer(servers)
-  setGroupChatServer(groupChatServer)
-  groupAgentRelayServer = new GroupAgentRelayServer(groupChatServer.getIO(), groupChatServer)
+  const activeGroupChatServer = new GroupChatServer(servers)
+  groupChatServer = activeGroupChatServer
+  setGroupChatServer(activeGroupChatServer)
+  groupAgentRelayServer = new GroupAgentRelayServer(activeGroupChatServer.getIO(), activeGroupChatServer)
+  additionalShutdownSteps.push({
+    name: 'Group agent relay',
+    close: () => groupAgentRelayServer?.shutdown(),
+  })
 
   // Chat run Socket.IO — shares the same Server instance, just adds /chat-run namespace
-  chatRunServer = new ChatRunSocket(groupChatServer.getIO())
+  chatRunServer = new ChatRunSocket(activeGroupChatServer.getIO())
   setChatRunServer(chatRunServer)
-  groupChatServer.setChatRunService(chatRunServer)
+  activeGroupChatServer.setChatRunService(chatRunServer)
   chatRunServer.init()
-  startLocalAppRelayServer(groupChatServer.getIO(), { localBaseUrl: loopbackBaseUrl })
+  startLocalAppRelayServer(activeGroupChatServer.getIO(), { localBaseUrl: loopbackBaseUrl })
   console.log('[bootstrap] local App relay server ready')
   if (
     listAppConnections().some(connection => connection.connection_type === 'cloud')
@@ -379,7 +439,14 @@ export async function bootstrap() {
   ) {
     void ensureAppRelayHostClient().catch(err => logger.warn(err, '[app-relay] cloud host restore failed'))
   }
-  void getGroupAgentOutboundRelayManager(() => groupChatServer.getChatRunService()).restore()
+  const groupAgentOutboundRelayManager = getGroupAgentOutboundRelayManager(
+    () => activeGroupChatServer.getChatRunService(),
+  )
+  additionalShutdownSteps.push({
+    name: 'Group agent outbound relay',
+    close: () => groupAgentOutboundRelayManager.shutdown(),
+  })
+  void groupAgentOutboundRelayManager.restore()
 
   // A process restart loses in-memory scheduler, approval, and runner ownership.
   // Persist a fail-closed terminal state before exposing workflow sockets, then abort
@@ -390,15 +457,24 @@ export async function bootstrap() {
     logger.warn('Recovered %d orphaned workflow runs and aborted %d sessions', recoveredWorkflows.runs, recoveredWorkflows.sessions)
   }
   const { getWorkflowScheduleService } = await import('../modules/studio/services/workflow/schedule')
-  getWorkflowScheduleService().start()
+  const workflowScheduleService = getWorkflowScheduleService()
+  workflowScheduleService.start()
+  additionalShutdownSteps.push({
+    name: 'Workflow scheduler',
+    close: () => workflowScheduleService.stop(),
+  })
 
-  workflowSocketServer = new WorkflowSocketServer(groupChatServer.getIO())
+  workflowSocketServer = new WorkflowSocketServer(activeGroupChatServer.getIO())
   workflowSocketServer.init()
+  additionalShutdownSteps.push({
+    name: 'Workflow Socket.IO runtime',
+    close: () => workflowSocketServer?.close(),
+  })
 
-  petStateSocketServer = new PetStateSocketServer(groupChatServer.getIO())
+  petStateSocketServer = new PetStateSocketServer(activeGroupChatServer.getIO())
   petStateSocketServer.init()
 
-  startGlobalAgentServer(groupChatServer.getIO(), { localBaseUrl: loopbackBaseUrl })
+  startGlobalAgentServer(activeGroupChatServer.getIO(), { localBaseUrl: loopbackBaseUrl })
   console.log('[bootstrap] global agent server ready')
 
   // Session deleter — periodically drain pending session deletes
@@ -406,6 +482,10 @@ export async function bootstrap() {
   const sessionDeleter = SessionDeleter.getInstance()
   const activeProfile = process.env.PROFILE || 'default'
   sessionDeleter.start(activeProfile)
+  additionalShutdownSteps.push({
+    name: 'Session deleter',
+    close: () => sessionDeleter.stop(),
+  })
   console.log('[bootstrap] session deleter started, profile=%s', activeProfile)
 
   // Catch-all: destroy upgrade requests not handled by terminal or Socket.IO
@@ -427,15 +507,19 @@ export async function bootstrap() {
   console.log(`Log: ${config.appHome}/logs/server.log`)
   logger.info('Server: http://localhost:%d (LAN: http://%s:%d)', config.port, localIp, config.port)
   startLanDiscovery()
+  additionalShutdownSteps.push({
+    name: 'LAN discovery responder',
+    close: stopLanDiscoveryResponder,
+  })
   refreshConfiguredProviderModelCatalogsInBackground('bootstrap')
 
   if (isDesktopRuntime()) {
-    agentBridgeManager = getAgentBridgeManager()
-    startRuntimeServicesAfterListen()
+    await startRuntimeServicesAfterListen()
   }
+  if (shutdownRequested) return
 
   // Restore group chat agents after server is ready.
-  groupChatServer.restoreWhenReady()
+  activeGroupChatServer.restoreWhenReady()
 
   servers.forEach((httpServer) => {
     httpServer.on('error', (err: any) => {
@@ -444,7 +528,13 @@ export async function bootstrap() {
     })
   })
 
-  desktopShutdownHandler = bindShutdown(servers, groupChatServer, chatRunServer, agentBridgeManager)
+  desktopShutdownHandler = createShutdownHandler(
+    servers,
+    activeGroupChatServer,
+    chatRunServer,
+    agentBridgeManager,
+    additionalShutdownSteps,
+  )
   startVersionCheck()
 }
 
@@ -452,5 +542,5 @@ bootstrap().catch((error) => {
   console.error('FATAL: Failed to start Hermes Web UI')
   console.error(error)
   logger.fatal(error, 'Fatal error during bootstrap')
-  process.exit(1)
+  void shutdownAfterFatal('bootstrap-error')
 })

--- a/packages/server/src/bootstrap/lifecycle.ts
+++ b/packages/server/src/bootstrap/lifecycle.ts
@@ -1,5 +1,5 @@
 import { codingAgentRunManager } from '../modules/coding-agents/services/runtime/run-manager'
-import { shutdownManagedGateways } from '../modules/hermes/services/gateway/runner'
+import { forceStopManagedGateways, shutdownManagedGateways } from '../modules/hermes/services/gateway/runner'
 import { closeDb } from '../modules/studio/infrastructure/database'
 import { logger } from '../modules/studio/public/logging'
 import { shutdownLocalSttRuntime } from '../modules/studio/services/voice/stt/local-model-manager'
@@ -10,8 +10,8 @@ import { stopChatWebhookDispatcher } from '../modules/studio/services/webhooks'
 import { shutdownSocialMessageRuntimes } from '../modules/studio/services/social-messages'
 import { stopPreviewRuntime } from './update'
 
-const DEFAULT_SHUTDOWN_FORCE_EXIT_MS = 15_000
-const DEFAULT_DESKTOP_SHUTDOWN_FORCE_EXIT_MS = 15_000
+const DEFAULT_SHUTDOWN_FORCE_EXIT_MS = 10_000
+const DEFAULT_DESKTOP_SHUTDOWN_FORCE_EXIT_MS = 10_000
 
 function envPositiveInt(name: string): number | undefined {
   const value = Number(process.env[name])
@@ -41,129 +41,168 @@ export function shouldStopManagedGatewaysOnShutdown(env: NodeJS.ProcessEnv = pro
   if (['1', 'true', 'yes', 'on'].includes(raw)) return true
   if (['0', 'false', 'no', 'off'].includes(raw)) return false
 
-  return String(env.NODE_ENV || '').trim().toLowerCase() === 'production'
+  // Only gateways spawned through the managed runner are present in its
+  // ownership registry, so stopping by default cannot touch an externally
+  // managed gateway that Studio merely discovered.
+  return true
 }
 
-export type ShutdownHandler = (signal: string) => Promise<void>
+export interface AdditionalShutdownStep {
+  name: string
+  close: () => void | Promise<void>
+  forceClose?: () => void
+}
 
-export function createShutdownHandler(server: any, groupChatServer?: any, chatRunServer?: any, agentBridgeManager?: any): ShutdownHandler {
-  let isShuttingDown = false
+export type ShutdownHandler = (signal: string, exitCode?: number) => Promise<void>
 
-  return async (signal: string) => {
-    if (isShuttingDown) return
-    isShuttingDown = true
-
-    const stopAgentBridge = Boolean(agentBridgeManager && shouldStopAgentBridgeOnShutdown(signal))
-
-    // Force exit only if graceful cleanup hangs. The bridge can take up to 10s
-    // to stop worker subprocesses, so this cap must be longer than that.
-    const forceExitTimer = setTimeout(() => {
-      if (stopAgentBridge) {
-        try {
-          agentBridgeManager?.forceStop?.()
-        } catch (err) {
-          logger.warn(err, 'Failed to force-stop agent bridge during shutdown timeout')
-        }
-      }
-      process.exit(0)
-    }, getShutdownForceExitMs())
-
-    logger.info('Shutting down (%s)...', signal)
-    console.log(`[shutdown] Received signal: ${signal}`)
-
-    try {
-      try {
-        await stopPreviewRuntime()
-        logger.info('Preview runtime stopped')
-      } catch (err) {
-        logger.warn(err, 'Failed to stop preview runtime (non-fatal)')
-      }
-
-      try {
-        await shutdownLocalSttRuntime()
-        logger.info('Local STT runtime stopped')
-      } catch (err) {
-        logger.warn(err, 'Failed to stop local STT runtime (non-fatal)')
-      }
-
-      try {
-        await shutdownSocialMessageRuntimes()
-        logger.info('Social message runtimes stopped')
-      } catch (err) {
-        logger.warn(err, 'Failed to stop social message runtimes (non-fatal)')
-      }
-
-      if (shouldStopManagedGatewaysOnShutdown()) {
-        try {
-          const result = await shutdownManagedGateways()
-          logger.info('[shutdown] managed gateways stopped result=%j', result)
-        } catch (err) {
-          logger.warn(err, 'Failed to stop managed gateways (non-fatal)')
-        }
-      } else {
-        logger.info('[shutdown] leaving managed gateways running')
-      }
-
-      // Stop accepting/routing chat work before stopping the bridge. This lets
-      // ChatRunSocket release any claimed background completion back to Hermes
-      // while the broker is still reachable.
-      if (chatRunServer) {
-        await chatRunServer.close()
-        logger.info('ChatRunSocket closed')
-      }
-      stopChatWebhookDispatcher()
-      logger.info('Chat webhook dispatcher stopped')
-
-      if (stopAgentBridge) {
-        try {
-          await agentBridgeManager.stop()
-          logger.info('Agent bridge stopped')
-        } catch (err) {
-          logger.warn(err, 'Failed to stop agent bridge (non-fatal)')
-        }
-      } else if (agentBridgeManager) {
-        logger.info('Leaving agent bridge running across Web UI shutdown')
-      }
-
-      stopOutboundRelayClient()
-      logger.info('Outbound relay clients closed')
-      stopAppRelayClient()
-      logger.info('App relay clients closed')
-
-      codingAgentRunManager.shutdown()
-      logger.info('Coding agent hidden sessions closed')
-
-      // Disconnect Socket.IO before HTTP server to prevent hanging
-      if (groupChatServer) {
-        await groupChatServer.agentClients.disconnectAll()
-        groupChatServer.getIO().close()
-        logger.info('Socket.IO closed')
-      }
-
-      const servers = Array.isArray(server) ? server : [server].filter(Boolean)
-      if (servers.length) {
-        await Promise.all(servers.map((httpServer) => (
-          new Promise<void>((resolve) => {
-            httpServer.close(() => {
-              logger.info('HTTP server closed')
-              resolve()
-            })
-          })
-        )))
-      }
-    } catch (err) {
-      logger.error(err, 'Shutdown error')
-    }
-
-    closeGlobalEkkoAgent()
-    closeDb()
-    clearTimeout(forceExitTimer)
-    process.exit(0)
+async function runShutdownStep(name: string, step: () => void | Promise<void>): Promise<void> {
+  const startedAt = Date.now()
+  try {
+    await step()
+    logger.info({ durationMs: Date.now() - startedAt }, '%s stopped', name)
+  } catch (err) {
+    logger.warn({ err, durationMs: Date.now() - startedAt }, 'Failed to stop %s (non-fatal)', name)
   }
 }
 
-export function bindShutdown(server: any, groupChatServer?: any, chatRunServer?: any, agentBridgeManager?: any): ShutdownHandler {
-  const shutdown = createShutdownHandler(server, groupChatServer, chatRunServer, agentBridgeManager)
+export function createShutdownHandler(
+  server: any,
+  groupChatServer?: any,
+  chatRunServer?: any,
+  agentBridgeManager?: any,
+  additionalSteps: AdditionalShutdownStep[] = [],
+): ShutdownHandler {
+  let shutdownPromise: Promise<void> | null = null
+
+  return (signal: string, exitCode = 0) => {
+    if (shutdownPromise) return shutdownPromise
+
+    const stopAgentBridge = Boolean(agentBridgeManager && shouldStopAgentBridgeOnShutdown(signal))
+    const stopManagedGateways = shouldStopManagedGatewaysOnShutdown()
+    const shutdownStartedAt = Date.now()
+
+    shutdownPromise = (async () => {
+      // Give resource cleanup a short bounded window, then prefer a clean
+      // process tree over waiting indefinitely for graceful acknowledgements.
+      const forceExitTimer = setTimeout(() => {
+        logger.warn(
+          { elapsedMs: Date.now() - shutdownStartedAt },
+          'Graceful shutdown deadline reached; force-stopping owned process trees',
+        )
+        if (stopManagedGateways) {
+          try {
+            forceStopManagedGateways()
+          } catch (err) {
+            logger.warn(err, 'Failed to force-stop managed gateways during shutdown timeout')
+          }
+        }
+        for (const step of additionalSteps) {
+          try { step.forceClose?.() } catch (err) {
+            logger.warn(err, 'Failed to force-stop %s during shutdown timeout', step.name)
+          }
+        }
+        if (stopAgentBridge) {
+          try {
+            agentBridgeManager?.forceStop?.()
+          } catch (err) {
+            logger.warn(err, 'Failed to force-stop agent bridge during shutdown timeout')
+          }
+        }
+        try {
+          codingAgentRunManager.shutdown()
+        } catch (err) {
+          logger.warn(err, 'Failed to force-stop coding agent processes during shutdown timeout')
+        }
+        process.exit(exitCode)
+      }, getShutdownForceExitMs())
+
+      logger.info('Shutting down (%s)...', signal)
+      console.log(`[shutdown] Received signal: ${signal}`)
+
+      try {
+        // Managed gateways are bounded child-process trees. Stop them first so
+        // a later cleanup hang cannot strand them after the force-exit deadline.
+        if (stopManagedGateways) {
+          await runShutdownStep('Managed gateways', async () => {
+            const result = await shutdownManagedGateways()
+            logger.info('[shutdown] managed gateways stopped result=%j', result)
+          })
+        } else {
+          logger.info('[shutdown] leaving managed gateways running')
+        }
+
+        await runShutdownStep('Preview runtime', stopPreviewRuntime)
+        await runShutdownStep('Local STT runtime', shutdownLocalSttRuntime)
+        await runShutdownStep('Social message runtimes', shutdownSocialMessageRuntimes)
+
+        // Stop accepting/routing chat work before stopping the bridge. This
+        // lets ChatRunSocket release claimed background completions while the
+        // broker is still reachable.
+        if (chatRunServer) await runShutdownStep('ChatRunSocket', () => chatRunServer.close())
+        await runShutdownStep('Chat webhook dispatcher', () => stopChatWebhookDispatcher())
+
+        // These runtimes own the most likely long-lived descendants (PTYs,
+        // watchers, exec jobs, and coding agents), so begin their teardown
+        // before waiting on relays and network servers.
+        await runShutdownStep('Coding agent hidden sessions', () => codingAgentRunManager.shutdown())
+
+        for (const step of additionalSteps) {
+          await runShutdownStep(step.name, step.close)
+        }
+
+        if (stopAgentBridge) {
+          if (process.platform === 'win32' && typeof agentBridgeManager.forceStop === 'function') {
+            await runShutdownStep('Agent bridge process tree', () => agentBridgeManager.forceStop())
+          } else {
+            await runShutdownStep('Agent bridge', () => agentBridgeManager.stop())
+          }
+        } else if (agentBridgeManager) {
+          logger.info('Leaving agent bridge running across Web UI shutdown')
+        }
+
+        await runShutdownStep('Outbound relay clients', () => stopOutboundRelayClient())
+        await runShutdownStep('App relay clients', () => stopAppRelayClient())
+
+        // Disconnect Socket.IO before HTTP server to prevent hanging, and wait
+        // for adapter/namespace cleanup instead of racing process.exit().
+        if (groupChatServer) {
+          await runShutdownStep('Group chat agents', () => groupChatServer.agentClients.disconnectAll())
+          await runShutdownStep('Socket.IO', () => groupChatServer.getIO().close())
+        }
+
+        const servers = Array.isArray(server) ? server : [server].filter(Boolean)
+        if (servers.length) {
+          await runShutdownStep('HTTP servers', () => Promise.all(servers.map((httpServer) => (
+            new Promise<void>((resolve) => {
+              if (httpServer.listening === false) {
+                resolve()
+                return
+              }
+              httpServer.close(() => resolve())
+            })
+          ))).then(() => undefined))
+        }
+      } finally {
+        await runShutdownStep('Global Ekko agent', () => closeGlobalEkkoAgent())
+        await runShutdownStep('Database', () => closeDb())
+        clearTimeout(forceExitTimer)
+        logger.info({ durationMs: Date.now() - shutdownStartedAt }, 'Shutdown cleanup complete')
+        process.exit(exitCode)
+      }
+    })()
+
+    return shutdownPromise
+  }
+}
+
+export function bindShutdown(
+  server: any,
+  groupChatServer?: any,
+  chatRunServer?: any,
+  agentBridgeManager?: any,
+  additionalSteps: AdditionalShutdownStep[] = [],
+): ShutdownHandler {
+  const shutdown = createShutdownHandler(server, groupChatServer, chatRunServer, agentBridgeManager, additionalSteps)
 
   process.once('SIGUSR2', shutdown)
   process.on('SIGINT', shutdown)

--- a/packages/server/src/modules/coding-agents/services/runtime/codex-compact.ts
+++ b/packages/server/src/modules/coding-agents/services/runtime/codex-compact.ts
@@ -6,6 +6,7 @@ import {
   windowsCmdShimExecution,
   windowsCommandNeedsShell,
 } from '../../../studio/public/windows-command'
+import { killOwnedProcessTree } from '../../../studio/infrastructure/process-tree'
 
 const APP_SERVER_READY_TIMEOUT_MS = 30_000
 const COMPACT_TIMEOUT_MS = 5 * 60 * 1000
@@ -201,10 +202,7 @@ export async function compactCodexThread(
 function terminateCodexChild(child: ChildProcess) {
   if (!child || child.killed || !child.pid) return
   if (process.platform === 'win32') {
-    spawn('taskkill', ['/pid', String(child.pid), '/t', '/f'], { stdio: 'ignore' })
-      .on('error', () => {
-        try { child.kill() } catch {}
-      })
+    try { killOwnedProcessTree(child.pid, () => { child.kill() }) } catch {}
     return
   }
   try {

--- a/packages/server/src/modules/coding-agents/services/runtime/codex-compact.ts
+++ b/packages/server/src/modules/coding-agents/services/runtime/codex-compact.ts
@@ -6,7 +6,7 @@ import {
   windowsCmdShimExecution,
   windowsCommandNeedsShell,
 } from '../../../studio/public/windows-command'
-import { killOwnedProcessTree } from '../../../studio/infrastructure/process-tree'
+import { killOwnedProcessTree } from '../../../studio/public/process-tree'
 
 const APP_SERVER_READY_TIMEOUT_MS = 30_000
 const COMPACT_TIMEOUT_MS = 5 * 60 * 1000

--- a/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
+++ b/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
@@ -19,6 +19,7 @@ import {
 import type { SessionState } from '../../../studio/contracts/runs/session'
 import type { CanonicalResponsesEvent } from '../../protocol/adapters/responses-stream'
 import { normalizeWindowsCommandPath, windowsCmdShimExecution, windowsCommandNeedsShell } from '../../../studio/public/windows-command'
+import { killOwnedProcessTree } from '../../../studio/infrastructure/process-tree'
 import { attachPiJsonlReader } from '../pi/jsonl-parser'
 import { normalizePiThinkingLevel } from '../pi/thinking'
 import { compactCodexThread } from './codex-compact'
@@ -502,7 +503,7 @@ function appendedTextDelta(existing: string, next: string): string {
 function terminateChildProcess(child?: ChildProcess) {
   if (!child || !child.pid || !childIsRunning(child)) return
   if (process.platform === 'win32') {
-    spawn('taskkill', ['/pid', String(child.pid), '/t', '/f'], { stdio: 'ignore' }).on('error', () => {})
+    try { killOwnedProcessTree(child.pid, () => { child.kill() }) } catch {}
     return
   }
   try {
@@ -515,7 +516,7 @@ function terminateChildProcess(child?: ChildProcess) {
 function forceKillChildProcess(child?: ChildProcess) {
   if (!child || !child.pid || !childIsRunning(child)) return
   if (process.platform === 'win32') {
-    spawn('taskkill', ['/pid', String(child.pid), '/t', '/f'], { stdio: 'ignore' }).on('error', () => {})
+    try { killOwnedProcessTree(child.pid, () => { child.kill('SIGKILL') }) } catch {}
     return
   }
   try {
@@ -590,6 +591,7 @@ export function sanitizeCodingAgentTerminalOutput(value: string): string {
 export class CodingAgentRunManager {
   private runs = new Map<string, ManagedCodingAgentRun>()
   private sessionIndex = new Map<string, string>()
+  private memoryExportChildren = new Set<ChildProcess>()
 
   constructor(private readonly idleMs = DEFAULT_IDLE_MS) {}
 
@@ -1208,6 +1210,8 @@ export class CodingAgentRunManager {
 
   shutdown() {
     for (const run of [...this.runs.values()]) this.cleanupRun(run, { kill: true })
+    for (const child of this.memoryExportChildren) forceKillChildProcess(child)
+    this.memoryExportChildren.clear()
   }
 
   private getBySession(sessionId: string): ManagedCodingAgentRun | null {
@@ -1312,7 +1316,9 @@ export class CodingAgentRunManager {
       if (run.launch.agentId === 'pi' && run.turnActive && childIsRunning(run.currentChild)) {
         this.writePiRpcCommand(run, { id: `abort_${Date.now()}`, type: 'abort' })
       }
-      try { run.pty?.kill() } catch {}
+      if (run.pty) {
+        try { killOwnedProcessTree(run.pty.pid, () => run.pty?.kill()) } catch {}
+      }
       terminateChildProcess(run.currentChild)
       if (childIsRunning(run.currentChild)) {
         run.currentChildKillTimer = setTimeout(() => forceKillChildProcess(run.currentChild), 1500)
@@ -2046,7 +2052,6 @@ export class CodingAgentRunManager {
       }
       return
     }
-
     if (role === 'user') {
       for (const [index, block] of content.entries()) {
         if (block?.type !== 'tool_result') continue
@@ -2931,11 +2936,12 @@ export class CodingAgentRunManager {
       logger.debug({ err, runId: run.id, sessionId: run.launch.sessionId, agentId, nativeSessionId }, '[coding-agent-run] memory export failed to start')
       return
     }
+    this.memoryExportChildren.add(child)
 
     let stdout = ''
     let stderr = ''
     const timeout = setTimeout(() => {
-      try { child.kill() } catch {}
+      forceKillChildProcess(child)
     }, 60_000)
     timeout.unref?.()
     child.stdout?.on('data', (chunk: Buffer) => {
@@ -2946,10 +2952,12 @@ export class CodingAgentRunManager {
     })
     child.on('error', (err) => {
       clearTimeout(timeout)
+      this.memoryExportChildren.delete(child)
       logger.debug({ err, runId: run.id, sessionId: run.launch.sessionId, agentId, nativeSessionId }, '[coding-agent-run] memory export process error')
     })
     child.on('exit', (code) => {
       clearTimeout(timeout)
+      this.memoryExportChildren.delete(child)
       if (code === 0) {
         logger.info({ runId: run.id, sessionId: run.launch.sessionId, agentId, nativeSessionId }, '[coding-agent-run] memory export completed')
       } else {

--- a/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
+++ b/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
@@ -19,7 +19,7 @@ import {
 import type { SessionState } from '../../../studio/contracts/runs/session'
 import type { CanonicalResponsesEvent } from '../../protocol/adapters/responses-stream'
 import { normalizeWindowsCommandPath, windowsCmdShimExecution, windowsCommandNeedsShell } from '../../../studio/public/windows-command'
-import { killOwnedProcessTree } from '../../../studio/infrastructure/process-tree'
+import { killOwnedProcessTree } from '../../../studio/public/process-tree'
 import { attachPiJsonlReader } from '../pi/jsonl-parser'
 import { normalizePiThinkingLevel } from '../pi/thinking'
 import { compactCodexThread } from './codex-compact'

--- a/packages/server/src/modules/hermes/services/gateway/runner.ts
+++ b/packages/server/src/modules/hermes/services/gateway/runner.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'child_process'
+import { execFile, execFileSync } from 'child_process'
 import { promisify } from 'util'
 import { logger } from '../../../studio/public/logging'
 import { getActiveProfileDir } from '../profiles/profile'
@@ -38,6 +38,8 @@ interface ProfileState {
 }
 
 const profileState = new Map<string, ProfileState>()
+const stoppingGateways = new Map<number, SupervisedGateway>()
+let managedGatewayShutdownStarted = false
 
 /** Delay before respawning a gateway that exited unexpectedly. */
 const RESPAWN_DELAY_MS = 2000
@@ -62,6 +64,9 @@ function getOrCreateProfileState(profileDir: string): ProfileState {
 }
 
 type KillWindowsProcessTree = (pid: number) => Promise<void>
+type ForceKillWindowsProcessTree = (pid: number) => void
+type ListPosixDescendantPids = (pid: number) => number[]
+type KillPosixPid = (pid: number, signal: NodeJS.Signals) => void
 
 function clearRespawnTimer(state: ProfileState, profileDir: string): void {
   if (!state.respawnTimer) return
@@ -77,12 +82,101 @@ async function taskkillWindowsProcessTree(pid: number): Promise<void> {
   })
 }
 
+function forceTaskkillWindowsProcessTree(pid: number): void {
+  execFileSync('taskkill.exe', ['/PID', String(pid), '/T', '/F'], {
+    timeout: 5000,
+    windowsHide: true,
+    stdio: 'ignore',
+  })
+}
+
+function posixDescendantPids(rootPid: number): number[] {
+  try {
+    const output = execFileSync('ps', ['-ax', '-o', 'pid=,ppid='], {
+      encoding: 'utf-8',
+      timeout: 5000,
+    })
+    const children = new Map<number, number[]>()
+    for (const line of output.split(/\r?\n/)) {
+      const match = line.trim().match(/^(\d+)\s+(\d+)$/)
+      if (!match) continue
+      const pid = Number(match[1])
+      const parentPid = Number(match[2])
+      children.set(parentPid, [...(children.get(parentPid) || []), pid])
+    }
+
+    const descendants: number[] = []
+    const visit = (parentPid: number) => {
+      for (const pid of children.get(parentPid) || []) {
+        visit(pid)
+        descendants.push(pid)
+      }
+    }
+    visit(rootPid)
+    return descendants
+  } catch {
+    return []
+  }
+}
+
+function killPosixPid(pid: number, signal: NodeJS.Signals): void {
+  process.kill(pid, signal)
+}
+
+function forceKillKnownPosixDescendants(
+  descendantPids: Iterable<number>,
+  killPid: KillPosixPid,
+): number {
+  let killed = 0
+  for (const pid of new Set(descendantPids)) {
+    try {
+      killPid(pid, 'SIGKILL')
+      killed += 1
+    } catch {
+      // The gateway may have already reaped this child during graceful exit.
+    }
+  }
+  return killed
+}
+
+function forceKillManagedGateway(
+  entry: SupervisedGateway,
+  opts: {
+    platform: NodeJS.Platform
+    forceKillWindowsProcessTree: ForceKillWindowsProcessTree
+    listPosixDescendantPids: ListPosixDescendantPids
+    killPosixPid: KillPosixPid
+  },
+): void {
+  if (opts.platform === 'win32') {
+    try {
+      opts.forceKillWindowsProcessTree(entry.pid)
+      return
+    } catch (err) {
+      logger.warn(err, '[gateway-runner] forced taskkill failed for managed gateway pid=%s; falling back to child.kill', entry.pid)
+      try { entry.child.kill('SIGKILL') } catch {}
+      return
+    }
+  }
+
+  forceKillKnownPosixDescendants(opts.listPosixDescendantPids(entry.pid), opts.killPosixPid)
+  try {
+    // Managed POSIX gateways are spawned detached, so this also catches any
+    // descendants which stayed in the gateway process group.
+    opts.killPosixPid(-entry.pid, 'SIGKILL')
+  } catch {
+    try { entry.child.kill('SIGKILL') } catch {}
+  }
+}
+
 async function stopManagedGateway(
   entry: SupervisedGateway,
   opts: {
     timeoutMs: number
     platform: NodeJS.Platform
     killWindowsProcessTree: KillWindowsProcessTree
+    listPosixDescendantPids: ListPosixDescendantPids
+    killPosixPid: KillPosixPid
   },
 ): Promise<{ forced: boolean; error?: unknown }> {
   if (opts.platform === 'win32') {
@@ -100,6 +194,8 @@ async function stopManagedGateway(
     }
   }
 
+  const ownedDescendantPids = opts.listPosixDescendantPids(entry.pid)
+
   return new Promise(resolve => {
     let settled = false
     let forced = false
@@ -112,9 +208,22 @@ async function stopManagedGateway(
       resolve({ forced, error })
     }
 
-    const onExit = () => finish()
+    const onExit = () => {
+      // The gateway may exit before its MCP/watchdog descendants. Once their
+      // parent is gone they are reparented and can no longer be rediscovered
+      // from the gateway PID, so clean the ownership snapshot taken above.
+      if (forceKillKnownPosixDescendants(ownedDescendantPids, opts.killPosixPid) > 0) {
+        forced = true
+      }
+      finish()
+    }
     const timer = setTimeout(() => {
       forced = true
+      const descendants = [
+        ...ownedDescendantPids,
+        ...opts.listPosixDescendantPids(entry.pid),
+      ]
+      forceKillKnownPosixDescendants(descendants, opts.killPosixPid)
       try {
         entry.child.kill('SIGKILL')
       } catch (err) {
@@ -140,11 +249,19 @@ export async function shutdownManagedGateways(
     timeoutMs?: number
     platform?: NodeJS.Platform
     killWindowsProcessTree?: KillWindowsProcessTree
+    listPosixDescendantPids?: ListPosixDescendantPids
+    killPosixPid?: KillPosixPid
   } = {},
 ): Promise<ManagedGatewayShutdownResult> {
+  // This is a process-lifecycle boundary, not a profile reconcile. Once it
+  // starts, an in-flight bootstrap/autostart task must not create a new
+  // detached gateway after the ownership registry has been drained.
+  managedGatewayShutdownStarted = true
   const timeoutMs = opts.timeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS
   const platform = opts.platform ?? process.platform
   const killWindowsProcessTree = opts.killWindowsProcessTree ?? taskkillWindowsProcessTree
+  const listDescendants = opts.listPosixDescendantPids ?? posixDescendantPids
+  const killPid = opts.killPosixPid ?? killPosixPid
   const stops: Promise<{ forced: boolean; error?: unknown }>[] = []
   let signaled = 0
 
@@ -160,7 +277,14 @@ export async function shutdownManagedGateways(
     state.current = null
     signaled += 1
     logger.info('[gateway-runner] stopping managed gateway profileDir=%s pid=%s', profileDir, entry.pid)
-    stops.push(stopManagedGateway(entry, { timeoutMs, platform, killWindowsProcessTree }))
+    stoppingGateways.set(entry.pid, entry)
+    stops.push(stopManagedGateway(entry, {
+      timeoutMs,
+      platform,
+      killWindowsProcessTree,
+      listPosixDescendantPids: listDescendants,
+      killPosixPid: killPid,
+    }).finally(() => stoppingGateways.delete(entry.pid)))
     profileState.delete(profileDir)
   }
 
@@ -181,6 +305,8 @@ export async function retireManagedGatewayForProfile(
     timeoutMs?: number
     platform?: NodeJS.Platform
     killWindowsProcessTree?: KillWindowsProcessTree
+    listPosixDescendantPids?: ListPosixDescendantPids
+    killPosixPid?: KillPosixPid
   } = {},
 ): Promise<ManagedGatewayShutdownResult> {
   const state = profileState.get(profileDir)
@@ -197,9 +323,18 @@ export async function retireManagedGatewayForProfile(
   const timeoutMs = opts.timeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS
   const platform = opts.platform ?? process.platform
   const killWindowsProcessTree = opts.killWindowsProcessTree ?? taskkillWindowsProcessTree
+  const listDescendants = opts.listPosixDescendantPids ?? posixDescendantPids
+  const killPid = opts.killPosixPid ?? killPosixPid
 
   logger.info('[gateway-runner] retiring managed gateway profileDir=%s pid=%s', profileDir, entry.pid)
-  const result = await stopManagedGateway(entry, { timeoutMs, platform, killWindowsProcessTree })
+  stoppingGateways.set(entry.pid, entry)
+  const result = await stopManagedGateway(entry, {
+    timeoutMs,
+    platform,
+    killWindowsProcessTree,
+    listPosixDescendantPids: listDescendants,
+    killPosixPid: killPid,
+  }).finally(() => stoppingGateways.delete(entry.pid))
   const forced = result.forced ? 1 : 0
   const errors = result.error ? 1 : 0
 
@@ -211,6 +346,44 @@ export async function retireManagedGatewayForProfile(
   )
 
   return { signaled: 1, forced, errors }
+}
+
+export function forceStopManagedGateways(
+  opts: {
+    platform?: NodeJS.Platform
+    forceKillWindowsProcessTree?: ForceKillWindowsProcessTree
+    listPosixDescendantPids?: ListPosixDescendantPids
+    killPosixPid?: KillPosixPid
+  } = {},
+): number {
+  managedGatewayShutdownStarted = true
+  const platform = opts.platform ?? process.platform
+  const forceKillWindowsProcessTree = opts.forceKillWindowsProcessTree ?? forceTaskkillWindowsProcessTree
+  const listDescendants = opts.listPosixDescendantPids ?? posixDescendantPids
+  const killPid = opts.killPosixPid ?? killPosixPid
+  const entries = new Map<number, SupervisedGateway>(stoppingGateways)
+
+  for (const [profileDir, state] of profileState) {
+    clearRespawnTimer(state, profileDir)
+    if (state.current) entries.set(state.current.pid, state.current)
+    state.current = null
+    profileState.delete(profileDir)
+  }
+
+  for (const entry of entries.values()) {
+    forceKillManagedGateway(entry, {
+      platform,
+      forceKillWindowsProcessTree,
+      listPosixDescendantPids: listDescendants,
+      killPosixPid: killPid,
+    })
+    stoppingGateways.delete(entry.pid)
+  }
+
+  if (entries.size > 0) {
+    logger.warn('[gateway-runner] force-stopped managed gateway trees count=%s', entries.size)
+  }
+  return entries.size
 }
 
 export function startGatewayRunManaged(
@@ -228,6 +401,10 @@ function startGatewayRunManagedInternal(
   opts: { profileDir?: string; preserveRespawnAttempts?: boolean } = {},
 ): { pid: number | null; reused: boolean } {
   const profileDir = opts.profileDir || getActiveProfileDir()
+  if (managedGatewayShutdownStarted) {
+    logger.warn('[gateway-runner] refusing managed gateway start after shutdown began profileDir=%s', profileDir)
+    return { pid: null, reused: false }
+  }
   const state = getOrCreateProfileState(profileDir)
 
   // A new spawn for this profile cancels any pending respawn from a previous

--- a/packages/server/src/modules/hermes/sockets/kanban-events.ts
+++ b/packages/server/src/modules/hermes/sockets/kanban-events.ts
@@ -7,7 +7,7 @@ import { config } from '../../studio/public/config'
 import { logger } from '../../studio/public/logging'
 import { shouldRejectUpgradeOrigin, writeForbiddenOrigin } from '../../studio/public/security'
 import { userCanAccessProfile } from '../../studio/public/users'
-import { killOwnedProcessTree } from '../../studio/infrastructure/process-tree'
+import { killOwnedProcessTree } from '../../studio/public/process-tree'
 import * as kanbanCli from '../services/kanban/kanban-service'
 
 interface KanbanEventsRequest extends IncomingMessage {

--- a/packages/server/src/modules/hermes/sockets/kanban-events.ts
+++ b/packages/server/src/modules/hermes/sockets/kanban-events.ts
@@ -1,11 +1,13 @@
 import { WebSocketServer } from 'ws'
 import type { WebSocket } from 'ws'
 import type { Server as HttpServer, IncomingMessage } from 'http'
+import type { Duplex } from 'stream'
 import { authenticateUserToken, isAuthEnabled } from '../../studio/public/auth'
 import { config } from '../../studio/public/config'
 import { logger } from '../../studio/public/logging'
 import { shouldRejectUpgradeOrigin, writeForbiddenOrigin } from '../../studio/public/security'
 import { userCanAccessProfile } from '../../studio/public/users'
+import { killOwnedProcessTree } from '../../studio/infrastructure/process-tree'
 import * as kanbanCli from '../services/kanban/kanban-service'
 
 interface KanbanEventsRequest extends IncomingMessage {
@@ -34,46 +36,46 @@ export function setupKanbanEventsWebSocket(httpServers: HttpServer | HttpServer[
   const wss = new WebSocketServer({ noServer: true })
   const servers = Array.isArray(httpServers) ? httpServers : [httpServers]
 
-  servers.forEach((httpServer) => {
-    httpServer.on('upgrade', async (req: KanbanEventsRequest, socket, head) => {
-      const url = new URL(req.url || '', `http://${req.headers.host}`)
-      if (url.pathname !== '/api/hermes/kanban/events') return
+  const onUpgrade = async (req: KanbanEventsRequest, socket: Duplex, head: Buffer) => {
+    const url = new URL(req.url || '', `http://${req.headers.host}`)
+    if (url.pathname !== '/api/hermes/kanban/events') return
 
-      if (shouldRejectUpgradeOrigin(req, config.corsOrigins)) {
-        writeForbiddenOrigin(socket)
-        return
-      }
+    if (shouldRejectUpgradeOrigin(req, config.corsOrigins)) {
+      writeForbiddenOrigin(socket)
+      return
+    }
 
-      if (await isAuthEnabled()) {
-        const token = url.searchParams.get('token') || ''
-        const user = await authenticateUserToken(token)
-        if (!user) {
-          socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n')
-          socket.destroy()
-          return
-        }
-        const profile = (url.searchParams.get('profile') || '').trim()
-        if (profile && user.role !== 'super_admin' && !userCanAccessProfile(user.id, profile)) {
-          socket.write('HTTP/1.1 403 Forbidden\r\n\r\n')
-          socket.destroy()
-          return
-        }
-        req.kanbanProfile = profile || undefined
-      }
-
-      try {
-        req.kanbanBoard = kanbanCli.normalizeBoardSlug(url.searchParams.get('board'))
-      } catch {
-        socket.write('HTTP/1.1 400 Bad Request\r\n\r\n')
+    if (await isAuthEnabled()) {
+      const token = url.searchParams.get('token') || ''
+      const user = await authenticateUserToken(token)
+      if (!user) {
+        socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n')
         socket.destroy()
         return
       }
+      const profile = (url.searchParams.get('profile') || '').trim()
+      if (profile && user.role !== 'super_admin' && !userCanAccessProfile(user.id, profile)) {
+        socket.write('HTTP/1.1 403 Forbidden\r\n\r\n')
+        socket.destroy()
+        return
+      }
+      req.kanbanProfile = profile || undefined
+    }
 
-      wss.handleUpgrade(req, socket, head, (ws) => {
-        wss.emit('connection', ws, req)
-      })
+    try {
+      req.kanbanBoard = kanbanCli.normalizeBoardSlug(url.searchParams.get('board'))
+    } catch {
+      socket.write('HTTP/1.1 400 Bad Request\r\n\r\n')
+      socket.destroy()
+      return
+    }
+
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      wss.emit('connection', ws, req)
     })
-  })
+  }
+
+  servers.forEach(httpServer => httpServer.on('upgrade', onUpgrade))
 
   wss.on('connection', (ws, req: KanbanEventsRequest) => {
     const board = req.kanbanBoard || 'default'
@@ -85,7 +87,9 @@ export function setupKanbanEventsWebSocket(httpServers: HttpServer | HttpServer[
     const closeChild = () => {
       if (closed) return
       closed = true
-      if (!child.killed) child.kill()
+      killOwnedProcessTree(child.pid, () => {
+        if (!child.killed) child.kill()
+      })
     }
 
     child.stdout?.on('data', streamLines((line) => {
@@ -113,4 +117,21 @@ export function setupKanbanEventsWebSocket(httpServers: HttpServer | HttpServer[
   })
 
   logger.info('WebSocket ready at /api/hermes/kanban/events (kanban watch bridge)')
+
+  let closePromise: Promise<void> | null = null
+  const detachAndTerminate = () => {
+    servers.forEach(httpServer => httpServer.off('upgrade', onUpgrade))
+    for (const ws of wss.clients) ws.terminate()
+  }
+  return {
+    forceClose: detachAndTerminate,
+    close(): Promise<void> {
+      if (closePromise) return closePromise
+      detachAndTerminate()
+      closePromise = new Promise(resolve => {
+        wss.close(() => resolve())
+      })
+      return closePromise
+    },
+  }
 }

--- a/packages/server/src/modules/hermes/sockets/terminal.ts
+++ b/packages/server/src/modules/hermes/sockets/terminal.ts
@@ -1,5 +1,6 @@
 import { WebSocketServer } from 'ws'
-import type { Server as HttpServer } from 'http'
+import type { IncomingMessage, Server as HttpServer } from 'http'
+import type { Duplex } from 'stream'
 import { accessSync, chmodSync, constants as fsConstants, existsSync } from 'fs'
 import { dirname, join, isAbsolute, resolve as resolvePath } from 'path'
 import { homedir } from 'os'
@@ -9,6 +10,7 @@ import { authenticateUserToken, isAuthEnabled } from '../../studio/public/auth'
 import { logger } from '../../studio/public/logging'
 import { config } from '../../studio/public/config'
 import { shouldRejectUpgradeOrigin, writeForbiddenOrigin } from '../../studio/public/security'
+import { killOwnedProcessTree } from '../../studio/infrastructure/process-tree'
 
 let pty: any = null
 
@@ -137,51 +139,57 @@ function createSession(shell: string): PtySession {
   return session
 }
 
+function killPtySession(session: PtySession): void {
+  try {
+    killOwnedProcessTree(session.pid, () => session.pty.kill())
+  } catch { }
+}
+
 // ─── WebSocket server setup ─────────────────────────────────────
 
 export function setupTerminalWebSocket(httpServers: HttpServer | HttpServer[]) {
   if (!pty) {
     logger.warn('node-pty not available, skipping terminal WebSocket setup')
-    return
+    return null
   }
 
   const wss = new WebSocketServer({ noServer: true })
   const defaultShell = findShell()
   const servers = Array.isArray(httpServers) ? httpServers : [httpServers]
 
-  servers.forEach((httpServer) => {
-    httpServer.on('upgrade', async (req, socket, head) => {
-      const url = new URL(req.url || '', `http://${req.headers.host}`)
-      if (url.pathname !== '/api/hermes/terminal') {
+  const onUpgrade = async (req: IncomingMessage, socket: Duplex, head: Buffer) => {
+    const url = new URL(req.url || '', `http://${req.headers.host}`)
+    if (url.pathname !== '/api/hermes/terminal') {
+      return
+    }
+
+    if (shouldRejectUpgradeOrigin(req, config.corsOrigins)) {
+      writeForbiddenOrigin(socket)
+      return
+    }
+
+    // Auth check
+    if (await isAuthEnabled()) {
+      const token = url.searchParams.get('token') || ''
+      const user = await authenticateUserToken(token)
+      if (!user) {
+        socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n')
+        socket.destroy()
         return
       }
-
-      if (shouldRejectUpgradeOrigin(req, config.corsOrigins)) {
-        writeForbiddenOrigin(socket)
+      if (!canOpenTerminal(user)) {
+        socket.write('HTTP/1.1 403 Forbidden\r\n\r\n')
+        socket.destroy()
         return
       }
+    }
 
-      // Auth check
-      if (await isAuthEnabled()) {
-        const token = url.searchParams.get('token') || ''
-        const user = await authenticateUserToken(token)
-        if (!user) {
-          socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n')
-          socket.destroy()
-          return
-        }
-        if (!canOpenTerminal(user)) {
-          socket.write('HTTP/1.1 403 Forbidden\r\n\r\n')
-          socket.destroy()
-          return
-        }
-      }
-
-      wss.handleUpgrade(req, socket, head, (ws) => {
-        wss.emit('connection', ws, req)
-      })
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      wss.emit('connection', ws, req)
     })
-  })
+  }
+
+  servers.forEach(httpServer => httpServer.on('upgrade', onUpgrade))
 
   wss.on('connection', (ws) => {
     const conn: Connection = {
@@ -302,7 +310,7 @@ export function setupTerminalWebSocket(httpServers: HttpServer | HttpServer[]) {
           const { sessionId } = parsed
           const session = conn.sessions.get(sessionId)
           if (!session) return
-          session.pty.kill()
+          killPtySession(session)
           conn.sessions.delete(sessionId)
           conn.outputBuffers.delete(sessionId)
           if (conn.activeSessionId === sessionId) {
@@ -334,7 +342,7 @@ export function setupTerminalWebSocket(httpServers: HttpServer | HttpServer[]) {
 
     ws.on('close', () => {
       for (const session of Array.from(conn.sessions.values())) {
-        try { session.pty.kill() } catch { }
+        killPtySession(session)
       }
       conn.sessions.clear()
       logger.info('Connection closed, all sessions killed')
@@ -342,7 +350,7 @@ export function setupTerminalWebSocket(httpServers: HttpServer | HttpServer[]) {
 
     ws.on('error', () => {
       for (const session of Array.from(conn.sessions.values())) {
-        try { session.pty.kill() } catch { }
+        killPtySession(session)
       }
       conn.sessions.clear()
     })
@@ -371,4 +379,21 @@ export function setupTerminalWebSocket(httpServers: HttpServer | HttpServer[]) {
   })
 
   logger.info('WebSocket ready at /terminal (shell: %s, transport: node-pty)', defaultShell)
+
+  let closePromise: Promise<void> | null = null
+  const detachAndTerminate = () => {
+    servers.forEach(httpServer => httpServer.off('upgrade', onUpgrade))
+    for (const ws of wss.clients) ws.terminate()
+  }
+  return {
+    forceClose: detachAndTerminate,
+    close(): Promise<void> {
+      if (closePromise) return closePromise
+      detachAndTerminate()
+      closePromise = new Promise(resolve => {
+        wss.close(() => resolve())
+      })
+      return closePromise
+    },
+  }
 }

--- a/packages/server/src/modules/hermes/sockets/terminal.ts
+++ b/packages/server/src/modules/hermes/sockets/terminal.ts
@@ -10,7 +10,7 @@ import { authenticateUserToken, isAuthEnabled } from '../../studio/public/auth'
 import { logger } from '../../studio/public/logging'
 import { config } from '../../studio/public/config'
 import { shouldRejectUpgradeOrigin, writeForbiddenOrigin } from '../../studio/public/security'
-import { killOwnedProcessTree } from '../../studio/infrastructure/process-tree'
+import { killOwnedProcessTree } from '../../studio/public/process-tree'
 
 let pty: any = null
 

--- a/packages/server/src/modules/studio/infrastructure/process-tree.ts
+++ b/packages/server/src/modules/studio/infrastructure/process-tree.ts
@@ -1,0 +1,42 @@
+import { execFileSync } from 'child_process'
+
+type TaskkillProcessTree = (pid: number) => void
+
+function taskkillProcessTree(pid: number): void {
+  execFileSync('taskkill.exe', ['/PID', String(pid), '/T', '/F'], {
+    timeout: 5000,
+    windowsHide: true,
+    stdio: 'ignore',
+  })
+}
+
+/**
+ * Kill a process owned by Studio.
+ *
+ * Node's child.kill() only terminates the immediate process on Windows. CLI
+ * shims, Python workers, MCP servers, and PTY shells commonly survive it, so
+ * Windows must use taskkill /T /F and wait for the tree operation to finish.
+ * Other platforms retain the caller's existing signal behavior.
+ */
+export function killOwnedProcessTree(
+  pid: number | null | undefined,
+  fallback: () => void,
+  options: {
+    platform?: NodeJS.Platform
+    taskkill?: TaskkillProcessTree
+  } = {},
+): void {
+  const platform = options.platform ?? process.platform
+  if (platform === 'win32' && Number.isInteger(pid) && Number(pid) > 0) {
+    try {
+      const taskkill = options.taskkill ?? taskkillProcessTree
+      taskkill(Number(pid))
+      return
+    } catch {
+      // The process may have already exited, or taskkill may be unavailable.
+      // Fall back to the native child/PTY kill operation in either case.
+    }
+  }
+
+  fallback()
+}

--- a/packages/server/src/modules/studio/public/process-tree.ts
+++ b/packages/server/src/modules/studio/public/process-tree.ts
@@ -1,0 +1,1 @@
+export { killOwnedProcessTree } from '../infrastructure/process-tree'

--- a/packages/server/src/modules/studio/services/network/lan-peer-socket.ts
+++ b/packages/server/src/modules/studio/services/network/lan-peer-socket.ts
@@ -1,5 +1,6 @@
 import WebSocket, { WebSocketServer, type RawData } from 'ws'
 import type { Server as HttpServer, IncomingMessage } from 'http'
+import type { Duplex } from 'stream'
 import { randomUUID } from 'crypto'
 import { createReadStream, createWriteStream, type WriteStream } from 'fs'
 import { existsSync } from 'fs'
@@ -12,6 +13,7 @@ import { createDeviceSignature, getPublicSystemInfo, verifyDeviceSignature } fro
 import { logger } from '../../public/logging'
 import { config } from '../../public/config'
 import { shouldRejectUpgradeOrigin, writeForbiddenOrigin } from '../../middleware/security'
+import { killOwnedProcessTree } from '../../infrastructure/process-tree'
 
 export interface LanPeerFilesystemDependencies {
   getActiveProfileDir: () => string
@@ -257,6 +259,7 @@ class LanPeerConnection {
   private uploads = new Map<string, UploadTransfer>()
   private pendingRequests = new Map<string, PendingRequest>()
   private pendingDownloads = new Map<string, PendingDownload>()
+  private execChildren = new Set<ReturnType<typeof spawn>>()
   private heartbeatTimer: NodeJS.Timeout | null = null
   private alive = true
   private closed = false
@@ -313,6 +316,11 @@ class LanPeerConnection {
     this.terminalSessions.clear()
     this.remoteTerminals.clear()
 
+    for (const child of this.execChildren) {
+      try { killOwnedProcessTree(child.pid, () => { child.kill() }) } catch { }
+    }
+    this.execChildren.clear()
+
     for (const upload of this.uploads.values()) {
       try { upload.stream.destroy() } catch { }
     }
@@ -363,7 +371,7 @@ class LanPeerConnection {
       session.idleTimer = null
     }
     this.terminalSessions.delete(session.id)
-    try { session.pty.kill() } catch { }
+    try { killOwnedProcessTree(session.pid, () => session.pty.kill()) } catch { }
     if (options.notify) {
       this.sendJson({ type: 'terminal.exit', terminal_id: session.id, exit_code: options.exitCode ?? 0 })
     }
@@ -799,11 +807,13 @@ class LanPeerConnection {
       this.sendJson({ type: 'terminal.exec.error', request_id: msg.request_id, message: err?.message || 'Failed to start command' })
       return
     }
+    this.execChildren.add(child)
 
     const finish = (exitCode: number | null) => {
       if (settled) return
       settled = true
       clearTimeout(timer)
+      this.execChildren.delete(child)
       this.sendJson({
         type: 'terminal.exec.result',
         request_id: msg.request_id,
@@ -824,7 +834,7 @@ class LanPeerConnection {
 
     const timer = setTimeout(() => {
       timedOut = true
-      try { child.kill() } catch { }
+      try { killOwnedProcessTree(child.pid, () => { child.kill() }) } catch { }
       finish(null)
     }, timeoutMs)
     timer.unref?.()
@@ -839,6 +849,7 @@ class LanPeerConnection {
       if (settled) return
       settled = true
       clearTimeout(timer)
+      this.execChildren.delete(child)
       this.sendJson({ type: 'terminal.exec.error', request_id: msg.request_id, message: err.message })
     })
     child.on('close', code => finish(code))
@@ -919,6 +930,7 @@ export class LanPeerSocketManager {
   private readonly connections = new Map<string, LanPeerConnection>()
   private readonly clientTargets = new Map<string, ClientPeerTarget>()
   private readonly seenNonces = new Map<string, number>()
+  private readonly upgradeHandlers = new Map<HttpServer, (req: IncomingMessage, socket: Duplex, head: Buffer) => void>()
   private setupDone = false
 
   setupServer(httpServers: HttpServer | HttpServer[]) {
@@ -927,7 +939,7 @@ export class LanPeerSocketManager {
     const servers = Array.isArray(httpServers) ? httpServers : [httpServers]
 
     servers.forEach(httpServer => {
-      httpServer.on('upgrade', async (req, socket, head) => {
+      const onUpgrade = async (req: IncomingMessage, socket: Duplex, head: Buffer) => {
         const url = new URL(req.url || '', `http://${req.headers.host}`)
         if (url.pathname !== PEER_SOCKET_PATH) return
 
@@ -955,8 +967,34 @@ export class LanPeerSocketManager {
           this.connections.set(connection.id, connection)
           this.wss.emit('connection', ws, req)
         })
-      })
+      }
+      this.upgradeHandlers.set(httpServer, onUpgrade)
+      httpServer.on('upgrade', onUpgrade)
     })
+  }
+
+  forceClose(): void {
+    for (const [httpServer, onUpgrade] of this.upgradeHandlers) {
+      httpServer.off('upgrade', onUpgrade)
+    }
+    this.upgradeHandlers.clear()
+
+    for (const target of this.clientTargets.values()) {
+      target.disabled = true
+      if (target.reconnectTimer) clearTimeout(target.reconnectTimer)
+      target.reconnectTimer = null
+    }
+    this.clientTargets.clear()
+
+    for (const connection of [...this.connections.values()]) {
+      connection.close({ intentional: true })
+    }
+    for (const ws of this.wss.clients) ws.terminate()
+  }
+
+  async shutdown(): Promise<void> {
+    this.forceClose()
+    await new Promise<void>(resolve => this.wss.close(() => resolve()))
   }
 
   async connectToDevice(device: LanDeviceInfo): Promise<LanPeerConnectionInfo> {

--- a/packages/server/src/modules/studio/services/voice/stt/audio-convert.ts
+++ b/packages/server/src/modules/studio/services/voice/stt/audio-convert.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process'
 import { createRequire } from 'node:module'
+import { killOwnedProcessTree } from '../../../infrastructure/process-tree'
 
 const TRANSCODE_TIMEOUT_MS = 30_000
 const DEFAULT_PCM_SAMPLE_RATE = 16000
@@ -28,7 +29,7 @@ function runFfmpeg(args: string[], input: Buffer, timeoutMs: number): Promise<Bu
     const child = spawn('ffmpeg', args, { stdio: ['pipe', 'pipe', 'pipe'] })
 
     const timer = setTimeout(() => {
-      child.kill('SIGKILL')
+      killOwnedProcessTree(child.pid, () => { child.kill('SIGKILL') })
       reject(new Error('ffmpeg transcoding timed out'))
     }, timeoutMs)
 

--- a/packages/server/src/modules/studio/services/voice/stt/local-model-manager.ts
+++ b/packages/server/src/modules/studio/services/voice/stt/local-model-manager.ts
@@ -8,6 +8,7 @@ import { basename, dirname, join } from 'node:path'
 import { createRequire } from 'node:module'
 import * as tar from 'tar'
 import { config } from '../../../public/config'
+import { killOwnedProcessTree } from '../../../infrastructure/process-tree'
 import { transcodeToPcmS16le } from './audio-convert'
 import { SttNoSpeechDetectedError, type SttTranscribeInput, type SttTranscribeResult } from './types'
 
@@ -493,7 +494,9 @@ function stopModelProcess(child: ChildProcess, graceful = true): Promise<void> {
       resolvePromise()
     }
     const forceTimer = setTimeout(() => {
-      if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL')
+      if (child.exitCode === null && child.signalCode === null) {
+        killOwnedProcessTree(child.pid, () => { child.kill('SIGKILL') })
+      }
       finish()
     }, CHILD_EXIT_TIMEOUT_MS)
     forceTimer.unref?.()
@@ -501,10 +504,12 @@ function stopModelProcess(child: ChildProcess, graceful = true): Promise<void> {
 
     if (graceful && child.connected) {
       child.send({ action: 'shutdown' }, error => {
-        if (error && child.exitCode === null && child.signalCode === null) child.kill('SIGTERM')
+        if (error && child.exitCode === null && child.signalCode === null) {
+          killOwnedProcessTree(child.pid, () => { child.kill('SIGTERM') })
+        }
       })
     } else {
-      child.kill('SIGTERM')
+      killOwnedProcessTree(child.pid, () => { child.kill('SIGTERM') })
     }
   })
 }

--- a/tests/server/gateway-respawn.test.ts
+++ b/tests/server/gateway-respawn.test.ts
@@ -261,6 +261,78 @@ describe('gateway-runner supervision', () => {
     expect(fakeChildren).toHaveLength(2)
   })
 
+  it('refuses a late managed gateway start after shutdown begins', async () => {
+    vi.resetModules()
+    const { shutdownManagedGateways, startGatewayRunManaged } = await import(
+      '../../packages/server/src/modules/hermes/services/gateway/runner'
+    )
+
+    await expect(shutdownManagedGateways()).resolves.toEqual({ signaled: 0, forced: 0, errors: 0 })
+
+    expect(startGatewayRunManaged('/usr/bin/hermes', { profileDir: '/tmp/late-start' })).toEqual({
+      pid: null,
+      reused: false,
+    })
+    expect(fakeChildren).toHaveLength(0)
+  })
+
+  it('kills the owned descendant snapshot when the gateway root exits first', async () => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    const listPosixDescendantPids = vi.fn(() => [20002, 20001])
+    const killPosixPid = vi.fn()
+    const { shutdownManagedGateways, startGatewayRunManaged } = await import(
+      '../../packages/server/src/modules/hermes/services/gateway/runner'
+    )
+
+    startGatewayRunManaged('/usr/bin/hermes', { profileDir: '/tmp/descendants' })
+    const shutdown = shutdownManagedGateways({
+      timeoutMs: 5000,
+      platform: 'linux',
+      listPosixDescendantPids,
+      killPosixPid,
+    })
+
+    fakeChildren[0].emit('exit', 0, 'SIGTERM')
+
+    await expect(shutdown).resolves.toEqual({ signaled: 1, forced: 1, errors: 0 })
+    expect(listPosixDescendantPids).toHaveBeenCalledWith(10000)
+    expect(killPosixPid.mock.calls).toEqual([
+      [20002, 'SIGKILL'],
+      [20001, 'SIGKILL'],
+    ])
+  })
+
+  it('force-stops only gateway trees recorded in this process', async () => {
+    vi.resetModules()
+    const listPosixDescendantPids = vi.fn(() => [21001, 21002])
+    const killPosixPid = vi.fn()
+    const { forceStopManagedGateways, startGatewayRunManaged } = await import(
+      '../../packages/server/src/modules/hermes/services/gateway/runner'
+    )
+
+    startGatewayRunManaged('/usr/bin/hermes', { profileDir: '/tmp/force-owned' })
+
+    expect(forceStopManagedGateways({
+      platform: 'linux',
+      listPosixDescendantPids,
+      killPosixPid,
+    })).toBe(1)
+    expect(killPosixPid.mock.calls).toEqual([
+      [21001, 'SIGKILL'],
+      [21002, 'SIGKILL'],
+      [-10000, 'SIGKILL'],
+    ])
+
+    killPosixPid.mockClear()
+    expect(forceStopManagedGateways({
+      platform: 'linux',
+      listPosixDescendantPids,
+      killPosixPid,
+    })).toBe(0)
+    expect(killPosixPid).not.toHaveBeenCalled()
+  })
+
   it('cancels pending respawn timers during managed gateway shutdown', async () => {
     vi.useFakeTimers()
     vi.resetModules()

--- a/tests/server/process-tree.test.ts
+++ b/tests/server/process-tree.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest'
+import { killOwnedProcessTree } from '../../packages/server/src/modules/studio/infrastructure/process-tree'
+
+describe('owned process tree cleanup', () => {
+  it('uses synchronous Windows tree termination instead of killing only the root', () => {
+    const taskkill = vi.fn()
+    const fallback = vi.fn()
+
+    killOwnedProcessTree(4321, fallback, { platform: 'win32', taskkill })
+
+    expect(taskkill).toHaveBeenCalledWith(4321)
+    expect(fallback).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the native child kill when Windows tree termination fails', () => {
+    const taskkill = vi.fn(() => { throw new Error('taskkill failed') })
+    const fallback = vi.fn()
+
+    killOwnedProcessTree(4321, fallback, { platform: 'win32', taskkill })
+
+    expect(fallback).toHaveBeenCalledOnce()
+  })
+
+  it('preserves the existing signal behavior outside Windows', () => {
+    const taskkill = vi.fn()
+    const fallback = vi.fn()
+
+    killOwnedProcessTree(4321, fallback, { platform: 'linux', taskkill })
+
+    expect(taskkill).not.toHaveBeenCalled()
+    expect(fallback).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/server/process-tree.test.ts
+++ b/tests/server/process-tree.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { killOwnedProcessTree } from '../../packages/server/src/modules/studio/infrastructure/process-tree'
+import { killOwnedProcessTree } from '../../packages/server/src/modules/studio/public/process-tree'
 
 describe('owned process tree cleanup', () => {
   it('uses synchronous Windows tree termination instead of killing only the root', () => {

--- a/tests/server/shutdown-background-order.test.ts
+++ b/tests/server/shutdown-background-order.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const closeDbMock = vi.hoisted(() => vi.fn())
 const stopPreviewRuntimeMock = vi.hoisted(() => vi.fn(async () => {}))
 const shutdownManagedGatewaysMock = vi.hoisted(() => vi.fn(async () => ({ stopped: 0 })))
+const forceStopManagedGatewaysMock = vi.hoisted(() => vi.fn())
 const stopOutboundRelayClientMock = vi.hoisted(() => vi.fn())
 const codingAgentShutdownMock = vi.hoisted(() => vi.fn())
 const shutdownLocalSttRuntimeMock = vi.hoisted(() => vi.fn(async () => {}))
@@ -10,6 +11,7 @@ const shutdownLocalSttRuntimeMock = vi.hoisted(() => vi.fn(async () => {}))
 vi.mock('../../packages/server/src/modules/studio/infrastructure/database/index', () => ({ closeDb: closeDbMock }))
 vi.mock('../../packages/server/src/bootstrap/update', () => ({ stopPreviewRuntime: stopPreviewRuntimeMock }))
 vi.mock('../../packages/server/src/modules/hermes/services/gateway/runner', () => ({
+  forceStopManagedGateways: forceStopManagedGatewaysMock,
   shutdownManagedGateways: shutdownManagedGatewaysMock,
 }))
 vi.mock('../../packages/server/src/modules/studio/services/voice/stt/local-model-manager', () => ({
@@ -28,6 +30,7 @@ vi.mock('../../packages/server/src/modules/studio/public/logging', () => ({
 vi.mock('../../packages/server/src/modules/studio/infrastructure/database', () => ({ closeDb: closeDbMock }))
 vi.mock('../../packages/server/src/bootstrap/update', () => ({ stopPreviewRuntime: stopPreviewRuntimeMock }))
 vi.mock('../../packages/server/src/modules/hermes/services/gateway/runner', () => ({
+  forceStopManagedGateways: forceStopManagedGatewaysMock,
   shutdownManagedGateways: shutdownManagedGatewaysMock,
 }))
 vi.mock('../../packages/server/src/modules/coding-agents/services/runtime/run-manager', () => ({
@@ -105,6 +108,30 @@ describe('graceful shutdown background delivery ordering', () => {
     expect(process.exit).toHaveBeenCalledWith(0)
   })
 
+  it('force-stops the bridge process tree immediately on Windows', async () => {
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    try {
+      const agentBridgeManager = {
+        stop: vi.fn(async () => {}),
+        forceStop: vi.fn(),
+      }
+      const httpServer = {
+        close: vi.fn((callback: () => void) => callback()),
+      }
+      vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+      const { createShutdownHandler } = await import('../../packages/server/src/bootstrap/lifecycle')
+
+      await createShutdownHandler(httpServer, undefined, undefined, agentBridgeManager)('desktop-request')
+
+      expect(agentBridgeManager.forceStop).toHaveBeenCalledOnce()
+      expect(agentBridgeManager.stop).not.toHaveBeenCalled()
+      expect(process.exit).toHaveBeenCalledWith(0)
+    } finally {
+      if (platformDescriptor) Object.defineProperty(process, 'platform', platformDescriptor)
+    }
+  })
+
   it('force-kills the bridge before the shutdown deadline exits the server', async () => {
     stopPreviewRuntimeMock.mockImplementationOnce(() => new Promise<void>(() => {}))
     const agentBridgeManager = {
@@ -119,7 +146,9 @@ describe('graceful shutdown background delivery ordering', () => {
     await Promise.resolve()
     await vi.advanceTimersByTimeAsync(getShutdownForceExitMs())
 
+    expect(forceStopManagedGatewaysMock).toHaveBeenCalledOnce()
     expect(agentBridgeManager.forceStop).toHaveBeenCalledOnce()
+    expect(codingAgentShutdownMock).toHaveBeenCalledOnce()
     expect(exitSpy).toHaveBeenCalledWith(0)
   })
 
@@ -138,8 +167,38 @@ describe('graceful shutdown background delivery ordering', () => {
     await Promise.resolve()
     await vi.advanceTimersByTimeAsync(getShutdownForceExitMs())
 
+    expect(forceStopManagedGatewaysMock).toHaveBeenCalledOnce()
     expect(agentBridgeManager.stop).not.toHaveBeenCalled()
     expect(agentBridgeManager.forceStop).not.toHaveBeenCalled()
+    expect(codingAgentShutdownMock).toHaveBeenCalledOnce()
     expect(exitSpy).toHaveBeenCalledWith(0)
+  })
+
+  it('continues cleanup after one runtime fails and preserves a fatal exit code', async () => {
+    const order: string[] = []
+    const httpServer = {
+      close: vi.fn((callback: () => void) => {
+        order.push('http-close')
+        callback()
+      }),
+    }
+    const firstClose = vi.fn(async () => {
+      order.push('first-close')
+      throw new Error('close failed')
+    })
+    const secondClose = vi.fn(() => {
+      order.push('second-close')
+    })
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+    const { createShutdownHandler } = await import('../../packages/server/src/bootstrap/lifecycle')
+
+    await createShutdownHandler(httpServer, undefined, undefined, undefined, [
+      { name: 'first runtime', close: firstClose },
+      { name: 'second runtime', close: secondClose },
+    ])('bootstrap-error', 1)
+
+    expect(order).toEqual(['first-close', 'second-close', 'http-close'])
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(closeDbMock).toHaveBeenCalledOnce()
   })
 })

--- a/tests/server/shutdown-websocket-runtimes.test.ts
+++ b/tests/server/shutdown-websocket-runtimes.test.ts
@@ -1,0 +1,17 @@
+import { EventEmitter } from 'events'
+import type { Server as HttpServer } from 'http'
+import { describe, expect, it } from 'vitest'
+import { setupKanbanEventsWebSocket } from '../../packages/server/src/modules/hermes/sockets/kanban-events'
+
+describe('shutdown-owned WebSocket runtimes', () => {
+  it('detaches the Kanban upgrade handler and closes idempotently', async () => {
+    const httpServer = new EventEmitter() as HttpServer
+    const runtime = setupKanbanEventsWebSocket(httpServer)
+
+    expect(httpServer.listenerCount('upgrade')).toBe(1)
+
+    await Promise.all([runtime.close(), runtime.close()])
+
+    expect(httpServer.listenerCount('upgrade')).toBe(0)
+  })
+})

--- a/tests/server/shutdown.test.ts
+++ b/tests/server/shutdown.test.ts
@@ -42,11 +42,11 @@ describe('shutdown bridge policy', () => {
     expect(shouldStopAgentBridgeOnShutdown('SIGTERM')).toBe(false)
   })
 
-  it('stops managed gateways by default in production only', () => {
+  it('stops Studio-owned managed gateways by default in every runtime', () => {
     delete process.env.HERMES_WEB_UI_STOP_GATEWAYS_ON_SHUTDOWN
 
     process.env.NODE_ENV = 'development'
-    expect(shouldStopManagedGatewaysOnShutdown()).toBe(false)
+    expect(shouldStopManagedGatewaysOnShutdown()).toBe(true)
 
     process.env.NODE_ENV = 'production'
     expect(shouldStopManagedGatewaysOnShutdown()).toBe(true)
@@ -62,14 +62,14 @@ describe('shutdown bridge policy', () => {
     expect(shouldStopManagedGatewaysOnShutdown()).toBe(false)
   })
 
-  it('keeps desktop shutdown force-exit timing long enough for runtime cleanup by default', () => {
+  it('uses a short bounded cleanup window before force-exiting by default', () => {
     delete process.env.HERMES_WEB_UI_SHUTDOWN_FORCE_EXIT_MS
 
     delete process.env.HERMES_DESKTOP
-    expect(getShutdownForceExitMs()).toBe(15_000)
+    expect(getShutdownForceExitMs()).toBe(10_000)
 
     process.env.HERMES_DESKTOP = 'true'
-    expect(getShutdownForceExitMs()).toBe(15_000)
+    expect(getShutdownForceExitMs()).toBe(10_000)
   })
 
   it('allows operators to override shutdown force-exit timing', () => {


### PR DESCRIPTION
## Summary

- route signals, fatal bootstrap failures, and Desktop shutdown requests through one bounded cleanup pipeline
- stop only gateways started and tracked by the current Studio process, while preventing late gateway respawns during shutdown
- close Studio websocket and background runtimes and terminate their owned process trees, using taskkill /T /F on Windows
- use a 10-second Web UI cleanup deadline while leaving the existing Desktop 18/20-second stop and upgrade behavior unchanged

## Validation

- env -u PORT npm test -- tests/server
  - 283 files passed, 2 skipped
  - 2745 tests passed, 5 skipped
- npx tsc --noEmit -p packages/server/tsconfig.json
- npm --prefix packages/desktop run build:main
- git diff --check

## Notes

- externally discovered gateways are not adopted or stopped
- the existing Windows Desktop startup recovery and Desktop updater/runtime migration flows are unchanged