### PR TITLE
fix(chat): preserve Recent collapse across refresh

### DIFF
--- a/docs/chat-chain-changes/2026-08-27-recent-session-refresh-collapse.md
+++ b/docs/chat-chain-changes/2026-08-27-recent-session-refresh-collapse.md
@@ -1,0 +1,5 @@
+# Preserve Recent category collapse across refresh
+
+- Persist the session selected through the Recent shortcut for the lifetime of the current browser tab.
+- Reloading that tab no longer expands the session's real category or overwrites its saved collapsed state.
+- Ordinary category, pinned-session, and direct navigation continue to clear or omit the shortcut marker and retain normal category reveal behavior.

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -328,7 +328,13 @@ async function submitBrowserAnnotations(payload: BrowserAnnotationSubmission): P
   return true;
 }
 
-async function handleSessionClick(sessionId: string) {
+async function handleSessionClick(
+  sessionId: string,
+  options: { preserveCategoryCollapse?: boolean } = {},
+) {
+  if (!options.preserveCategoryCollapse) {
+    setCategoryRevealSuppressedSessionId(null);
+  }
   chatStore.clearSessionCompletedUnread(sessionId);
   await router.push({
     name: chatStore.runtimeMode === "global_agent" ? "hermes.globalAgentSession" : "hermes.session",
@@ -342,8 +348,8 @@ async function handleSessionClick(sessionId: string) {
 
 async function handleRecentSessionClick(sessionId: string) {
   // Recent is a shortcut; selecting it must not overwrite the real category's saved collapse state.
-  categoryRevealSuppressedSessionId.value = sessionId;
-  await handleSessionClick(sessionId);
+  setCategoryRevealSuppressedSessionId(sessionId);
+  await handleSessionClick(sessionId, { preserveCategoryCollapse: true });
 }
 
 function handleMobileChange(e: MediaQueryListEvent | MediaQueryList) {
@@ -527,6 +533,7 @@ const sessionCategoriesLoaded = ref(false);
 const sessionCategoriesLoadFailed = ref(false);
 let sessionCategoriesLoadPromise: Promise<void> | null = null;
 const COLLAPSED_CATEGORIES_STORAGE_KEY = "hermes_chat_collapsed_categories";
+const RECENT_CATEGORY_REVEAL_SUPPRESSION_STORAGE_KEY = "hermes_chat_recent_category_reveal_suppression";
 const showRecentCountModal = ref(false);
 const recentCountDraft = ref(sessionBrowserPrefsStore.recentCount);
 
@@ -540,7 +547,31 @@ function loadCollapsedCategories(): Set<string> {
 }
 
 const collapsedCategories = ref<Set<string>>(loadCollapsedCategories());
-const categoryRevealSuppressedSessionId = ref<string | null>(null);
+
+function loadCategoryRevealSuppressedSessionId(): string | null {
+  try {
+    return sessionStorage.getItem(RECENT_CATEGORY_REVEAL_SUPPRESSION_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+const categoryRevealSuppressedSessionId = ref<string | null>(
+  loadCategoryRevealSuppressedSessionId(),
+);
+
+function setCategoryRevealSuppressedSessionId(sessionId: string | null) {
+  categoryRevealSuppressedSessionId.value = sessionId;
+  try {
+    if (sessionId) {
+      sessionStorage.setItem(RECENT_CATEGORY_REVEAL_SUPPRESSION_STORAGE_KEY, sessionId);
+    } else {
+      sessionStorage.removeItem(RECENT_CATEGORY_REVEAL_SUPPRESSION_STORAGE_KEY);
+    }
+  } catch {
+    // Keep the in-memory behavior when session storage is unavailable.
+  }
+}
 
 function persistCollapsedCategories() {
   localStorage.setItem(
@@ -646,7 +677,7 @@ watch(
     if (!sessionCategoriesLoaded.value || categorizedSessions.value.length === 0) return;
     const activeSession = chatStore.sessions.find((session) => session.id === chatStore.activeSessionId);
     if (categoryRevealSuppressedSessionId.value === activeSession?.id) return;
-    categoryRevealSuppressedSessionId.value = null;
+    setCategoryRevealSuppressedSessionId(null);
     const activeKey = activeSession?.categoryId == null
       ? "category-none"
       : `category-${activeSession.categoryId}`;

--- a/tests/e2e/session-categories.spec.ts
+++ b/tests/e2e/session-categories.spec.ts
@@ -139,6 +139,14 @@ test('selects a recent session without expanding its collapsed category', async 
   await expect(page.getByRole('link', { name: /Project Alpha/ })).toHaveCount(1)
   await expect.poll(() => page.evaluate(() => localStorage.getItem('hermes_chat_collapsed_categories')))
     .toContain('category-1')
+
+  await page.reload()
+
+  await expect(page).toHaveURL(/\/hermes\/session\/work-session$/)
+  await expect(page.getByRole('link', { name: /Project Alpha/ }).first()).toHaveClass(/active/)
+  await expect(page.getByRole('link', { name: /Project Alpha/ })).toHaveCount(1)
+  await expect.poll(() => page.evaluate(() => localStorage.getItem('hermes_chat_collapsed_categories')))
+    .toContain('category-1')
 })
 
 test('persists the collapsed recent group across reloads without changing the active session', async ({ page }) => {


### PR DESCRIPTION
## Summary

- persist the Recent-origin category reveal suppression for the lifetime of the current browser tab
- preserve the real category's collapsed state after F5/reload
- clear the marker on ordinary session selection so normal category reveal behavior remains intact
- retain in-memory fallback when session storage is unavailable

## Root cause

PR #2742 stored the Recent-origin session only in a Vue `ref`. Reloading recreated `ChatPanel`, lost the ref, and allowed the active-session watcher to remove the real category from the persisted collapsed set.

## RED / GREEN

The existing Recent regression test now reloads after selecting `Project Alpha`:

- RED on current `main`: expected one visible `Project Alpha` row, received two
- GREEN after this change: the Recent row remains active and `category-1` remains collapsed after reload

## Validation

- `NODE_ENV=test npx playwright test tests/e2e/session-categories.spec.ts` — 9 passed
- `NODE_ENV=test npx vitest run tests/client/session-category-groups.test.ts` — 5 passed
- `NODE_ENV=development npm run harness:check` — passed, including Ekko public API docs check
- `NODE_ENV=development npm run build` — passed

Closes #2753

Reported during installation acceptance of #2742. This PR is left unmerged pending a new LPK acceptance round.
