### PR TITLE
[codex] add opt-in Studio turn-tail context compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ controllers.
 - Inline previews for generated HTML, PDF, DOCX, PPTX, XLSX, CSV, images, Markdown, and source files
 - Session search — Ctrl+K search across the Studio local session database; read-only Hermes history sessions are not included
 - Session categories, message references, compression progress, and durable background delegation results
+- Optional Studio turn-tail compression — set `compression.studio_compact_on_turn_end: true` in the Hermes profile config to move threshold evaluation after a successful persisted turn; failures remain fail-open and Hermes Agent Core compression is unchanged
 - Profile-aware model selector — discovers models available to the signed-in account through authorized Hermes profiles
 - Per-session model display badge and context token usage
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -80,6 +80,7 @@ Hermes 控制面 API 使用 `/api/hermes/*`。已经发布的旧版移动 App �
 - 可直接预览 Agent 生成的 HTML、PDF、DOCX、PPTX、XLSX、CSV、图片、Markdown 和源码文件
 - 会话搜索 — Ctrl+K 搜索 Studio 本地会话库；不包含只读 Hermes 历史会话
 - 会话分类、消息引用、压缩进度和可持久恢复的后台委派结果
+- 可选的 Studio turn-tail 压缩 — 在 Hermes Profile 配置中设置 `compression.studio_compact_on_turn_end: true`，将阈值检查移到成功响应持久化之后；压缩失败保持 fail-open，且不改变 Hermes Agent Core 的压缩行为
 - 按账号授权 Profile 汇总模型选择器 — 只展示当前账号可访问的 Hermes Profile 中可用的模型
 - 每个会话显示模型标签和上下文 Token 用量
 

