### PR TITLE
feat(ekko): support parallel tool calls

### DIFF
--- a/packages/ekko-agent/README.md
+++ b/packages/ekko-agent/README.md
@@ -155,6 +155,12 @@ these decisions into its UI.
 events together. The default `maxSteps` is `90`, matching Hermes' regular agent
 turn budget.
 
+Tools execute serially unless their `AgentTool.concurrency` is explicitly set
+to `parallel`. Consecutive parallel-safe calls run with an eight-call limit;
+serial tools remain ordered barriers, and results are replayed to the model in
+the original tool-call order. Built-in file/image/skill/memory reads opt in.
+MCP tools opt in per server with `supports_parallel_tool_calls: true`.
+
 The default registry exposes `clarify` only for a foreground run whose
 `AgentToolContext` provides `requestUserClarification`. Delegated subagents and
 non-interactive hosts do not receive the tool. When available, the runtime

--- a/packages/ekko-agent/docs/API.md
+++ b/packages/ekko-agent/docs/API.md
@@ -162,7 +162,7 @@ JavaScript 运行时也会为不与根字段冲突的 Profile 安装直接属性
 | `refresh(context?)` | `AgentToolContext?` | `Promise<void>` | 刷新动态工具；强制写入本 Profile ID。 |
 | `execute(name, input, context?)` | 工具名、对象入参、上下文 | `Promise<AgentToolResult>` | 执行工具；强制写入本 Profile ID。 |
 
-`AgentTool` 字段：`definition.name` 是唯一工具名，`definition.description?` 是模型说明，`definition.parameters?` 是 JSON Schema；`execute(input, context?)` 返回 `{ ok, content, contentParts?, data?, error? }`。`AgentToolProvider` 字段为 `id`，并实现 `listTools(context?)`。
+`AgentTool` 字段：`definition.name` 是唯一工具名，`definition.description?` 是模型说明，`definition.parameters?` 是 JSON Schema；`concurrency?` 默认为 `serial`，只有不共享可变状态且允许同批并发的工具才应设为 `parallel`；`execute(input, context?)` 返回 `{ ok, content, contentParts?, data?, error? }`。`AgentToolProvider` 字段为 `id`，并实现 `listTools(context?)`。Ekko runtime 将连续的 `parallel` 调用以最多 8 路并发执行，并把结果按原 tool-call 顺序回放；未标记工具仍是串行屏障。
 
 ## Profile `skill` 模块
 
