### PR TITLE
[fix] speed up Agents status loading

### DIFF
--- a/packages/client/src/api/agent-status.ts
+++ b/packages/client/src/api/agent-status.ts
@@ -9,6 +9,7 @@ export interface AgentStatusRecord {
   source: AgentStatusSource
   path: string
   version: string
+  error?: string
 }
 
 export interface AgentStatusSnapshot {

--- a/packages/client/src/views/hermes/AgentManagerView.vue
+++ b/packages/client/src/views/hermes/AgentManagerView.vue
@@ -12,10 +12,8 @@ import {
   type CodingAgentToolStatus,
   type CodingAgentUpdateResult,
 } from '@/api/coding-agents'
-import {
-  fetchRuntimeVersionStatus,
-  type RuntimeVersionStatus,
-} from '@/api/hermes/runtime-versions'
+import { fetchAgentStatusSnapshot, type AgentStatusSnapshot } from '@/api/agent-status'
+import { fetchRuntimeVersionStatus } from '@/api/hermes/runtime-versions'
 import VersionManagementModal from '@/components/layout/VersionManagementModal.vue'
 import { useAppStore } from '@/stores/hermes/app'
 
@@ -24,6 +22,8 @@ interface CodingAgentCard {
   name: string
   provider: string
   logo: string
+  command: string
+  packageName: string
 }
 
 defineProps<{
@@ -35,9 +35,30 @@ const emit = defineEmits<{
 }>()
 
 const codingAgents: CodingAgentCard[] = [
-  { id: 'claude-code', name: 'Claude', provider: 'Anthropic', logo: '/coding-agents/claude-code.svg' },
-  { id: 'codex', name: 'Codex', provider: 'OpenAI', logo: '/coding-agents/codex-openai.png' },
-  { id: 'pi', name: 'Pi', provider: 'Pi', logo: '/coding-agents/pi.svg' },
+  {
+    id: 'claude-code',
+    name: 'Claude',
+    provider: 'Anthropic',
+    logo: '/coding-agents/claude-code.svg',
+    command: 'claude',
+    packageName: '@anthropic-ai/claude-code',
+  },
+  {
+    id: 'codex',
+    name: 'Codex',
+    provider: 'OpenAI',
+    logo: '/coding-agents/codex-openai.png',
+    command: 'codex',
+    packageName: '@openai/codex',
+  },
+  {
+    id: 'pi',
+    name: 'Pi',
+    provider: 'Pi',
+    logo: '/coding-agents/pi.svg',
+    command: 'pi',
+    packageName: '@earendil-works/pi-coding-agent',
+  },
 ]
 
 const { t } = useI18n()
@@ -47,7 +68,7 @@ const route = useRoute()
 const router = useRouter()
 
 const tools = ref<CodingAgentToolStatus[]>([])
-const runtimeStatus = ref<RuntimeVersionStatus | null>(null)
+const agentStatusSnapshot = ref<AgentStatusSnapshot | null>(null)
 const loading = ref(false)
 const loadError = ref('')
 const runtimeManagerVisible = ref(false)
@@ -60,29 +81,21 @@ const updateInfo = ref<Record<CodingAgentId, CodingAgentUpdateResult | null>>({
   pi: null,
 })
 
-const allCliInstallations = computed(() => runtimeStatus.value?.hermes.cliInstallations || [])
-const hermesDetected = computed(() => Boolean(
-  runtimeStatus.value?.hermes.agentVersion
-  || allCliInstallations.value.length,
-))
-const hermesVersion = computed(() => formatVersion(
-  allCliInstallations.value.find(item => item.selected)?.version
-  || runtimeStatus.value?.hermes.agentVersion
-  || runtimeStatus.value?.hermes.activeVersion
-  || allCliInstallations.value[0]?.version,
-))
+const hermesStatus = computed(() => agentStatusSnapshot.value?.agents.find(agent => agent.id === 'hermes'))
+const hermesDetected = computed(() => Boolean(hermesStatus.value?.installed))
+const hermesVersion = computed(() => formatHermesVersion(hermesStatus.value?.version))
 const hermesType = computed<'CLI' | 'Runtime' | ''>(() => {
-  const selected = allCliInstallations.value.find(item => item.selected)
-  if (selected) return selected.source === 'user-cli' ? 'CLI' : 'Runtime'
-
-  const activeRuntime = runtimeStatus.value?.hermes.installed.some(item => item.active)
-    || Boolean(runtimeStatus.value?.hermes.activeVersion)
-  if (activeRuntime) return 'Runtime'
-  return allCliInstallations.value.some(item => item.source === 'user-cli') ? 'CLI' : ''
+  if (hermesStatus.value?.source === 'user-cli') return 'CLI'
+  if (hermesStatus.value?.source === 'managed-runtime') return 'Runtime'
+  return ''
 })
 
 watch(runtimeManagerVisible, (visible, previous) => {
-  if (!visible && previous) void loadRuntimeStatus()
+  if (!visible && previous) {
+    void syncAgentStatus().catch((error) => {
+      loadError.value = errorMessage(error)
+    })
+  }
 })
 
 function toolStatus(id: CodingAgentId): CodingAgentToolStatus | undefined {
@@ -93,6 +106,10 @@ function formatVersion(value?: string): string {
   const version = value?.trim()
   if (!version) return t('agentManager.unknownVersion')
   return /^v(?=\d)/i.test(version) ? version : `v${version}`
+}
+
+function formatHermesVersion(value?: string): string {
+  return formatVersion(value?.split('·')[0])
 }
 
 function installedVersion(id: CodingAgentId): string {
@@ -112,21 +129,54 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
-async function loadCodingAgents() {
-  tools.value = (await fetchCodingAgentsStatus()).tools
+function applyAgentStatusSnapshot(snapshot: AgentStatusSnapshot) {
+  agentStatusSnapshot.value = snapshot
+  const statuses = new Map(snapshot.agents.map(status => [status.id, status]))
+  tools.value = codingAgents.map((agent) => {
+    const status = statuses.get(agent.id)
+    return {
+      ...agent,
+      installed: Boolean(status?.installed),
+      version: status?.version || '',
+      rawVersion: status?.version || '',
+      source: status?.source === 'user-cli' ? 'user-cli' : 'not-installed',
+      path: status?.path || '',
+      error: status?.error || '',
+    }
+  })
 }
 
-async function loadRuntimeStatus() {
-  runtimeStatus.value = await fetchRuntimeVersionStatus({ includeRemote: false })
+async function syncAgentStatus() {
+  applyAgentStatusSnapshot(await fetchAgentStatusSnapshot())
 }
 
-async function loadAll() {
+async function loadCachedStatus() {
   loading.value = true
   loadError.value = ''
-  const results = await Promise.allSettled([loadCodingAgents(), loadRuntimeStatus()])
+  try {
+    await syncAgentStatus()
+  } catch (error) {
+    loadError.value = errorMessage(error)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function refreshAll() {
+  loading.value = true
+  loadError.value = ''
+  const results = await Promise.allSettled([
+    fetchCodingAgentsStatus(),
+    fetchRuntimeVersionStatus({ includeRemote: false }),
+  ])
   const errors = results
     .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
     .map(result => errorMessage(result.reason))
+  try {
+    await syncAgentStatus()
+  } catch (error) {
+    errors.push(errorMessage(error))
+  }
   if (errors.length) loadError.value = errors.join('\n')
   loading.value = false
 }
@@ -182,7 +232,7 @@ onMounted(() => {
     delete query.runtime
     void router.replace({ query })
   }
-  void loadAll()
+  void loadCachedStatus()
 })
 </script>
 
@@ -210,7 +260,7 @@ onMounted(() => {
           </NButton>
           <h2 class="header-title">{{ t('agentManager.title') }}</h2>
         </div>
-        <NButton size="small" secondary :loading="loading" @click="loadAll()">
+        <NButton size="small" secondary :loading="loading" @click="refreshAll()">
           {{ t('agentManager.refresh') }}
         </NButton>
       </header>

--- a/tests/client/agent-manager-page.test.ts
+++ b/tests/client/agent-manager-page.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const api = vi.hoisted(() => ({
   checkCodingAgentUpdate: vi.fn(),
   deleteCodingAgent: vi.fn(),
+  fetchAgentStatusSnapshot: vi.fn(),
   fetchCodingAgentsStatus: vi.fn(),
   fetchRuntimeVersionStatus: vi.fn(),
   installCodingAgent: vi.fn(),
@@ -18,6 +19,10 @@ vi.mock('@/api/coding-agents', () => ({
   deleteCodingAgent: api.deleteCodingAgent,
   fetchCodingAgentsStatus: api.fetchCodingAgentsStatus,
   installCodingAgent: api.installCodingAgent,
+}))
+
+vi.mock('@/api/agent-status', () => ({
+  fetchAgentStatusSnapshot: api.fetchAgentStatusSnapshot,
 }))
 
 vi.mock('@/api/hermes/runtime-versions', () => ({
@@ -96,7 +101,7 @@ function runtimeStatus() {
     remoteError: '',
     hermes: {
       activeVersion: '0.21.0',
-      agentVersion: '0.21.0',
+      agentVersion: 'v0.21.0 (2026.8.27) · upstream 3f497e2b · local 470cf66b (+1 carried commit)',
       activeDirectory: '/runtime/0.21.0',
       storageDirectory: '/runtime',
       defaultStorageDirectory: '/runtime',
@@ -127,6 +132,26 @@ function runtimeStatus() {
   }
 }
 
+function agentStatusSnapshot() {
+  return {
+    revision: 1,
+    updatedAt: '2026-08-27T00:00:00.000Z',
+    agents: [
+      {
+        id: 'hermes',
+        installed: true,
+        source: 'managed-runtime',
+        path: '/runtime/0.21.0/bin/hermes',
+        version: 'v0.21.0 (2026.8.27) · upstream 3f497e2b · local 470cf66b (+1 carried commit)',
+      },
+      { id: 'ekko-agent', installed: true, source: 'built-in', path: '', version: '0.7.0' },
+      { id: 'claude-code', installed: true, source: 'user-cli', path: '/usr/local/bin/claude', version: '2.0.0' },
+      { id: 'codex', installed: false, source: 'not-installed', path: '', version: '' },
+      { id: 'pi', installed: false, source: 'not-installed', path: '', version: '' },
+    ],
+  }
+}
+
 describe('Agent Manager page', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -148,6 +173,7 @@ describe('Agent Manager page', () => {
       ],
     })
     api.fetchRuntimeVersionStatus.mockResolvedValue(runtimeStatus())
+    api.fetchAgentStatusSnapshot.mockResolvedValue(agentStatusSnapshot())
   })
 
   it('shows Hermes with the same compact card structure as other Agents', async () => {
@@ -164,14 +190,18 @@ describe('Agent Manager page', () => {
     const hermesCard = wrapper.get('[data-testid="agent-card-hermes"]')
     expect(hermesCard.text()).not.toContain('agentManager.managedRuntimeHint')
     expect(hermesCard.text()).toContain('codingAgents.installed')
-    expect(hermesCard.get('.agent-version').text()).toBe('v0.21.0')
+    expect(hermesCard.get('.agent-version').text()).toBe('v0.21.0 (2026.8.27)')
+    expect(hermesCard.text()).not.toContain('3f497e2b')
+    expect(hermesCard.text()).not.toContain('470cf66b')
     expect(hermesCard.text()).not.toContain('agentManager.hermesDescription')
     expect(hermesCard.text()).not.toContain('/Users/test/.local/bin/hermes')
     expect(hermesCard.get('[data-testid="hermes-source-type"]').text()).toBe('Runtime')
     expect(hermesCard.findAll('button').map(button => button.text()))
       .toEqual(['agentManager.manageRuntime', 'sidebar.settings'])
     expect(wrapper.findComponent({ name: 'VersionManagementModal' }).exists()).toBe(true)
-    expect(api.fetchRuntimeVersionStatus).toHaveBeenCalledWith({ includeRemote: false })
+    expect(api.fetchAgentStatusSnapshot).toHaveBeenCalledOnce()
+    expect(api.fetchRuntimeVersionStatus).not.toHaveBeenCalled()
+    expect(api.fetchCodingAgentsStatus).not.toHaveBeenCalled()
 
     const ekkoCard = wrapper.get('[data-testid="agent-card-ekko"]')
     expect(ekkoCard.findAll('button')).toHaveLength(0)
@@ -188,9 +218,14 @@ describe('Agent Manager page', () => {
 
   it('detects the CLI before offering Runtime management in the desktop shell', async () => {
     ;(window as typeof window & { hermesDesktop?: { isDesktop: boolean } }).hermesDesktop = { isDesktop: true }
-    const status = runtimeStatus()
-    status.hermes.cliInstallations[0].selected = true
-    api.fetchRuntimeVersionStatus.mockResolvedValue(status)
+    const status = agentStatusSnapshot()
+    status.agents[0] = {
+      ...status.agents[0],
+      source: 'user-cli',
+      path: '/Users/test/.local/bin/hermes',
+      version: '0.20.4',
+    }
+    api.fetchAgentStatusSnapshot.mockResolvedValue(status)
     const wrapper = mount(AgentManagerView, {
       props: { sidebarCollapsed: false },
       global: {
@@ -206,16 +241,21 @@ describe('Agent Manager page', () => {
     expect(hermesCard.get('[data-testid="hermes-source-type"]').text()).toBe('CLI')
     expect(hermesCard.findAll('button').map(button => button.text()))
       .toEqual(['sidebar.settings'])
-    expect(api.fetchRuntimeVersionStatus).toHaveBeenCalledWith({ includeRemote: false })
+    expect(api.fetchRuntimeVersionStatus).not.toHaveBeenCalled()
     expect(wrapper.getComponent({ name: 'VersionManagementModal' }).props('show')).toBe(false)
   })
 
-  it('does not open Runtime management just because the desktop CLI probe finds nothing', async () => {
+  it('does not open Runtime management when cached Hermes status is unavailable', async () => {
     ;(window as typeof window & { hermesDesktop?: { isDesktop: boolean } }).hermesDesktop = { isDesktop: true }
-    const status = runtimeStatus()
-    status.hermes.agentVersion = ''
-    status.hermes.cliInstallations = []
-    api.fetchRuntimeVersionStatus.mockResolvedValue(status)
+    const status = agentStatusSnapshot()
+    status.agents[0] = {
+      ...status.agents[0],
+      installed: false,
+      source: 'not-installed',
+      path: '',
+      version: '',
+    }
+    api.fetchAgentStatusSnapshot.mockResolvedValue(status)
 
     const wrapper = mount(AgentManagerView, {
       props: { sidebarCollapsed: false },
@@ -227,7 +267,7 @@ describe('Agent Manager page', () => {
     })
     await flushPromises()
 
-    expect(api.fetchRuntimeVersionStatus).toHaveBeenCalledWith({ includeRemote: false })
+    expect(api.fetchRuntimeVersionStatus).not.toHaveBeenCalled()
     const hermesCard = wrapper.get('[data-testid="agent-card-hermes"]')
     expect(hermesCard.text()).toContain('codingAgents.notInstalled')
     expect(hermesCard.text()).toContain('agentManager.hermesDescription')
@@ -273,5 +313,27 @@ describe('Agent Manager page', () => {
     expect(claudeCard.find('.update-alert').exists()).toBe(false)
     expect(claudeCard.findAll('button').map(button => button.text()))
       .toContain('agentManager.updateToVersion:2.1.0')
+  })
+
+  it('only probes installed Agents after the user clicks refresh', async () => {
+    const wrapper = mount(AgentManagerView, {
+      props: { sidebarCollapsed: false },
+      global: { stubs: { VersionManagementModal: true } },
+    })
+    await flushPromises()
+
+    expect(api.fetchAgentStatusSnapshot).toHaveBeenCalledOnce()
+    expect(api.fetchCodingAgentsStatus).not.toHaveBeenCalled()
+    expect(api.fetchRuntimeVersionStatus).not.toHaveBeenCalled()
+
+    const refreshButton = wrapper.findAll('button')
+      .find(button => button.text() === 'agentManager.refresh')
+    expect(refreshButton).toBeDefined()
+    await refreshButton!.trigger('click')
+    await flushPromises()
+
+    expect(api.fetchCodingAgentsStatus).toHaveBeenCalledOnce()
+    expect(api.fetchRuntimeVersionStatus).toHaveBeenCalledWith({ includeRemote: false })
+    expect(api.fetchAgentStatusSnapshot).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION
## Summary
- load the Agents page from the in-memory Agent status snapshot instead of probing every local CLI on entry
- run live Hermes, Claude, Codex, and Pi discovery only when the user clicks Refresh
- keep the Agents view synchronized after Runtime management and shorten the Hermes label to version plus release date
- add focused coverage for cached loading, manual refresh, source labels, and version formatting

## Validation
- npm run test -- tests/client/agent-manager-page.test.ts tests/client/agent-status-availability.test.ts tests/client/profiles-store.test.ts
- npm run build
- npm run harness:check

## Known limitation
- npm run test:e2e -- tests/e2e/authenticated-shell.spec.ts could not start because the configured Playwright Chromium executable is missing locally; no browser assertion ran.