### PR TITLE
feat: add OrcaRouter as a first-class provider

### DIFF
--- a/packages/ekko-agent/src/model/providers/openai-compatible.ts
+++ b/packages/ekko-agent/src/model/providers/openai-compatible.ts
@@ -509,6 +509,7 @@ function usesReasoningContentProtocol(identifier: string): boolean {
     'glm',
     'z.ai',
     'bigmodel',
+    'orcarouter',
   ].some(part => identifier.includes(part))
 }
 

--- a/packages/server/src/modules/hermes/controllers/models.ts
+++ b/packages/server/src/modules/hermes/controllers/models.ts
@@ -243,6 +243,7 @@ function providerApiMode(providerKey: string, configuredMode?: unknown): Availab
 
 function providerShouldFetchLiveModels(providerKey: string): boolean {
   return providerKey === 'openrouter' ||
+    providerKey === 'orcarouter' ||
     providerKey === 'cliproxyapi' ||
     providerKey === 'ollama-cloud' ||
     providerKey === 'lmstudio' ||

--- a/packages/server/src/modules/hermes/services/profiles/config.ts
+++ b/packages/server/src/modules/hermes/services/profiles/config.ts
@@ -13,6 +13,7 @@ export const PROVIDER_ENV_MAP: Record<string, { api_key_env: string; base_url_en
   'fun-claude': { api_key_env: '', base_url_env: '' },
   lmstudio: { api_key_env: 'LM_API_KEY', base_url_env: 'LM_BASE_URL' },
   openrouter: { api_key_env: 'OPENROUTER_API_KEY', base_url_env: 'OPENROUTER_BASE_URL' },
+  orcarouter: { api_key_env: 'ORCAROUTER_API_KEY', base_url_env: 'ORCAROUTER_BASE_URL' },
   glm: { api_key_env: 'GLM_API_KEY', base_url_env: '' },
   zai: { api_key_env: 'ZAI_API_KEY', base_url_env: 'ZAI_BASE_URL' },
   'kimi-coding': { api_key_env: 'KIMI_API_KEY', base_url_env: 'KIMI_BASE_URL' },

--- a/packages/server/src/modules/studio/contracts/providers.ts
+++ b/packages/server/src/modules/studio/contracts/providers.ts
@@ -620,6 +620,13 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     models: [],
   },
   {
+    label: 'OrcaRouter',
+    value: 'orcarouter',
+    builtin: true,
+    base_url: 'https://api.orcarouter.ai/v1',
+    models: [],
+  },
+  {
     label: 'GitHub Copilot',
     value: 'copilot',
     builtin: true,


### PR DESCRIPTION
## Summary

Hermes Studio lets users manage models and providers from one local-first workspace — "add, update, and delete providers (preset and custom OpenAI-compatible)" is already part of the Model Management surface. When a user points Hermes Studio at an OpenAI-compatible gateway, they currently have to configure it as a **custom** provider and hand-write the base URL.

This PR makes [OrcaRouter](https://www.orcarouter.ai) a first-class, preset provider so that workflow becomes one click, mirroring the existing OpenRouter preset.

### What changed

- Added `orcarouter` to the provider registry (`PROVIDER_PRESETS`) with `base_url: https://api.orcarouter.ai/v1`, right next to OpenRouter.
- Added the `ORCAROUTER_API_KEY` / `ORCAROUTER_BASE_URL` environment mapping so keys and base URL overrides resolve from the profile `.env` exactly like OpenRouter.
- Enabled live model discovery for `orcarouter` (the same `/v1/models` fetch path OpenRouter uses), so the Models page populates the catalog automatically instead of showing an empty preset.
- Mapped `orcarouter` to the `reasoning_content` replay protocol in the Ekko OpenAI-compatible adapter (verified against the live gateway, which returns `reasoning_content` for reasoning models such as `deepseek/deepseek-reasoner`).

### Why

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means Hermes Studio users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Validation

- `npm run harness:check` — passed
- Focused provider tests (server + client + ekko-agent model adapter): 147 passed
- `vue-tsc -b`, `tsc --noEmit -p packages/server/tsconfig.json`, `ekko-agent` build — all clean
- Live check against `https://api.orcarouter.ai/v1`:
  - `GET /v1/models` → 200, 205 models returned
  - `POST /v1/chat/completions` → 200 with a valid completion
  - `deepseek/deepseek-reasoner` → returns `reasoning_content`

Note: the repo requires Node >= 23; this container runs Node 20, so the sqlite-backed server/ekko-agent suites cannot run here (they fail identically on the untouched `main` baseline with `No such built-in module: node:sqlite`). All runnable suites and both type-checks pass.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