@@ -2466,7 +2466,7 @@ export interface SystemPromptInput {
 
 export const EKKO_OUTPUT_FORMAT_GUIDELINES = `## Image and File Output When returning an image, video, or file to the user, use Markdown with an existing local absolute path. - Unix/macOS/WSL image: \`![description](/absolute/path/image.png)\` - Windows image: \`![description](<C:/absolute/path/image.png>)\` - Unix/macOS/WSL file: \`[filename](/absolute/path/file.pdf)\` - Windows file: \`[filename](<C:/absolute/path/file.pdf>)\` - Use forward slashes for Windows paths. - Wrap paths containing spaces, non-ASCII characters, or special characters in angle brackets. - Do not use relative paths or \`file://\` URLs. - Verify that the referenced file exists before returning it.`
 
-export const EKKO_TOOL_EXECUTION_GUIDELINES = `## Tool Execution Treat external commands, language packages, and other prerequisites named by a Skill as requirements, not proof that they are installed. - Before relying on an external dependency whose availability has not already been established, perform a lightweight availability check. - Do not run the primary dependency-based approach merely to discover whether its dependency exists. - When the user asks to execute or evaluate Node.js, JavaScript, or Python source code, use code_exec, including for one-line snippets. Do not probe Node or Python with terminal_exec first; code_exec resolves its runtime. - Use terminal_exec for CLI commands, project scripts, tests, builds, package managers, and other executables. - terminal_exec may use explicit absolute system paths and package-manager forms such as npx --dir. This capability is not limited to workspace files. - By default, keep downloads, clones, archives, extracted repositories, and generated intermediates inside the current workspace. Prefer the workspace's .ekko-tmp directory for disposable files so workspace-scoped file and image tools can inspect them. Use a system or external path only when the user or task explicitly requires it. - Dangerous tool calls may pause for runtime authorization. If authorization is denied, do not retry the operation through another tool or language runtime unless the user explicitly changes that decision. - After terminal_exec reports a [skill_validation] issue, do not claim the Skill installation is complete. Call skill_view for each writable local Skill and repair it with skill_manage until its frontmatter passes validation. Do not mutate read-only external Skill directories. - If a dependency is unavailable, prefer a compatible installed or built-in alternative. Install it only when installation is necessary and appropriate for the user's task. - Verify created artifacts before returning them.`
+export const EKKO_TOOL_EXECUTION_GUIDELINES = `## Tool Execution Treat external commands, language packages, and other prerequisites named by a Skill as requirements, not proof that they are installed. - Before relying on an external dependency whose availability has not already been established, perform a lightweight availability check. - Do not run the primary dependency-based approach merely to discover whether its dependency exists. - Request independent tool calls together in one response. The runtime executes tools marked as parallel-safe concurrently while preserving serial barriers for stateful or dependent work. - When the user asks to execute or evaluate Node.js, JavaScript, or Python source code, use code_exec, including for one-line snippets. Do not probe Node or Python with terminal_exec first; code_exec resolves its runtime. - Use terminal_exec for CLI commands, project scripts, tests, builds, package managers, and other executables. - terminal_exec may use explicit absolute system paths and package-manager forms such as npx --dir. This capability is not limited to workspace files. - By default, keep downloads, clones, archives, extracted repositories, and generated intermediates inside the current workspace. Prefer the workspace's .ekko-tmp directory for disposable files so workspace-scoped file and image tools can inspect them. Use a system or external path only when the user or task explicitly requires it. - Dangerous tool calls may pause for runtime authorization. If authorization is denied, do not retry the operation through another tool or language runtime unless the user explicitly changes that decision. - After terminal_exec reports a [skill_validation] issue, do not claim the Skill installation is complete. Call skill_view for each writable local Skill and repair it with skill_manage until its frontmatter passes validation. Do not mutate read-only external Skill directories. - If a dependency is unavailable, prefer a compatible installed or built-in alternative. Install it only when installation is necessary and appropriate for the user's task. - Verify created artifacts before returning them.`
 
 export const EKKO_CLARIFICATION_GUIDELINES = `## User Clarification When missing user input materially blocks or changes the task, call the clarify tool and wait for the response. - Do not present a blocking clarification question as an ordinary assistant response. - Ask one concise question that collects the necessary information; provide choices only for a short fixed set of answers. - Do not call clarify when a safe, reasonable assumption lets you continue without materially changing the outcome.`
 
@@ -2906,6 +2906,7 @@ export interface WriteFileInput extends Record<string, unknown> {
 }
 
 export class ReadFileTool implements AgentTool<ReadFileInput> {
+  readonly concurrency = 'parallel' as const
   readonly definition = { name: 'read_file', description: 'Read a UTF-8 text file from the workspace.', parameters: { type: 'object', properties: { path: { type: 'string', description: 'File path relative to the current workspace.' }, encoding: { type: 'string', description: 'Text encoding. Defaults to utf8.' }, }, required: ['path'], additionalProperties: false, }, }
   async execute(input: ReadFileInput, context: AgentToolContext = {}): Promise<AgentToolResult>
 }
@@ -2929,6 +2930,7 @@ export interface ViewImageToolOptions {
 }
 
 export class ViewImageTool implements AgentTool<ViewImageInput> {
+  readonly concurrency = 'parallel' as const
   readonly definition = { name: 'view_image', description: 'Load a local PNG, JPEG, WebP, or GIF image from the workspace for visual inspection.', parameters: { type: 'object', properties: { path: { type: 'string', description: 'Image path relative to the current workspace, or an absolute path inside workspaceRoot.', }, }, required: ['path'], additionalProperties: false, }, }
   constructor(options: ViewImageToolOptions = {})
   async execute(input: ViewImageInput, context: AgentToolContext = {}): Promise<AgentToolResult>
@@ -3046,12 +3048,14 @@ export interface SkillRoutingResolution {
 }
 
 export class SkillListTool implements AgentTool<SkillListInput> {
+  readonly concurrency = 'parallel' as const
   constructor(private readonly skillDirectory?: string, private readonly externalSkillDirectories: EkkoExternalSkillDirectory[] = [], private readonly disabledSkillNames: string[] = [])
   readonly definition = { name: 'skill_list', description: 'Fallback discovery for skills in this Ekko Agent instance\'s configured skill directory. Available skill names are already present in the system prompt; use skill_view directly when one clearly matches.', parameters: { type: 'object', properties: { query: { type: 'string', description: 'Optional case-insensitive search across skill names, descriptions, and maintained keywords.', }, }, additionalProperties: false, }, }
   async execute(input: SkillListInput): Promise<AgentToolResult>
 }
 
 export class SkillViewTool implements AgentTool<SkillViewInput> {
+  readonly concurrency = 'parallel' as const
   constructor(private readonly skillDirectory?: string, private readonly tracker = new SkillReadTracker(), private readonly externalSkillDirectories: EkkoExternalSkillDirectory[] = [], private readonly disabledSkillNames: string[] = [])
   readonly definition = { name: 'skill_view', description: 'Load the complete SKILL.md instructions for one skill in this Ekko Agent instance\'s configured skill directory. Use an exact name from the system prompt or skill_list.', parameters: { type: 'object', properties: { name: { type: 'string', description: 'Exact skill name from the system prompt or skill_list.', }, filePath: { type: 'string', description: 'Optional support file path under references/, templates/, scripts/, or assets/. Defaults to SKILL.md.', }, }, required: ['name'], additionalProperties: false, }, }
   async execute(input: SkillViewInput, context: AgentToolContext = {}): Promise<AgentToolResult>
@@ -3202,8 +3206,11 @@ export interface AgentToolResult {
 
 export type AgentToolContentPart = | { type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }
 
+export type AgentToolConcurrency = 'serial' | 'parallel'
+
 export interface AgentTool<TInput extends Record<string, unknown> = Record<string, unknown>> {
   definition: AgentToolDefinition
+  concurrency?: AgentToolConcurrency
   execute(input: TInput, context?: AgentToolContext): Promise<AgentToolResult>
 }
 

--- a/packages/ekko-agent/src/memory/tools.ts
+++ b/packages/ekko-agent/src/memory/tools.ts
@@ -41,6 +41,8 @@ class MemoryReviewTool implements AgentTool {
 }
 
 class MemorySearchTool implements AgentTool {
+  readonly concurrency = 'parallel' as const
+
   readonly definition = {
     name: 'memory_search',
     description: 'Search memory in the host-authorized recall scopes. Results include the canonical key, scope, id, revision, value, and content required for precise mutations. Do not search again when automatic recall already contains a direct, conflict-free answer. Otherwise, use this tool to verify remembered information or before saying that you do not know or remember. Prefer kinds for known categories and queryText for open-ended questions.',
@@ -94,6 +96,8 @@ function validMemoryKinds(value: unknown): MemoryQuery['kinds'] {
 }
 
 class MemoryGetTool implements AgentTool {
+  readonly concurrency = 'parallel' as const
+
   readonly definition = {
     name: 'memory_get',
     description: 'Get one complete memory card by id, including its server canonical key and current revision.',

--- a/packages/ekko-agent/src/runtime/runtime.ts
+++ b/packages/ekko-agent/src/runtime/runtime.ts
@@ -56,6 +56,7 @@ import {
 } from '../config'
 
 const MAX_TRACKED_SKILL_REVIEW_CONTEXTS = 1_024
+const MAX_CONCURRENT_TOOL_CALLS = 8
 const SUBTASK_OUTPUT_TAIL_CHARS = 4_000
 const SUBTASK_SUMMARY_CHARS = 500
 
@@ -88,6 +89,16 @@ interface HistoricalSkillView {
   declaredCharacters?: number
   declaredHash?: string
   body: string
+}
+
+interface ToolCallSegment {
+  mode: 'serial' | 'parallel'
+  toolCalls: AgentToolCall[]
+}
+
+interface ExecutedToolCall {
+  toolCall: AgentToolCall
+  result: AgentToolResult
 }
 
 function foregroundOnlyDelegateTaskDefinition(definition: AgentToolDefinition): AgentToolDefinition {
@@ -414,17 +425,19 @@ export class AgentRuntime {
         }
         messages.push(skillLoadMessage)
         steps.push({ type: 'model', step: 0, message: skillLoadMessage })
-        for (const toolCall of toolCalls) {
-          const result = await this.executeTool(
+        for (const segment of this.planToolCallSegments(toolCalls)) {
+          const executedCalls = await this.executeToolCallSegment(
             runId,
             0,
-            toolCall,
+            segment,
             executionToolContext,
             emit,
             input.signal,
           )
-          messages.push(createToolResultMessage(toolCall.id, result.content, toolCall.name, result.contentParts))
-          steps.push({ type: 'tool', step: 0, toolCallId: toolCall.id, toolName: toolCall.name, result })
+          for (const { toolCall, result } of executedCalls) {
+            messages.push(createToolResultMessage(toolCall.id, result.content, toolCall.name, result.contentParts))
+            steps.push({ type: 'tool', step: 0, toolCallId: toolCall.id, toolName: toolCall.name, result })
+          }
         }
       }
       for (let step = 1; step <= maxSteps; step += 1) {
@@ -492,34 +505,34 @@ export class AgentRuntime {
           return { runId, messages, output, steps, events, context, contextEstimate, memoryContext }
         }
 
-        for (const toolCall of toolCalls) {
-          throwIfAborted(input.signal)
-          const result = await this.executeTool(
+        for (const segment of this.planToolCallSegments(toolCalls)) {
+          const executedCalls = await this.executeToolCallSegment(
             runId,
             step,
-            toolCall,
+            segment,
             executionToolContext,
             emit,
             input.signal,
           )
-          throwIfAborted(input.signal)
-          messages.push(createToolResultMessage(toolCall.id, result.content, toolCall.name, result.contentParts))
-          steps.push({ type: 'tool', step, toolCallId: toolCall.id, toolName: toolCall.name, result })
-          consecutiveToolFailures = result.ok ? 0 : consecutiveToolFailures + 1
-          if (input.skillReviewEnabled !== false) this.recordSkillToolCall(contextKey, toolCall.name)
-          if (maxConsecutiveToolFailures > 0 && consecutiveToolFailures >= maxConsecutiveToolFailures) {
-            if (activeBoundaryRun) activeBoundaryRun.terminal = true
-            emit({ type: 'run.tool_failure_limit', runId, failures: consecutiveToolFailures })
-            output = {
-              role: 'assistant',
-              content: `Stopped after ${consecutiveToolFailures} consecutive tool failures.`,
-              finishReason: 'tool_failure_limit',
+          for (const { toolCall, result } of executedCalls) {
+            messages.push(createToolResultMessage(toolCall.id, result.content, toolCall.name, result.contentParts))
+            steps.push({ type: 'tool', step, toolCallId: toolCall.id, toolName: toolCall.name, result })
+            consecutiveToolFailures = result.ok ? 0 : consecutiveToolFailures + 1
+            if (input.skillReviewEnabled !== false) this.recordSkillToolCall(contextKey, toolCall.name)
+            if (maxConsecutiveToolFailures > 0 && consecutiveToolFailures >= maxConsecutiveToolFailures) {
+              if (activeBoundaryRun) activeBoundaryRun.terminal = true
+              emit({ type: 'run.tool_failure_limit', runId, failures: consecutiveToolFailures })
+              output = {
+                role: 'assistant',
+                content: `Stopped after ${consecutiveToolFailures} consecutive tool failures.`,
+                finishReason: 'tool_failure_limit',
+              }
+              const context = contextKey ? this.modelContexts.get(contextKey) : undefined
+              emit({ type: 'run.completed', runId, output, steps: step, context, contextEstimate })
+              this.completeMemory(runId, memoryIdentity, messages, input, memoryReviewRequested)
+              this.completeSkillReview(runId, contextKey, messages, input, input.onEvent)
+              return { runId, messages, output, steps, events, context, contextEstimate, memoryContext }
             }
-            const context = contextKey ? this.modelContexts.get(contextKey) : undefined
-            emit({ type: 'run.completed', runId, output, steps: step, context, contextEstimate })
-            this.completeMemory(runId, memoryIdentity, messages, input, memoryReviewRequested)
-            this.completeSkillReview(runId, contextKey, messages, input, input.onEvent)
-            return { runId, messages, output, steps, events, context, contextEstimate, memoryContext }
           }
         }
         if (pendingBackgroundSubagentIds.size > 0) {
@@ -1028,6 +1041,56 @@ export class AgentRuntime {
       : undefined
     if (!this.profileId) return context
     return { ...context, profileId: this.profileId }
+  }
+
+  private planToolCallSegments(toolCalls: AgentToolCall[]): ToolCallSegment[] {
+    const segments: ToolCallSegment[] = []
+    for (const toolCall of toolCalls) {
+      const mode = this.tools.get(toolCall.name)?.concurrency === 'parallel'
+        ? 'parallel'
+        : 'serial'
+      const previous = segments.at(-1)
+      if (previous?.mode === mode) previous.toolCalls.push(toolCall)
+      else segments.push({ mode, toolCalls: [toolCall] })
+    }
+    return segments
+  }
+
+  private async executeToolCallSegment(
+    runId: string,
+    step: number,
+    segment: ToolCallSegment,
+    context: AgentToolContext | undefined,
+    emit: (event: AgentRuntimeEvent) => void,
+    signal?: AbortSignal,
+  ): Promise<ExecutedToolCall[]> {
+    if (segment.mode === 'serial' || segment.toolCalls.length <= 1) {
+      const executedCalls: ExecutedToolCall[] = []
+      for (const toolCall of segment.toolCalls) {
+        throwIfAborted(signal)
+        const result = await this.executeTool(runId, step, toolCall, context, emit, signal)
+        throwIfAborted(signal)
+        executedCalls.push({ toolCall, result })
+      }
+      return executedCalls
+    }
+
+    const results: Array<ExecutedToolCall | undefined> = new Array(segment.toolCalls.length)
+    let nextIndex = 0
+    const worker = async () => {
+      while (!signal?.aborted) {
+        const index = nextIndex
+        nextIndex += 1
+        if (index >= segment.toolCalls.length) return
+        const toolCall = segment.toolCalls[index]
+        const result = await this.executeTool(runId, step, toolCall, context, emit, signal)
+        results[index] = { toolCall, result }
+      }
+    }
+    const workerCount = Math.min(MAX_CONCURRENT_TOOL_CALLS, segment.toolCalls.length)
+    await Promise.all(Array.from({ length: workerCount }, worker))
+    throwIfAborted(signal)
+    return results as ExecutedToolCall[]
   }
 
   private async executeTool(

--- a/packages/ekko-agent/src/runtime/system-prompt.ts
+++ b/packages/ekko-agent/src/runtime/system-prompt.ts
@@ -35,6 +35,7 @@ Treat external commands, language packages, and other prerequisites named by a S
 
 - Before relying on an external dependency whose availability has not already been established, perform a lightweight availability check.
 - Do not run the primary dependency-based approach merely to discover whether its dependency exists.
+- Request independent tool calls together in one response. The runtime executes tools marked as parallel-safe concurrently while preserving serial barriers for stateful or dependent work.
 - When the user asks to execute or evaluate Node.js, JavaScript, or Python source code, use code_exec, including for one-line snippets. Do not probe Node or Python with terminal_exec first; code_exec resolves its runtime.
 - Use terminal_exec for CLI commands, project scripts, tests, builds, package managers, and other executables.
 - terminal_exec may use explicit absolute system paths and package-manager forms such as npx --dir. This capability is not limited to workspace files.

--- a/packages/ekko-agent/src/tools/files.ts
+++ b/packages/ekko-agent/src/tools/files.ts
@@ -16,6 +16,8 @@ export interface WriteFileInput extends Record<string, unknown> {
 }
 
 export class ReadFileTool implements AgentTool<ReadFileInput> {
+  readonly concurrency = 'parallel' as const
+
   readonly definition = {
     name: 'read_file',
     description: 'Read a UTF-8 text file from the workspace.',

--- a/packages/ekko-agent/src/tools/images.ts
+++ b/packages/ekko-agent/src/tools/images.ts
@@ -14,6 +14,8 @@ export interface ViewImageToolOptions {
 }
 
 export class ViewImageTool implements AgentTool<ViewImageInput> {
+  readonly concurrency = 'parallel' as const
+
   readonly definition = {
     name: 'view_image',
     description: 'Load a local PNG, JPEG, WebP, or GIF image from the workspace for visual inspection.',

--- a/packages/ekko-agent/src/tools/mcp.ts
+++ b/packages/ekko-agent/src/tools/mcp.ts
@@ -7,12 +7,14 @@ interface StdioMcpServerConfig {
   command: string
   args: string[]
   env: Record<string, string>
+  supportsParallelToolCalls: boolean
 }
 
 interface StreamableHttpMcpServerConfig {
   type: 'streamable_http'
   url: string
   headers: Record<string, string>
+  supportsParallelToolCalls: boolean
 }
 
 type McpServerConfig = StdioMcpServerConfig | StreamableHttpMcpServerConfig
@@ -26,6 +28,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function normalizeServerConfig(value: unknown): McpServerConfig | null {
   if (!isRecord(value) || value.enabled === false) return null
+  const supportsParallelToolCalls = value.supports_parallel_tool_calls === true
   const configuredType = typeof value.type === 'string' ? value.type.trim().toLowerCase() : ''
   const command = typeof value.command === 'string' ? value.command.trim() : ''
   const rawUrl = typeof value.url === 'string' ? value.url.trim() : ''
@@ -39,6 +42,7 @@ function normalizeServerConfig(value: unknown): McpServerConfig | null {
         type: 'streamable_http',
         url: url.toString(),
         headers: normalizeStringRecord(value.headers),
+        supportsParallelToolCalls,
       }
     } catch {
       return null
@@ -52,6 +56,7 @@ function normalizeServerConfig(value: unknown): McpServerConfig | null {
     command,
     args: Array.isArray(value.args) ? value.args.map(arg => String(arg)) : [],
     env: normalizeProcessEnv(value.env),
+    supportsParallelToolCalls,
   }
 }
 
@@ -188,13 +193,16 @@ class McpClientSession {
 
 class McpTool implements AgentTool {
   readonly definition: AgentTool['definition']
+  readonly concurrency: AgentTool['concurrency']
 
   constructor(
     serverName: string,
     private readonly remoteName: string,
     tool: any,
     private readonly session: McpClientSession,
+    supportsParallelToolCalls: boolean,
   ) {
+    this.concurrency = supportsParallelToolCalls ? 'parallel' : 'serial'
     this.definition = {
       name: String(tool.name || remoteName),
       description: String(tool.description || `MCP tool ${remoteName} from ${serverName}`),
@@ -233,7 +241,13 @@ export function createMcpToolProvider(): AgentToolProvider {
           for (const tool of await session.listTools(timeoutMs)) {
             if (!tool?.name || usedNames.has(String(tool.name))) continue
             usedNames.add(String(tool.name))
-            tools.push(new McpTool(serverName, String(tool.name), tool, session))
+            tools.push(new McpTool(
+              serverName,
+              String(tool.name),
+              tool,
+              session,
+              server.supportsParallelToolCalls,
+            ))
           }
         } catch {
           // A broken MCP server should not prevent the rest of the agent run.

--- a/packages/ekko-agent/src/tools/skills.ts
+++ b/packages/ekko-agent/src/tools/skills.ts
@@ -112,6 +112,8 @@ class SkillReadTracker {
 }
 
 export class SkillListTool implements AgentTool<SkillListInput> {
+  readonly concurrency = 'parallel' as const
+
   constructor(
     private readonly skillDirectory?: string,
     private readonly externalSkillDirectories: EkkoExternalSkillDirectory[] = [],
@@ -173,6 +175,8 @@ export class SkillListTool implements AgentTool<SkillListInput> {
 }
 
 export class SkillViewTool implements AgentTool<SkillViewInput> {
+  readonly concurrency = 'parallel' as const
+
   constructor(
     private readonly skillDirectory?: string,
     private readonly tracker = new SkillReadTracker(),

--- a/packages/ekko-agent/src/tools/types.ts
+++ b/packages/ekko-agent/src/tools/types.ts
@@ -92,8 +92,12 @@ export type AgentToolContentPart =
   | { type: 'text'; text: string }
   | { type: 'image'; data: string; mimeType: string }
 
+export type AgentToolConcurrency = 'serial' | 'parallel'
+
 export interface AgentTool<TInput extends Record<string, unknown> = Record<string, unknown>> {
   definition: AgentToolDefinition
+  /** Defaults to serial. Use parallel only when independent calls cannot race through shared mutable state. */
+  concurrency?: AgentToolConcurrency
   execute(input: TInput, context?: AgentToolContext): Promise<AgentToolResult>
 }
 

--- a/tests/ekko-agent/runtime.test.ts
+++ b/tests/ekko-agent/runtime.test.ts
@@ -354,6 +354,173 @@ describe('ekko-agent runtime', () => {
     expect(result.steps.map(step => step.type)).toEqual(['model', 'tool', 'model'])
   })
 
+  it('executes explicitly parallel-safe tool calls concurrently and preserves result order', async () => {
+    let releaseFirst!: () => void
+    let signalSecondStarted!: () => void
+    const firstRelease = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const secondStarted = new Promise<void>((resolve) => {
+      signalSecondStarted = resolve
+    })
+    const tools = new AgentToolRegistry()
+    tools.register({
+      definition: { name: 'parallel_probe', description: 'parallel probe', parameters: { type: 'object' } },
+      concurrency: 'parallel',
+      async execute(input) {
+        const label = String(input.label)
+        if (label === 'first') await firstRelease
+        else signalSecondStarted()
+        return { ok: true, content: label }
+      },
+    })
+    const client = modelClient((_request, call) => call === 1
+      ? {
+          content: '',
+          toolCalls: [
+            { id: 'call-1', name: 'parallel_probe', arguments: { label: 'first' } },
+            { id: 'call-2', name: 'parallel_probe', arguments: { label: 'second' } },
+          ],
+          finishReason: 'tool_calls',
+        }
+      : { content: 'done', finishReason: 'stop' })
+    const runtime = new AgentRuntime({ modelClient: client, tools })
+
+    const run = runtime.run({ messages: ['run both probes'] })
+    const startedTogether = await Promise.race([
+      secondStarted.then(() => true),
+      new Promise<boolean>(resolve => setTimeout(() => resolve(false), 200)),
+    ])
+    releaseFirst()
+    const result = await run
+
+    expect(startedTogether).toBe(true)
+    expect(result.messages.filter(message => message.role === 'tool')).toMatchObject([
+      { toolCallId: 'call-1', content: 'first' },
+      { toolCallId: 'call-2', content: 'second' },
+    ])
+    expect(result.steps.filter(step => step.type === 'tool').map(step => step.toolCallId))
+      .toEqual(['call-1', 'call-2'])
+  })
+
+  it('keeps serial tools as barriers between parallel-safe segments', async () => {
+    let activeParallelCalls = 0
+    let barrierStartedWhileParallel = false
+    let parallelStartedBeforeBarrierFinished = false
+    let barrierFinished = false
+    const tools = new AgentToolRegistry()
+    tools.register({
+      definition: { name: 'parallel_segment', description: 'parallel segment', parameters: { type: 'object' } },
+      concurrency: 'parallel',
+      async execute(input) {
+        if (input.phase === 'after' && !barrierFinished) parallelStartedBeforeBarrierFinished = true
+        activeParallelCalls += 1
+        await new Promise(resolve => setTimeout(resolve, 10))
+        activeParallelCalls -= 1
+        return { ok: true, content: String(input.phase) }
+      },
+    })
+    tools.register({
+      definition: { name: 'serial_barrier', description: 'serial barrier', parameters: { type: 'object' } },
+      async execute() {
+        barrierStartedWhileParallel = activeParallelCalls > 0
+        barrierFinished = true
+        return { ok: true, content: 'barrier' }
+      },
+    })
+    const client = modelClient((_request, call) => call === 1
+      ? {
+          content: '',
+          toolCalls: [
+            { id: 'before-1', name: 'parallel_segment', arguments: { phase: 'before-1' } },
+            { id: 'before-2', name: 'parallel_segment', arguments: { phase: 'before-2' } },
+            { id: 'barrier', name: 'serial_barrier', arguments: {} },
+            { id: 'after-1', name: 'parallel_segment', arguments: { phase: 'after' } },
+            { id: 'after-2', name: 'parallel_segment', arguments: { phase: 'after' } },
+          ],
+          finishReason: 'tool_calls',
+        }
+      : { content: 'done', finishReason: 'stop' })
+
+    const result = await new AgentRuntime({ modelClient: client, tools }).run({ messages: ['run segments'] })
+
+    expect(barrierStartedWhileParallel).toBe(false)
+    expect(parallelStartedBeforeBarrierFinished).toBe(false)
+    expect(result.messages.filter(message => message.role === 'tool').map(message => message.toolCallId))
+      .toEqual(['before-1', 'before-2', 'barrier', 'after-1', 'after-2'])
+  })
+
+  it('limits parallel-safe tool execution to eight calls', async () => {
+    let activeCalls = 0
+    let maxActiveCalls = 0
+    const tools = new AgentToolRegistry()
+    tools.register({
+      definition: { name: 'bounded_parallel', description: 'bounded parallel tool', parameters: { type: 'object' } },
+      concurrency: 'parallel',
+      async execute(input) {
+        activeCalls += 1
+        maxActiveCalls = Math.max(maxActiveCalls, activeCalls)
+        await new Promise(resolve => setTimeout(resolve, 10))
+        activeCalls -= 1
+        return { ok: true, content: String(input.index) }
+      },
+    })
+    const toolCalls = Array.from({ length: 12 }, (_, index) => ({
+      id: `bounded-${index}`,
+      name: 'bounded_parallel',
+      arguments: { index },
+    }))
+    const client = modelClient((_request, call) => call === 1
+      ? { content: '', toolCalls, finishReason: 'tool_calls' }
+      : { content: 'done', finishReason: 'stop' })
+
+    const result = await new AgentRuntime({ modelClient: client, tools }).run({ messages: ['run bounded tools'] })
+
+    expect(maxActiveCalls).toBe(8)
+    expect(result.messages.filter(message => message.role === 'tool').map(message => message.toolCallId))
+      .toEqual(toolCalls.map(toolCall => toolCall.id))
+  })
+
+  it('applies the failure limit in call order before crossing a serial barrier', async () => {
+    let serialToolExecuted = false
+    const tools = new AgentToolRegistry()
+    tools.register({
+      definition: { name: 'parallel_failure', description: 'parallel failure', parameters: { type: 'object' } },
+      concurrency: 'parallel',
+      async execute(input) {
+        return { ok: false, content: `failed-${String(input.index)}`, error: 'failed' }
+      },
+    })
+    tools.register({
+      definition: { name: 'serial_after_failures', description: 'serial tool', parameters: { type: 'object' } },
+      async execute() {
+        serialToolExecuted = true
+        return { ok: true, content: 'should not run' }
+      },
+    })
+    const client = modelClient(() => ({
+      content: '',
+      toolCalls: [
+        { id: 'failure-1', name: 'parallel_failure', arguments: { index: 1 } },
+        { id: 'failure-2', name: 'parallel_failure', arguments: { index: 2 } },
+        { id: 'serial-after', name: 'serial_after_failures', arguments: {} },
+      ],
+      finishReason: 'tool_calls',
+    }))
+    const runtime = new AgentRuntime({
+      modelClient: client,
+      tools,
+      maxConsecutiveToolFailures: 2,
+    })
+
+    const result = await runtime.run({ messages: ['stop after failures'] })
+
+    expect(serialToolExecuted).toBe(false)
+    expect(result.output.finishReason).toBe('tool_failure_limit')
+    expect(result.messages.filter(message => message.role === 'tool').map(message => message.toolCallId))
+      .toEqual(['failure-1', 'failure-2'])
+  })
+
   it('waits for foreground delegated tasks and hides delegation from the child', async () => {
     const tools = new AgentToolRegistry()
     tools.register(new DelegateTaskTool())
@@ -1839,6 +2006,7 @@ describe('ekko-agent runtime', () => {
     expect(prompt).toContain('## Tool Execution')
     expect(prompt).toContain('prerequisites named by a Skill as requirements, not proof that they are installed')
     expect(prompt).toContain('perform a lightweight availability check')
+    expect(prompt).toContain('Request independent tool calls together in one response')
     expect(prompt).toContain('use code_exec, including for one-line snippets')
     expect(prompt).toContain('Do not probe Node or Python with terminal_exec first')
     expect(prompt).toContain('Use terminal_exec for CLI commands')


### PR DESCRIPTION
## Summary

- add an explicit serial or parallel concurrency policy to Ekko tools
- execute contiguous parallel-safe calls with an eight-worker limit while preserving model-visible result order
- retain serial tools as ordering barriers and preserve failure-limit behavior
- opt read-only built-ins into parallel execution and let MCP servers opt in with `supports_parallel_tool_calls`
- update Ekko documentation and runtime coverage

## Validation

- `npm --prefix packages/ekko-agent run check`
- Ekko API documentation check
- focused runtime tests: 6 passed
- remaining Ekko test files: 217 passed
- `npm --prefix packages/ekko-agent run build`
- `git diff --check`