--- a/packages/server/src/modules/studio/services/chat-run/compression.ts
+++ b/packages/server/src/modules/studio/services/chat-run/compression.ts
@@ -464,7 +464,7 @@ export async function compactStudioTurnTail(args: {
   sessionMap: Map<string, SessionState>
   modelContext?: CompressionModelContext
   contextTokenEstimator?: (messages: ChatMessage[], messageTokens: number) => Promise<number | null | undefined>
-}): Promise<void> {
+}): Promise<number | undefined> {
   try {
     await buildCompressedHistory(
       args.sessionId,
@@ -478,6 +478,7 @@ export async function compactStudioTurnTail(args: {
       0,
       false,
     )
+    return args.sessionMap.get(args.sessionId)?.contextTokens
   } catch (err) {
     logger.warn(err, '[context-compress] Studio turn-tail compression failed for session %s; completing run', args.sessionId)
   }

--- a/packages/server/src/modules/studio/services/chat-run/compression.ts
+++ b/packages/server/src/modules/studio/services/chat-run/compression.ts
@@ -186,6 +186,16 @@ async function resolveCompressionModelContext(
   return { model, provider }
 }
 
+export async function isStudioTurnTailCompressionEnabled(profile: string): Promise<boolean> {
+  try {
+    const compression = (await readConfigYamlForProfile(profile))?.compression
+    return compression?.studio_compact_on_turn_end === true
+  } catch (err) {
+    logger.warn(err, '[context-compress] failed to read Studio turn-tail compression config for profile %s', profile)
+    return false
+  }
+}
+
 async function getRunChatCompressionConfig(profile: string, contextLength: number): Promise<RunChatCompressionConfig> {
   let raw: Record<string, any> = {}
   try {
@@ -442,6 +452,34 @@ export async function buildCompressedHistory(
     if (isContextWindowTooSmallError(err)) throw err
     logger.warn(err, '[chat-run-socket] failed to build compressed history for session %s', sessionId)
     return []
+  }
+}
+
+export async function compactStudioTurnTail(args: {
+  sessionId: string
+  profile: string
+  upstream: string
+  apiKey?: string
+  emit: (event: string, payload: any) => void
+  sessionMap: Map<string, SessionState>
+  modelContext?: CompressionModelContext
+  contextTokenEstimator?: (messages: ChatMessage[], messageTokens: number) => Promise<number | null | undefined>
+}): Promise<void> {
+  try {
+    await buildCompressedHistory(
+      args.sessionId,
+      args.profile,
+      args.upstream,
+      args.apiKey,
+      args.emit,
+      args.sessionMap,
+      args.modelContext,
+      args.contextTokenEstimator,
+      0,
+      false,
+    )
+  } catch (err) {
+    logger.warn(err, '[context-compress] Studio turn-tail compression failed for session %s; completing run', args.sessionId)
   }
 }
 

--- a/packages/server/src/modules/studio/services/chat-run/handle-bridge-run.ts
+++ b/packages/server/src/modules/studio/services/chat-run/handle-bridge-run.ts
@@ -88,6 +88,8 @@ interface BridgeRunMetadata {
   autonomous?: boolean
   delegationId?: string
   queueId?: string
+  studioTurnTailEnabled: boolean
+  backgroundDelegationEnabled: boolean
   backgroundDelegationIds: Set<string>
   originContext: Omit<HermesBackgroundContinuationContext, 'delegationId' | 'originRunId'>
 }
@@ -661,6 +663,7 @@ export async function handleBridgeRun(
     return
   }
 
+  const studioTurnTailEnabled = await isStudioTurnTailCompressionEnabled(profile)
   const history = callbackContext
     ? structuredClone(callbackContext.messages)
     : await buildCompressedHistory(
@@ -710,6 +713,8 @@ export async function handleBridgeRun(
       autonomous: data.autonomous === true,
       delegationId: data.background_delegation_id,
       queueId: data.queue_id,
+      studioTurnTailEnabled,
+      backgroundDelegationEnabled,
       backgroundDelegationIds: new Set<string>(),
       originContext: {
         runtime: 'hermes',
@@ -1768,7 +1773,7 @@ async function applyBridgeChunkAsync(
   updateSessionStats(sessionId)
   await delay(BRIDGE_USAGE_FLUSH_DELAY_MS)
   const usage = await calcAndUpdateUsage(sessionId, state, emit)
-  const contextTokens = await refreshFinalContextUsage({
+  let contextTokens = await refreshFinalContextUsage({
     sessionId,
     profile,
     model: modelContext.model,
@@ -1780,8 +1785,8 @@ async function applyBridgeChunkAsync(
     emit,
     bridge,
   })
-  if (!terminalError && !runMetadata?.delegationId && await isStudioTurnTailCompressionEnabled(profile)) {
-    await compactStudioTurnTail({
+  if (!terminalError && !state.isAborting && state.activeRunMarker === runMarker && runMetadata?.studioTurnTailEnabled) {
+    const turnTailContextTokens = await compactStudioTurnTail({
       sessionId,
       profile,
       upstream: '',
@@ -1800,10 +1805,12 @@ async function applyBridgeChunkAsync(
           state,
           bridge,
           refresh: true,
+          backgroundDelegationEnabled: runMetadata.backgroundDelegationEnabled,
         })
         return fixedContextTokens == null ? localMessageTokens : fixedContextTokens + localMessageTokens
       },
     })
+    if (turnTailContextTokens != null) contextTokens = turnTailContextTokens
   }
   const hadQueuedRunBeforeGoalEvaluation = state.queue.length > 0
   const eventName = terminalError ? 'run.failed' : 'run.completed'

--- a/packages/server/src/modules/studio/services/chat-run/handle-bridge-run.ts
+++ b/packages/server/src/modules/studio/services/chat-run/handle-bridge-run.ts
@@ -15,7 +15,7 @@ import type {
   PrimaryAgentBridgeOutput as AgentBridgeOutput,
 } from '../../public/chat-agent-runtime'
 import { contentBlocksToString, convertContentBlocksForAgent, extractTextForPreview, isContentBlockArray } from './content-blocks'
-import { buildCompressedHistory, buildDbSnapshotAwareHistory, forceCompressBridgeHistory, pushState, replaceState } from './compression'
+import { buildCompressedHistory, buildDbSnapshotAwareHistory, compactStudioTurnTail, forceCompressBridgeHistory, isStudioTurnTailCompressionEnabled, pushState, replaceState } from './compression'
 import {
   calcAndUpdateUsage,
   contextTokensWithCachedOverhead,
@@ -1780,6 +1780,31 @@ async function applyBridgeChunkAsync(
     emit,
     bridge,
   })
+  if (!terminalError && !runMetadata?.delegationId && await isStudioTurnTailCompressionEnabled(profile)) {
+    await compactStudioTurnTail({
+      sessionId,
+      profile,
+      upstream: '',
+      apiKey: undefined,
+      emit,
+      sessionMap,
+      modelContext: { model: modelContext.model, provider: modelContext.provider },
+      contextTokenEstimator: async (_messages, localMessageTokens) => {
+        const fixedContextTokens = await ensureBridgeFixedContext({
+          sessionId,
+          profile,
+          model: modelContext.model,
+          provider: modelContext.provider,
+          workspace,
+          instructions,
+          state,
+          bridge,
+          refresh: true,
+        })
+        return fixedContextTokens == null ? localMessageTokens : fixedContextTokens + localMessageTokens
+      },
+    })
+  }
   const hadQueuedRunBeforeGoalEvaluation = state.queue.length > 0
   const eventName = terminalError ? 'run.failed' : 'run.completed'
   if (runMetadata?.delegationId && state.backgroundDelegations?.[runMetadata.delegationId]) {

--- a/packages/server/src/modules/studio/services/chat-run/handle-ekko-agent-run.ts
+++ b/packages/server/src/modules/studio/services/chat-run/handle-ekko-agent-run.ts
@@ -40,7 +40,7 @@ import { logger } from '../../public/logging'
 import { recordSessionUsage } from '../usage/usage-recorder'
 import { observeRunChatPetEvent } from '../../public/pet-events'
 import { contentBlocksToString, convertContentBlocksForAgent, extractTextForPreview } from './content-blocks'
-import { buildCompressedHistory, getOrCreateSession } from './compression'
+import { buildCompressedHistory, compactStudioTurnTail, getOrCreateSession, isStudioTurnTailCompressionEnabled } from './compression'
 import { resolveBridgeRunModelConfig, type RunModelGroup } from './model-config'
 import { persistRunMessages, type RunMessageDraft } from './message-persistence'
 import { buildOutboundRunEvent } from './resume-payload'
@@ -1494,6 +1494,39 @@ export async function handleEkkoAgentRun(
       contextTokens: contextEstimate?.contextTokens ?? state.contextTokens,
       context_tokens: contextEstimate?.contextTokens ?? state.contextTokens,
     })
+    if (
+      data.context_compression_enabled !== false
+      && !data.background_delegation_id
+      && await isStudioTurnTailCompressionEnabled(profile)
+    ) {
+      await compactStudioTurnTail({
+        sessionId,
+        profile,
+        upstream: baseUrl,
+        apiKey,
+        emit,
+        sessionMap,
+        modelContext: {
+          model: modelConfig.model,
+          provider: modelConfig.provider,
+          allowHermesFallback: false,
+        },
+        contextTokenEstimator: async (_messages, localMessageTokens) => {
+          const estimate = await agent.estimateContext({
+            modelClient,
+            model: modelConfig.model,
+            modelDefaults: { model: modelConfig.model },
+            messages: instructionMessages,
+            signal: abortController.signal,
+            memoryEnabled: false,
+            toolContext,
+            metadata,
+            backgroundDelegationEnabled: data.background_delegation_enabled !== false,
+          })
+          return estimate.contextTokens + localMessageTokens
+        },
+      })
+    }
     const workspaceRunChange = completeWorkspaceRunDiff()
     emit('run.completed', {
       event: 'run.completed',

--- a/packages/server/src/modules/studio/services/chat-run/handle-ekko-agent-run.ts
+++ b/packages/server/src/modules/studio/services/chat-run/handle-ekko-agent-run.ts
@@ -1255,6 +1255,8 @@ export async function handleEkkoAgentRun(
       )
     }
     let fixedContextEstimate: Promise<number> | undefined
+    const studioTurnTailEnabled = data.context_compression_enabled !== false
+      && await isStudioTurnTailCompressionEnabled(profile)
     const compressedHistory = callbackContext
       ? []
       : data.context_compression_enabled === false ? [] : await buildCompressedHistory(
@@ -1494,12 +1496,9 @@ export async function handleEkkoAgentRun(
       contextTokens: contextEstimate?.contextTokens ?? state.contextTokens,
       context_tokens: contextEstimate?.contextTokens ?? state.contextTokens,
     })
-    if (
-      data.context_compression_enabled !== false
-      && !data.background_delegation_id
-      && await isStudioTurnTailCompressionEnabled(profile)
-    ) {
-      await compactStudioTurnTail({
+    let completedContextTokens = contextEstimate?.contextTokens ?? state.contextTokens
+    if (studioTurnTailEnabled && !abortController.signal.aborted) {
+      const turnTailContextTokens = await compactStudioTurnTail({
         sessionId,
         profile,
         upstream: baseUrl,
@@ -1526,6 +1525,14 @@ export async function handleEkkoAgentRun(
           return estimate.contextTokens + localMessageTokens
         },
       })
+      if (turnTailContextTokens != null) completedContextTokens = turnTailContextTokens
+    }
+    const completedContextEstimate = contextEstimate && typeof contextEstimate === 'object'
+      ? { ...contextEstimate }
+      : contextEstimate
+    if (completedContextEstimate && typeof completedContextEstimate === 'object') {
+      completedContextEstimate.contextTokens = completedContextTokens
+      completedContextEstimate.context_tokens = completedContextTokens
     }
     const workspaceRunChange = completeWorkspaceRunDiff()
     emit('run.completed', {
@@ -1534,9 +1541,9 @@ export async function handleEkkoAgentRun(
       message_id: assistantMessageId || undefined,
       output: assistantText,
       context: result.context,
-      contextTokens: contextEstimate?.contextTokens,
-      context_tokens: contextEstimate?.contextTokens,
-      contextEstimate,
+      contextTokens: completedContextTokens,
+      context_tokens: completedContextTokens,
+      contextEstimate: completedContextEstimate,
       usage: {
         input_tokens: usageInput,
         output_tokens: usageOutput,

--- a/tests/server/run-chat-bridge-final-context.test.ts
+++ b/tests/server/run-chat-bridge-final-context.test.ts
@@ -217,6 +217,7 @@ describe('bridge run final context usage', () => {
     flushBridgePendingToDbMock.mockImplementation(() => order.push('persist'))
     compactStudioTurnTailMock.mockImplementation(async () => {
       order.push('compress')
+      return 1_234
     })
     const emit = vi.fn((event: string) => {
       if (event === 'run.completed') order.push('completed')
@@ -240,6 +241,7 @@ describe('bridge run final context usage', () => {
     expect(order).toEqual(expect.arrayContaining(['persist', 'compress', 'completed']))
     expect(order.indexOf('persist')).toBeLessThan(order.indexOf('compress'))
     expect(order.indexOf('compress')).toBeLessThan(order.indexOf('completed'))
+    expect(emit).toHaveBeenCalledWith('run.completed', expect.objectContaining({ contextTokens: 1_234 }))
   })
 
   it('reopens an ended bridge session when starting a new run', async () => {
@@ -1763,6 +1765,25 @@ describe('bridge run final context usage', () => {
         workspace: '/tmp/hermes-bridge-final-context/default/workspace',
       }),
     )
+  })
+
+  it('skips enabled turn-tail compression when a bridge run fails', async () => {
+    isStudioTurnTailCompressionEnabledMock.mockResolvedValue(true)
+    const emit = vi.fn()
+    const nsp = makeNamespace(emit)
+    const socket = makeSocket()
+    const sessionMap = new Map([['session-1', makeState()]])
+    const bridge = {
+      chat: vi.fn().mockRejectedValue(new Error('bridge timeout')),
+      contextEstimate: vi.fn().mockResolvedValue({ token_count: 5_000, fixed_context_tokens: 4_900 }),
+      streamOutput: vi.fn(),
+    } as any
+
+    const { handleBridgeRun } = await import('../../packages/server/src/modules/studio/services/chat-run/handle-bridge-run')
+    await handleBridgeRun(nsp, socket, { input: 'hello', session_id: 'session-1' }, 'default', sessionMap, bridge, false, vi.fn(), vi.fn())
+
+    expect(compactStudioTurnTailMock).not.toHaveBeenCalled()
+    expect(emit).toHaveBeenCalledWith('run.failed', expect.any(Object))
   })
 
   it('refreshes full context tokens when a bridge run fails', async () => {

--- a/tests/server/run-chat-bridge-final-context.test.ts
+++ b/tests/server/run-chat-bridge-final-context.test.ts
@@ -13,6 +13,8 @@ const updateUsageMock = vi.fn()
 const buildCompressedHistoryMock = vi.fn()
 const buildDbHistoryMock = vi.fn()
 const buildSnapshotAwareHistoryMock = vi.fn(async (_sessionId: string, _profile: string, history: any[]) => history)
+const compactStudioTurnTailMock = vi.fn()
+const isStudioTurnTailCompressionEnabledMock = vi.fn(async () => false)
 const buildDbSnapshotAwareHistoryMock = vi.fn(async (sessionId: string, profile: string, options: any, modelContext: any) => (
   buildSnapshotAwareHistoryMock(
     sessionId,
@@ -78,6 +80,8 @@ vi.mock('../../packages/server/src/modules/studio/services/chat-run/compression'
   buildDbHistory: buildDbHistoryMock,
   buildSnapshotAwareHistory: buildSnapshotAwareHistoryMock,
   buildDbSnapshotAwareHistory: buildDbSnapshotAwareHistoryMock,
+  compactStudioTurnTail: compactStudioTurnTailMock,
+  isStudioTurnTailCompressionEnabled: isStudioTurnTailCompressionEnabledMock,
   pushState: pushStateMock,
   replaceState: replaceStateMock,
   forceCompressBridgeHistory: forceCompressBridgeHistoryMock,
@@ -151,6 +155,7 @@ describe('bridge run final context usage', () => {
     homes.push(home)
     process.env.HERMES_WEB_UI_HOME = home
     vi.clearAllMocks()
+    isStudioTurnTailCompressionEnabledMock.mockResolvedValue(false)
     getSystemPromptMock.mockReturnValue('system prompt')
     issueModelRunJwtMock.mockResolvedValue('model-run-token')
     getSessionMock.mockReturnValue({ id: 'session-1', profile: 'default', model: '', provider: '' })
@@ -204,6 +209,37 @@ describe('bridge run final context usage', () => {
   afterEach(() => {
     delete process.env.HERMES_WEB_UI_HOME
     for (const home of homes.splice(0)) rmSync(home, { recursive: true, force: true })
+  })
+
+  it('runs enabled turn-tail compression after persistence and before completion', async () => {
+    isStudioTurnTailCompressionEnabledMock.mockResolvedValue(true)
+    const order: string[] = []
+    flushBridgePendingToDbMock.mockImplementation(() => order.push('persist'))
+    compactStudioTurnTailMock.mockImplementation(async () => {
+      order.push('compress')
+    })
+    const emit = vi.fn((event: string) => {
+      if (event === 'run.completed') order.push('completed')
+    })
+    const nsp = makeNamespace(emit)
+    const socket = makeSocket()
+    const sessionMap = new Map([['session-1', makeState()]])
+    const bridge = {
+      chat: vi.fn().mockResolvedValue({ run_id: 'run-1', status: 'started' }),
+      contextEstimate: vi.fn().mockResolvedValue({ token_count: 5_000, fixed_context_tokens: 4_900, message_count: 2 }),
+      streamOutput: vi.fn(async function* () {
+        yield { run_id: 'run-1', done: true, status: 'completed', output: 'done' }
+      }),
+    } as any
+
+    const { handleBridgeRun } = await import('../../packages/server/src/modules/studio/services/chat-run/handle-bridge-run')
+    await handleBridgeRun(nsp, socket, { input: 'hello', session_id: 'session-1' }, 'default', sessionMap, bridge, false, vi.fn(), vi.fn())
+
+    expect(compactStudioTurnTailMock).toHaveBeenCalledTimes(1)
+    expect(compactStudioTurnTailMock).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'session-1' }))
+    expect(order).toEqual(expect.arrayContaining(['persist', 'compress', 'completed']))
+    expect(order.indexOf('persist')).toBeLessThan(order.indexOf('compress'))
+    expect(order.indexOf('compress')).toBeLessThan(order.indexOf('completed'))
   })
 
   it('reopens an ended bridge session when starting a new run', async () => {

--- a/tests/server/run-chat-compression.test.ts
+++ b/tests/server/run-chat-compression.test.ts
@@ -111,6 +111,56 @@ describe('run chat compression trigger', () => {
     readConfigYamlForProfileMock.mockResolvedValue({})
   })
 
+  it('reads the Studio turn-tail compression switch independently from Core', async () => {
+    readConfigYamlForProfileMock.mockResolvedValue({
+      compression: { studio_compact_on_turn_end: true },
+    })
+
+    const { isStudioTurnTailCompressionEnabled } = await import(
+      '../../packages/server/src/modules/studio/services/chat-run/compression'
+    )
+
+    await expect(isStudioTurnTailCompressionEnabled('default')).resolves.toBe(true)
+    expect(readConfigYamlForProfileMock).toHaveBeenCalledWith('default')
+  })
+
+  it('keeps Studio turn-tail compression disabled for absent and Core-only switches', async () => {
+    const { isStudioTurnTailCompressionEnabled } = await import(
+      '../../packages/server/src/modules/studio/services/chat-run/compression'
+    )
+
+    readConfigYamlForProfileMock.mockResolvedValue({
+      compression: { compact_on_turn_end: true },
+    })
+    await expect(isStudioTurnTailCompressionEnabled('default')).resolves.toBe(false)
+
+    readConfigYamlForProfileMock.mockResolvedValue({})
+    await expect(isStudioTurnTailCompressionEnabled('default')).resolves.toBe(false)
+  })
+
+  it('fails open when Studio turn-tail compression cannot fit fixed context', async () => {
+    getSessionDetailMock.mockReturnValue({ messages: [] })
+    getModelContextLengthMock.mockReturnValue(100_000)
+    readConfigYamlForProfileMock.mockResolvedValue({
+      compression: { threshold: 0.5 },
+    })
+    calcAndUpdateUsageMock.mockResolvedValue({ inputTokens: 0, outputTokens: 0 })
+
+    const { compactStudioTurnTail } = await import(
+      '../../packages/server/src/modules/studio/services/chat-run/compression'
+    )
+
+    await expect(compactStudioTurnTail({
+      sessionId: 'session-1',
+      profile: 'default',
+      upstream: '',
+      emit: vi.fn(),
+      sessionMap: new Map(),
+      contextTokenEstimator: async () => 60_000,
+    })).resolves.toBeUndefined()
+    expect(compressorCompressMock).not.toHaveBeenCalled()
+  })
+
   it('preserves empty assistant reasoning_content in bridge history', async () => {
     getSessionDetailMock.mockReturnValue({
       messages: [

--- a/tests/server/run-chat-ekko-context.test.ts
+++ b/tests/server/run-chat-ekko-context.test.ts
@@ -25,6 +25,9 @@ const getGlobalEkkoAgentMock = vi.hoisted(() => vi.fn(() => ({
   sessionWorkspaceDirectory: agentSessionWorkspaceDirectoryMock,
 })))
 const buildCompressedHistoryMock = vi.hoisted(() => vi.fn())
+const buildDbSnapshotAwareHistoryMock = vi.hoisted(() => vi.fn())
+const compactStudioTurnTailMock = vi.hoisted(() => vi.fn())
+const isStudioTurnTailCompressionEnabledMock = vi.hoisted(() => vi.fn(async () => false))
 const recordSessionUsageMock = vi.hoisted(() => vi.fn())
 const startWorkspaceRunCheckpointMock = vi.hoisted(() => vi.fn())
 const completeWorkspaceRunCheckpointMock = vi.hoisted(() => vi.fn())
@@ -48,6 +51,9 @@ vi.mock('../../packages/server/src/modules/studio/services/chat-run/compression'
   return {
     ...actual,
     buildCompressedHistory: buildCompressedHistoryMock,
+    buildDbSnapshotAwareHistory: buildDbSnapshotAwareHistoryMock,
+    compactStudioTurnTail: compactStudioTurnTailMock,
+    isStudioTurnTailCompressionEnabled: isStudioTurnTailCompressionEnabledMock,
   }
 })
 
@@ -173,6 +179,8 @@ function continuationContext(subagentId = 'child-background') {
 describe('ekko-agent context usage events', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    isStudioTurnTailCompressionEnabledMock.mockResolvedValue(false)
+    buildDbSnapshotAwareHistoryMock.mockResolvedValue([])
     agentEstimateContextMock.mockResolvedValue({ contextTokens: 5_000 })
     buildCompressedHistoryMock.mockImplementation(async (
       sessionId: string,
@@ -219,6 +227,42 @@ describe('ekko-agent context usage events', () => {
       },
     })
     completeWorkspaceRunCheckpointMock.mockReturnValue(null)
+  })
+
+  it('runs enabled turn-tail compression before Ekko completion and queue release', async () => {
+    isStudioTurnTailCompressionEnabledMock.mockResolvedValue(true)
+    buildDbSnapshotAwareHistoryMock.mockResolvedValue([{ role: 'user', content: 'previous' }])
+    const order: string[] = []
+    addMessagesMock.mockImplementation((messages: unknown[]) => {
+      order.push('persist')
+      return messages.map((_, index) => 100 + index)
+    })
+    compactStudioTurnTailMock.mockImplementation(async () => {
+      order.push('compress')
+    })
+    agentRunMock.mockResolvedValueOnce({
+      runId: 'run-turn-tail',
+      output: { role: 'assistant', content: 'done' },
+      steps: [],
+      contextEstimate: { contextTokens: 5_000 },
+    })
+    const { handleEkkoAgentRun } = await import('../../packages/server/src/modules/studio/services/chat-run/handle-ekko-agent-run')
+    const { nsp, socket, sessionMap, events } = makeHarness()
+
+    await handleEkkoAgentRun(nsp as any, socket as any, {
+      session_id: 'session-1',
+      input: 'continue',
+      coding_agent_id: 'ekko-agent',
+      onEvent: (event: string, payload: any) => {
+        events.push({ event, payload })
+        if (event === 'run.completed') order.push('completed')
+      },
+    }, 'default', sessionMap as any, vi.fn())
+
+    expect(compactStudioTurnTailMock).toHaveBeenCalledTimes(1)
+    expect(compactStudioTurnTailMock).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'session-1' }))
+    expect(order.indexOf('persist')).toBeLessThan(order.indexOf('compress'))
+    expect(order.indexOf('compress')).toBeLessThan(order.indexOf('completed'))
   })
 
   it('bridges Ekko tool approval requests through the existing chat events', async () => {

--- a/tests/server/run-chat-ekko-context.test.ts
+++ b/tests/server/run-chat-ekko-context.test.ts
@@ -181,6 +181,7 @@ describe('ekko-agent context usage events', () => {
     vi.clearAllMocks()
     isStudioTurnTailCompressionEnabledMock.mockResolvedValue(false)
     buildDbSnapshotAwareHistoryMock.mockResolvedValue([])
+    compactStudioTurnTailMock.mockResolvedValue(undefined)
     agentEstimateContextMock.mockResolvedValue({ contextTokens: 5_000 })
     buildCompressedHistoryMock.mockImplementation(async (
       sessionId: string,
@@ -239,12 +240,15 @@ describe('ekko-agent context usage events', () => {
     })
     compactStudioTurnTailMock.mockImplementation(async () => {
       order.push('compress')
+      return 1_234
     })
-    agentRunMock.mockResolvedValueOnce({
-      runId: 'run-turn-tail',
-      output: { role: 'assistant', content: 'done' },
-      steps: [],
-      contextEstimate: { contextTokens: 5_000 },
+    agentRunMock.mockImplementationOnce(async (input: any) => {
+      input.onEvent({ type: 'context.estimated', runId: 'run-turn-tail', estimate: { contextTokens: 5_000, context_tokens: 5_000 } })
+      return {
+        runId: 'run-turn-tail',
+        output: { role: 'assistant', content: 'done' },
+        steps: [],
+      }
     })
     const { handleEkkoAgentRun } = await import('../../packages/server/src/modules/studio/services/chat-run/handle-ekko-agent-run')
     const { nsp, socket, sessionMap, events } = makeHarness()
@@ -263,6 +267,14 @@ describe('ekko-agent context usage events', () => {
     expect(compactStudioTurnTailMock).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'session-1' }))
     expect(order.indexOf('persist')).toBeLessThan(order.indexOf('compress'))
     expect(order.indexOf('compress')).toBeLessThan(order.indexOf('completed'))
+    expect(events.find(item => item.event === 'run.completed')?.payload).toMatchObject({
+      contextTokens: 1_234,
+      context_tokens: 1_234,
+    })
+    expect(events.find(item => item.event === 'run.completed')?.payload.contextEstimate).toMatchObject({
+      contextTokens: 1_234,
+      context_tokens: 1_234,
+    })
   })
 
   it('bridges Ekko tool approval requests through the existing chat events', async () => {


### PR DESCRIPTION
## Summary

- add the opt-in Studio-only `compression.studio_compact_on_turn_end` switch;
- preserve existing turn-start preflight compression as the context-window safety net;
- after successful bridge and Ekko turns, re-evaluate the existing Studio threshold after final message persistence and before `run.completed` / queued-run release;
- skip proactive tail compression for failed and aborted runs;
- keep turn-tail failures fail open without changing Hermes Agent Core or `state.db`;
- report post-compression context usage consistently in bridge and Ekko completion payloads.

## Why

Studio currently pays a near-threshold summarization cost on the next user request. This option moves that work between successful turns while reusing the existing Studio snapshot, threshold, protected windows, auxiliary compression model, and persistence path.

The switch is Studio-scoped deliberately. Hermes Agent Core owns a separate transcript and may gain its own post-response compression; a generic shared flag could cause two independent summarization calls.

## Lifecycle

```text
final assistant/tool persistence
→ Studio snapshot-aware threshold evaluation
→ optional compression + snapshot persistence
→ run.completed
→ state reset / queued-run release
```

Turn-start preflight remains unchanged, so a missing, stale, or failed turn-tail snapshot cannot allow an oversized request to bypass the existing safety check.

## Validation

- `NODE_ENV=development npm run test -- tests/server/run-chat-compression.test.ts tests/server/run-chat-bridge-final-context.test.ts tests/server/run-chat-ekko-context.test.ts --run` — 86 passed
- `npx tsc -p packages/server/tsconfig.json --noEmit` — passed
- `NODE_ENV=development npm run harness:check` — passed
- `NODE_ENV=development npm run build` — passed
- `NODE_ENV=development npm run test:e2e` — 139 passed; one unrelated XLSX worker visibility test failed once and passed on isolated rerun
- `git diff --check` — passed


### Isolated real-runtime canary

A real canary was also run from this PR branch's built `dist/server/index.js`, using an isolated SQLite online-backup database, isolated `HERMES_HOME` / `HERMES_WEB_UI_HOME`, a dedicated local port, gateway autostart disabled, and the configured `gpt-5.6-sol` provider. The threshold was kept high through turn-start and lowered only after `run.started`, so the run exercised turn-tail without a preceding turn-start compression.

Observed lifecycle:

```text
turn-start threshold check: 25,738 < 204,800 → skip
run.started
final user/assistant persistence (`CANARY_OK`)
turn-tail threshold check: 25,749 > 25,600 → compress
compression.started
compression.completed: 86 → 11 messages, 25,749 → 3,019 tokens
run.completed: contextTokens=3,019, queue_remaining=0
```

The isolated compression snapshot advanced through message id `210527`. No production Studio database or runtime was modified by this canary.

## Coverage baseline limitation

The full `npm run test:coverage` run reports 10 failures in two environment-sensitive suites, `agent-bridge-profile-env.test.ts` and `coding-agents-launch.test.ts`. The same failures reproduce on a clean `upstream/main` worktree on this machine: the tests observe the currently running Studio/profile environment (`8748` and current profile variables) while asserting isolated historical values (`8648` and fixture profile variables). This PR does not modify those suites or their code paths; 4,597 tests passed in the coverage run.

## Known trade-off

Turn-tail mode may spend a compression-model call even if the user never sends another message, so it defaults to `false`.

Refs #2768
Refs NousResearch/hermes-agent#53579
