### PR TITLE
[codex] keep boot animation visible across app hosts

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -136,6 +136,9 @@
 </head>
 
 <body>
+  <script>
+    window.__HERMES_BOOT_ANIMATION_STARTED_AT__ = performance.now()
+  </script>
   <div id="app">
     <div class="boot-fallback">
       <div class="boot-fallback__brand">

--- a/packages/client/src/env.d.ts
+++ b/packages/client/src/env.d.ts
@@ -2,6 +2,10 @@
 
 declare const __APP_VERSION__: string
 
+interface Window {
+  __HERMES_BOOT_ANIMATION_STARTED_AT__?: number
+}
+
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'
   const component: DefineComponent<{}, {}, any>

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -5,6 +5,7 @@ import { i18nReady } from './i18n'
 import App from './App.vue'
 import './styles/global.scss'
 import { desktopBridge } from '@/utils/desktop-bridge'
+import { waitForBootAnimation } from '@/utils/boot-animation'
 
 // Apply theme classes before mount to prevent FOUC (Flash of Unstyled Content)
 const savedBrightness = localStorage.getItem('hermes_brightness') || 'system'
@@ -52,6 +53,7 @@ async function mountApp(): Promise<void> {
   app.use(i18n)
   app.use(router)
   await router.isReady().catch(() => undefined)
+  await waitForBootAnimation()
   app.mount('#app')
 }
 

--- a/packages/client/src/utils/boot-animation.ts
+++ b/packages/client/src/utils/boot-animation.ts
@@ -1,0 +1,18 @@
+export const BOOT_ANIMATION_MIN_DURATION_MS = 1_800
+
+export function getBootAnimationDelay(
+  startedAt: number | undefined,
+  now = performance.now(),
+): number {
+  if (typeof startedAt !== 'number' || !Number.isFinite(startedAt)) return 0
+
+  const elapsed = Math.max(0, now - startedAt)
+  return Math.max(0, BOOT_ANIMATION_MIN_DURATION_MS - elapsed)
+}
+
+export async function waitForBootAnimation(): Promise<void> {
+  const delay = getBootAnimationDelay(window.__HERMES_BOOT_ANIMATION_STARTED_AT__)
+  if (delay <= 0) return
+
+  await new Promise<void>(resolve => window.setTimeout(resolve, delay))
+}

--- a/tests/client/boot-animation.test.ts
+++ b/tests/client/boot-animation.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'fs'
+import { describe, expect, it } from 'vitest'
+import {
+  BOOT_ANIMATION_MIN_DURATION_MS,
+  getBootAnimationDelay,
+} from '../../packages/client/src/utils/boot-animation'
+
+describe('boot animation', () => {
+  it('keeps one complete shimmer cycle visible on fast app hosts', () => {
+    expect(BOOT_ANIMATION_MIN_DURATION_MS).toBe(1_800)
+    expect(getBootAnimationDelay(100, 600)).toBe(1_300)
+  })
+
+  it('does not delay a launch after the shimmer cycle has elapsed', () => {
+    expect(getBootAnimationDelay(100, 2_000)).toBe(0)
+    expect(getBootAnimationDelay(undefined, 500)).toBe(0)
+  })
+
+  it('records the HTML fallback start and waits before Vue replaces it', () => {
+    const html = readFileSync('packages/client/index.html', 'utf8')
+    const main = readFileSync('packages/client/src/main.ts', 'utf8')
+
+    expect(html).toContain('window.__HERMES_BOOT_ANIMATION_STARTED_AT__ = performance.now()')
+    expect(main).toContain('await waitForBootAnimation()')
+    expect(main.indexOf('await waitForBootAnimation()')).toBeLessThan(main.indexOf("app.mount('#app')"))
+  })
+})


### PR DESCRIPTION
## Summary
- record when the HTML boot fallback starts and keep it visible for at least one 1.8-second shimmer cycle
- wait only for the remaining animation time before Vue mounts, so slower launches are not delayed further
- add focused coverage for duration calculation and shell integration

This makes the existing Hermes boot shimmer consistently visible in light and dark mode across Android, iPad/iOS, desktop, and browser app hosts.

Closes #2766

## Validation
- `npm run test -- tests/client/boot-animation.test.ts tests/client/pwa-metadata.test.ts` (5 passed)
- `NODE_ENV=development npm run build` (passed)
- Playwright runtime probe against the production build:
  - desktop light: 1845 ms, animated transform observed
  - desktop dark: 1761 ms, animated transform observed
  - iPad light: 1759 ms, animated transform observed
  - iPad dark: 1763 ms, animated transform observed
- `NODE_ENV=development npm run test:coverage` (4588 passed, 16 environment-sensitive failures)
  - the same 16 failures reproduce on clean `main@4ae23c69` because this host has `/usr/local/lib/hermes-agent`; they are unrelated to this client-only change
