### PR TITLE
fix(codex): bound historical inline image context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5093,13 +5093,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+      "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -7120,16 +7120,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -7378,9 +7378,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -9044,9 +9044,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/packages/server/src/bootstrap/http.ts
+++ b/packages/server/src/bootstrap/http.ts
@@ -51,11 +51,12 @@ import { getStaticCacheControl, SPA_ENTRY_CACHE_CONTROL } from '../modules/studi
 import { requireUserJwt, resolveUserProfile } from '../modules/studio/middleware/auth'
 import { createCorsOriginResolver, securityHeaders } from '../modules/studio/middleware/security'
 import type { AdditionalShutdownStep, ShutdownHandler } from './lifecycle'
-import { createRequestBodyParser } from '../modules/studio/middleware/request-body-parser'
+import { createCodexProxyRequestBodyParser, createRequestBodyParser } from '../modules/studio/middleware/request-body-parser'
 import {
   migratePersistedPiRuntimeMcpConfigs,
   restorePersistedPiProxyTargets,
 } from './coding-agents'
+import { isAuthorizedCodexProxyRequest } from '../modules/coding-agents/services/codex/proxy'
 
 // Injected by esbuild at build time; fallback to reading package.json in dev mode
 declare const __APP_VERSION__: string
@@ -355,6 +356,9 @@ export async function bootstrap() {
 
   app.use(securityHeaders())
   app.use(cors({ origin: createCorsOriginResolver(config.corsOrigins) }))
+  // Codex Responses requests may briefly exceed the public API limit before
+  // the proxy bounds historical inline images and tool outputs.
+  app.use(createCodexProxyRequestBodyParser(isAuthorizedCodexProxyRequest))
   // Raise body limits above the default 1mb: profile avatars and MiMo voice-clone
   // reference audio are posted as base64 data URLs before reaching handlers.
   app.use(createRequestBodyParser())

--- a/packages/server/src/modules/coding-agents/protocol/adapters/responses.ts
+++ b/packages/server/src/modules/coding-agents/protocol/adapters/responses.ts
@@ -13,6 +13,7 @@ const TOOL_SEARCH_NAME = 'tool_search'
 const RESPONSES_TOOL_OUTPUT_FORWARD_LIMIT = 32 * 1024
 const RESPONSES_TOOL_OUTPUT_HEAD_BYTES = 24 * 1024
 const RESPONSES_TOOL_OUTPUT_TAIL_BYTES = 7 * 1024
+const RESPONSES_INLINE_IMAGE_FORWARD_LIMIT = 8 * 1024 * 1024
 
 const HERMES_STUDIO_MCP_TOOLS = [
   {
@@ -366,12 +367,87 @@ function truncateResponsesToolOutputText(output: string): string {
   ].join('\n')
 }
 
+function inlineResponseImageUrl(part: any): string {
+  if (!part || typeof part !== 'object' || part.type !== 'input_image') return ''
+  const imageUrl = typeof part.image_url === 'string'
+    ? part.image_url
+    : typeof part.image_url?.url === 'string'
+      ? part.image_url.url
+      : ''
+  return imageUrl.startsWith('data:image/') ? imageUrl : ''
+}
+
+function responseImageOmission(reason: 'duplicate' | 'budget', originalBytes: number): any {
+  const description = reason === 'duplicate'
+    ? 'duplicate historical inline image omitted before provider request'
+    : 'historical inline image omitted before provider request'
+  return {
+    type: 'input_text',
+    text: `[Hermes Web UI: ${description}; original_bytes=${originalBytes}]`,
+  }
+}
+
+function boundResponsesInlineImages(input: any[]): { input: any[]; changed: boolean } {
+  const omitted = new Map<any, 'duplicate' | 'budget'>()
+  const seen = new Set<string>()
+  let forwardedBytes = 0
+  let preservedImages = 0
+
+  // Preserve the newest unique images first. Older screenshots are historical
+  // context and must not crowd the current turn out of the provider request.
+  for (let itemIndex = input.length - 1; itemIndex >= 0; itemIndex -= 1) {
+    const item = input[itemIndex]
+    for (const key of ['output', 'content'] as const) {
+      const parts = Array.isArray(item?.[key]) ? item[key] : []
+      for (let partIndex = parts.length - 1; partIndex >= 0; partIndex -= 1) {
+        const part = parts[partIndex]
+        const imageUrl = inlineResponseImageUrl(part)
+        if (!imageUrl) continue
+        if (seen.has(imageUrl)) {
+          omitted.set(part, 'duplicate')
+          continue
+        }
+        seen.add(imageUrl)
+        const imageBytes = utf8ByteLength(imageUrl)
+        if (preservedImages > 0 && forwardedBytes + imageBytes > RESPONSES_INLINE_IMAGE_FORWARD_LIMIT) {
+          omitted.set(part, 'budget')
+          continue
+        }
+        forwardedBytes += imageBytes
+        preservedImages += 1
+      }
+    }
+  }
+
+  if (!omitted.size) return { input, changed: false }
+  return {
+    changed: true,
+    input: input.map((item: any) => {
+      if (!item || typeof item !== 'object') return item
+      let changed = false
+      const nextItem = { ...item }
+      for (const key of ['content', 'output'] as const) {
+        if (!Array.isArray(item[key])) continue
+        const nextParts = item[key].map((part: any) => {
+          const reason = omitted.get(part)
+          if (!reason) return part
+          changed = true
+          return responseImageOmission(reason, utf8ByteLength(inlineResponseImageUrl(part)))
+        })
+        if (changed) nextItem[key] = nextParts
+      }
+      return changed ? nextItem : item
+    }),
+  }
+}
+
 export function truncateResponsesToolOutputs(body: any): any {
   const input = responseInputItems(body)
   if (!input.length) return body
 
-  let changed = false
-  const nextInput = input.map((item: any) => {
+  const boundedImages = boundResponsesInlineImages(input)
+  let changed = boundedImages.changed
+  const nextInput = boundedImages.input.map((item: any) => {
     if (!item || typeof item !== 'object' || item.type !== 'function_call_output' || typeof item.output !== 'string') {
       return item
     }

--- a/packages/server/src/modules/coding-agents/services/codex/proxy.ts
+++ b/packages/server/src/modules/coding-agents/services/codex/proxy.ts
@@ -80,6 +80,12 @@ function authToken(ctx: Context): string {
   return match?.[1]?.trim() || ''
 }
 
+export function isAuthorizedCodexProxyRequest(ctx: Context): boolean {
+  const routeKey = /^\/api\/codex-proxy\/([^/]+)\/v1\/responses$/.exec(ctx.path)?.[1] || ''
+  const target = findTarget(routeKey)
+  return Boolean(target && authToken(ctx) === target.token)
+}
+
 function requireTarget(ctx: Context): CodexProxyTarget | null {
   const target = findTarget(String(ctx.params.key || ''))
   if (!target) {

--- a/packages/server/src/modules/studio/middleware/request-body-parser.ts
+++ b/packages/server/src/modules/studio/middleware/request-body-parser.ts
@@ -15,3 +15,21 @@ export function createRequestBodyParser() {
     parsedMethods: ['POST', 'PUT', 'PATCH', 'DELETE'],
   })
 }
+
+export function createCodexProxyRequestBodyParser(isAuthorized: (ctx: any) => boolean) {
+  const parse = bodyParser({
+    encoding: 'utf-8',
+    enableTypes: ['json'],
+    jsonLimit: '64mb',
+    parsedMethods: ['POST'],
+  })
+  return async (ctx: any, next: any) => {
+    if (!/^\/api\/codex-proxy\/[^/]+\/v1\/responses$/.test(ctx.path)) return next()
+    if (!isAuthorized(ctx)) {
+      ctx.status = 401
+      ctx.body = { error: { type: 'authentication_error', message: 'Invalid Codex proxy token' } }
+      return
+    }
+    return parse(ctx, next)
+  }
+}

--- a/tests/server/agent-runner-adapters.test.ts
+++ b/tests/server/agent-runner-adapters.test.ts
@@ -75,6 +75,79 @@ describe('agent runner Responses adapters', () => {
     expect(cjkTruncated.endsWith('TAIL_MARKER')).toBe(true)
   })
 
+  it('bounds historical inline images while preserving the newest image context', () => {
+    const image = (fill: string, bytes: number) => `data:image/png;base64,${fill.repeat(bytes)}`
+    const oldest = image('A', 4 * 1024 * 1024)
+    const middle = image('B', 4 * 1024 * 1024)
+    const newest = image('C', 4 * 1024 * 1024)
+    const body = {
+      input: [
+        { role: 'user', content: [{ type: 'input_text', text: 'old' }, { type: 'input_image', image_url: oldest }] },
+        { type: 'function_call_output', call_id: 'call_image', output: [{ type: 'input_image', image_url: middle }] },
+        { role: 'user', content: [{ type: 'input_text', text: 'current' }, { type: 'input_image', image_url: newest }] },
+      ],
+    }
+
+    const sanitized = truncateResponsesToolOutputs(body)
+    const serialized = JSON.stringify(sanitized)
+
+    expect(sanitized).not.toBe(body)
+    expect(serialized).not.toContain(oldest)
+    expect(serialized).not.toContain(middle)
+    expect(serialized).toContain(newest)
+    expect(serialized).toContain('historical inline image omitted before provider request')
+    expect(body.input[0].content[1].image_url).toBe(oldest)
+  })
+
+  it('deduplicates identical historical inline images without dropping the newest copy', () => {
+    const shared = `data:image/jpeg;base64,${'D'.repeat(5 * 1024 * 1024)}`
+    const body = {
+      input: [
+        { role: 'user', content: [{ type: 'input_image', image_url: shared }] },
+        { type: 'function_call_output', call_id: 'call_same', output: [{ type: 'input_image', image_url: shared }] },
+      ],
+    }
+
+    const sanitized = truncateResponsesToolOutputs(body)
+    const serialized = JSON.stringify(sanitized)
+
+    expect(serialized.match(/data:image\/jpeg;base64,/g) || []).toHaveLength(1)
+    expect(serialized).toContain('duplicate historical inline image omitted before provider request')
+  })
+
+  it('keeps the newest inline image even when it alone exceeds the history budget', () => {
+    const newest = `data:image/png;base64,${'E'.repeat(9 * 1024 * 1024)}`
+    const sanitized = truncateResponsesToolOutputs({
+      input: [{ role: 'user', content: [{ type: 'input_image', image_url: newest }] }],
+    })
+
+    expect(JSON.stringify(sanitized)).toContain(newest)
+  })
+
+  it('shrinks a production-shaped screenshot history below the parser forwarding ceiling', () => {
+    const imageSizes = [
+      2_669_482, 1_610_290, 1_413_018, 1_412_674, 1_119_830, 1_078_366,
+      1_055_042, 788_558, 753_866, 728_194, 693_342, 619_554, 605_414,
+      595_074, 557_990, 505_554, 492_254, 248_319, 248_319, 205_695,
+      163_510, 132_202, 109_514,
+    ]
+    const body = {
+      instructions: 'system context'.repeat(250_000),
+      input: imageSizes.map((size, index) => ({
+        role: 'user',
+        content: [{
+          type: 'input_image',
+          image_url: `data:image/png;base64,${String(index % 10).repeat(size)}`,
+        }],
+      })),
+    }
+
+    expect(Buffer.byteLength(JSON.stringify(body), 'utf8')).toBeGreaterThan(20 * 1024 * 1024)
+    const sanitized = truncateResponsesToolOutputs(body)
+    expect(Buffer.byteLength(JSON.stringify(sanitized), 'utf8')).toBeLessThan(12 * 1024 * 1024)
+    expect(JSON.stringify(sanitized)).toContain(body.input.at(-1)?.content[0].image_url)
+  })
+
   it('converts Responses input to OpenAI Chat messages and tools', () => {
     const body = {
       instructions: 'be terse',

--- a/tests/server/bootstrap-body-limit.test.ts
+++ b/tests/server/bootstrap-body-limit.test.ts
@@ -1,17 +1,48 @@
+import { Readable } from 'node:stream'
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
+import { createCodexProxyRequestBodyParser } from '../../packages/server/src/modules/studio/middleware/request-body-parser'
 
 describe('bootstrap body parser limits', () => {
-  it('allows MiMo voice-clone JSON payloads advertised by the UI/docs', () => {
+  it('keeps the global parser at 20 MiB and isolates the Codex proxy allowance', () => {
     const source = readFileSync('packages/server/src/modules/studio/middleware/request-body-parser.ts', 'utf8')
+    const bootstrap = readFileSync('packages/server/src/bootstrap/http.ts', 'utf8')
 
     expect(source).toContain("jsonLimit: '20mb'")
     expect(source).toContain("formLimit: '20mb'")
+    expect(source).toContain('/api\\/codex-proxy\\/[^/]+\\/v1\\/responses$')
+    expect(source.indexOf('if (!isAuthorized(ctx))')).toBeLessThan(source.indexOf('return parse(ctx, next)'))
+    expect(source).toContain("jsonLimit: '64mb'")
+    expect(bootstrap.indexOf('createCodexProxyRequestBodyParser(isAuthorizedCodexProxyRequest)')).toBeLessThan(bootstrap.indexOf('createRequestBodyParser()'))
   })
 
   it('parses DELETE request bodies for file operations', () => {
     const source = readFileSync('packages/server/src/modules/studio/middleware/request-body-parser.ts', 'utf8')
 
     expect(source).toMatch(/parsedMethods:\s*\[\s*'POST',\s*'PUT',\s*'PATCH',\s*'DELETE'\s*\]/)
+  })
+
+  it('rejects unauthorized Codex proxy bodies before reading the request stream', async () => {
+    let reads = 0
+    const request = new Readable({
+      read() {
+        reads += 1
+        this.push('{"input":[]}')
+        this.push(null)
+      },
+    }) as any
+    request.headers = { 'content-type': 'application/json' }
+    request.method = 'POST'
+    const ctx: any = {
+      path: '/api/codex-proxy/unknown/v1/responses',
+      req: request,
+      request: { req: request },
+    }
+    const middleware = createCodexProxyRequestBodyParser(() => false)
+
+    await middleware(ctx, async () => {})
+
+    expect(ctx.status).toBe(401)
+    expect(reads).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary

- preserve the newest unique inline image context while bounding historical image data to 8 MiB
- deduplicate repeated image data URIs and replace omitted history with explicit text markers
- allow up to 64 MiB only on the authenticated Codex Responses proxy route so sanitation can run; keep the global JSON limit at 20 MiB

Closes #2757

## Evidence

- live failing thread: 23 inline images / 17,806,061 bytes; Responses items 21,113,207 bytes
- RED sabotage: new regressions fail on exact upstream base
- `npx vitest run tests/server/agent-runner-adapters.test.ts tests/server/bootstrap-body-limit.test.ts tests/server/coding-agents-launch.test.ts` — 100 passed
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm run harness:check`
- `npm run build`
- full-suite baseline/candidate comparison: both had 50 failures; differing failures passed on focused rerun and are unrelated to this server-only change
- independent exact-diff review: PASS

## Safety

- unauthorized proxy requests are rejected before request body consumption
- non-Codex JSON endpoints retain the 20 MiB global parser limit
- input payload objects are not mutated