### PR TITLE
fix(codex): strip historical inline images

### DIFF
--- a/packages/server/src/bootstrap/http.ts
+++ b/packages/server/src/bootstrap/http.ts
@@ -52,12 +52,13 @@ import { getStaticCacheControl, SPA_ENTRY_CACHE_CONTROL } from '../modules/studi
 import { requireUserJwt, resolveUserProfile } from '../modules/studio/middleware/auth'
 import { createCorsOriginResolver, securityHeaders } from '../modules/studio/middleware/security'
 import type { AdditionalShutdownStep, ShutdownHandler } from './lifecycle'
-import { createRequestBodyParser } from '../modules/studio/middleware/request-body-parser'
+import { createCodexProxyRequestBodyParser, createRequestBodyParser } from '../modules/studio/middleware/request-body-parser'
 import {
   getCodingAgentsStatus,
   migratePersistedPiRuntimeMcpConfigs,
   restorePersistedPiProxyTargets,
 } from './coding-agents'
+import { isAuthorizedCodexProxyRequest } from '../modules/coding-agents/services/codex/proxy'
 import { configurePreferredHermesRuntime } from '../modules/hermes/services/runtime/selection'
 import { configureRuntimeInstallCompletedHandler, getRuntimeVersionStatus } from '../modules/hermes/services/runtime/version-manager'
 import { isHermesAgentAvailable, updateAgentStatus } from '../modules/studio/public/agent-status-registry'
@@ -406,6 +407,10 @@ export async function bootstrap() {
 
   app.use(securityHeaders())
   app.use(cors({ origin: createCorsOriginResolver(config.corsOrigins) }))
+  // Codex can replay inline images from its native thread. Accept a bounded,
+  // authenticated request here so the proxy can remove historical image data
+  // before dispatching to any provider API mode.
+  app.use(createCodexProxyRequestBodyParser(isAuthorizedCodexProxyRequest))
   // Raise body limits above the default 1mb: profile avatars and MiMo voice-clone
   // reference audio are posted as base64 data URLs before reaching handlers.
   app.use(createRequestBodyParser())

--- a/packages/server/src/modules/coding-agents/protocol/adapters/responses.ts
+++ b/packages/server/src/modules/coding-agents/protocol/adapters/responses.ts
@@ -366,6 +366,67 @@ function truncateResponsesToolOutputText(output: string): string {
   ].join('\n')
 }
 
+function inlineResponseImageDataUrl(part: any): string {
+  if (!part || typeof part !== 'object' || part.type !== 'input_image') return ''
+  const imageUrl = typeof part.image_url === 'string'
+    ? part.image_url
+    : typeof part.image_url?.url === 'string'
+      ? part.image_url.url
+      : ''
+  return /^data:image\//i.test(imageUrl) ? imageUrl : ''
+}
+
+function historicalImageOmission(originalBytes: number): any {
+  return {
+    type: 'input_text',
+    text: `[Hermes Web UI: historical inline image omitted before provider request; original_bytes=${originalBytes}]`,
+  }
+}
+
+/**
+ * Remove every inline image before the latest user item. The latest user item
+ * and every item produced after it form the active Codex turn, so all of their
+ * images remain available to the model. The transformation is copy-on-write.
+ */
+export function stripHistoricalResponsesInlineImages(body: any): any {
+  const input = responseInputItems(body)
+  if (!input.length) return body
+
+  let currentTurnStart = -1
+  for (let index = input.length - 1; index >= 0; index -= 1) {
+    if (input[index]?.role === 'user') {
+      currentTurnStart = index
+      break
+    }
+  }
+  if (currentTurnStart <= 0) return body
+
+  let changed = false
+  const nextInput = input.map((item: any, itemIndex: number) => {
+    if (itemIndex >= currentTurnStart || !item || typeof item !== 'object') return item
+
+    let nextItem: any = item
+    for (const key of ['content', 'output'] as const) {
+      if (!Array.isArray(item[key])) continue
+      let partsChanged = false
+      const nextParts = item[key].map((part: any) => {
+        const imageUrl = inlineResponseImageDataUrl(part)
+        if (!imageUrl) return part
+        partsChanged = true
+        changed = true
+        return historicalImageOmission(utf8ByteLength(imageUrl))
+      })
+      if (partsChanged) {
+        if (nextItem === item) nextItem = { ...item }
+        nextItem[key] = nextParts
+      }
+    }
+    return nextItem
+  })
+
+  return changed ? { ...body, input: nextInput } : body
+}
+
 export function truncateResponsesToolOutputs(body: any): any {
   const input = responseInputItems(body)
   if (!input.length) return body

--- a/packages/server/src/modules/coding-agents/services/codex/proxy.ts
+++ b/packages/server/src/modules/coding-agents/services/codex/proxy.ts
@@ -14,6 +14,7 @@ import {
   openAiChatToResponses,
   responsesToAnthropicMessages,
   responsesToOpenAiChat,
+  stripHistoricalResponsesInlineImages,
   truncateResponsesToolOutputs,
 } from '../../protocol/adapters/responses'
 import {
@@ -78,6 +79,12 @@ function authToken(ctx: Context): string {
   const auth = ctx.get('authorization').trim()
   const match = auth.match(/^Bearer\s+(.+)$/i)
   return match?.[1]?.trim() || ''
+}
+
+export function isAuthorizedCodexProxyRequest(ctx: Context): boolean {
+  const routeKey = /^\/api\/codex-proxy\/([^/]+)\/v1\/responses$/.exec(ctx.path)?.[1] || ''
+  const target = findTarget(routeKey)
+  return Boolean(target && authToken(ctx) === target.token)
 }
 
 function requireTarget(ctx: Context): CodexProxyTarget | null {
@@ -246,7 +253,9 @@ export async function codexProxyResponses(ctx: Context) {
   const target = requireTarget(ctx)
   if (!target) return
   try {
-    const requestBody = ctx.request.body || {}
+    // Sanitize once before API-mode dispatch so native Responses, Chat
+    // Completions, and Anthropic adapters all receive the same bounded history.
+    const requestBody = stripHistoricalResponsesInlineImages(ctx.request.body || {})
     if ((requestBody as any).stream === true) {
       const stream = target.apiMode === 'anthropic_messages'
         ? await anthropicMessagesToResponsesSseStream(target, requestBody)

--- a/packages/server/src/modules/studio/middleware/request-body-parser.ts
+++ b/packages/server/src/modules/studio/middleware/request-body-parser.ts
@@ -1,4 +1,5 @@
 import bodyParser from '@koa/bodyparser'
+import type { Context, Next } from 'koa'
 
 /**
  * Parse every request shape used by the local APIs. `text` is required by the
@@ -14,4 +15,29 @@ export function createRequestBodyParser() {
     textLimit: '20mb',
     parsedMethods: ['POST', 'PUT', 'PATCH', 'DELETE'],
   })
+}
+
+/**
+ * Let authenticated Codex Responses requests reach the proxy sanitizer before
+ * applying the regular 20 MiB application-wide JSON limit. The proxy still has
+ * a bounded ceiling so an authenticated client cannot stream an unlimited body.
+ */
+export function createCodexProxyRequestBodyParser(isAuthorized: (ctx: Context) => boolean) {
+  const parse = bodyParser({
+    encoding: 'utf-8',
+    enableTypes: ['json'],
+    jsonLimit: '64mb',
+    parsedMethods: ['POST'],
+  })
+  return async (ctx: Context, next: Next) => {
+    if (ctx.method !== 'POST' || !/^\/api\/codex-proxy\/[^/]+\/v1\/responses$/.test(ctx.path)) {
+      return next()
+    }
+    if (!isAuthorized(ctx)) {
+      ctx.status = 401
+      ctx.body = { error: { type: 'authentication_error', message: 'Invalid Codex proxy token' } }
+      return
+    }
+    return parse(ctx, next)
+  }
 }

--- a/tests/server/agent-runner-adapters.test.ts
+++ b/tests/server/agent-runner-adapters.test.ts
@@ -6,6 +6,7 @@ import {
   responseToolNamespaceForName,
   responsesToAnthropicMessages,
   responsesToOpenAiChat,
+  stripHistoricalResponsesInlineImages,
   truncateResponsesToolOutputs,
 } from '../../packages/server/src/modules/coding-agents/protocol/adapters/responses'
 import {
@@ -73,6 +74,69 @@ describe('agent runner Responses adapters', () => {
     expect(Buffer.byteLength(cjkTruncated, 'utf8')).toBeLessThanOrEqual(32 * 1024)
     expect(cjkTruncated).toContain(`original_bytes=${Buffer.byteLength(cjkOutput, 'utf8')}`)
     expect(cjkTruncated.endsWith('TAIL_MARKER')).toBe(true)
+  })
+
+  it('strips every historical inline image while preserving the full current turn', () => {
+    const oldUserImage = 'data:image/png;base64,OLD_USER'
+    const oldToolImage = 'data:image/jpeg;base64,OLD_TOOL'
+    const currentImageA = 'data:image/png;base64,CURRENT_A'
+    const currentImageB = 'data:image/png;base64,CURRENT_B'
+    const currentToolImage = 'data:image/webp;base64,CURRENT_TOOL'
+    const remoteHistoricalImage = 'https://example.com/old.png'
+    const body = {
+      input: [
+        {
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'old turn' },
+            { type: 'input_image', image_url: oldUserImage },
+            { type: 'input_image', image_url: remoteHistoricalImage },
+          ],
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'old-tool',
+          output: [{ type: 'input_image', image_url: { url: oldToolImage } }],
+        },
+        {
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'current turn' },
+            { type: 'input_image', image_url: currentImageA },
+            { type: 'input_image', image_url: { url: currentImageB } },
+          ],
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'current-tool',
+          output: [{ type: 'input_image', image_url: currentToolImage }],
+        },
+      ],
+    }
+
+    const sanitized = stripHistoricalResponsesInlineImages(body)
+    const serialized = JSON.stringify(sanitized)
+
+    expect(sanitized).not.toBe(body)
+    expect(serialized).not.toContain(oldUserImage)
+    expect(serialized).not.toContain(oldToolImage)
+    expect(serialized).toContain(remoteHistoricalImage)
+    expect(serialized).toContain(currentImageA)
+    expect(serialized).toContain(currentImageB)
+    expect(serialized).toContain(currentToolImage)
+    expect(serialized.match(/historical inline image omitted before provider request/g)).toHaveLength(2)
+    expect(body.input[0].content[1]).toEqual({ type: 'input_image', image_url: oldUserImage })
+    expect(body.input[1].output[0]).toEqual({ type: 'input_image', image_url: { url: oldToolImage } })
+    expect(sanitized.input[2]).toBe(body.input[2])
+    expect(sanitized.input[3]).toBe(body.input[3])
+  })
+
+  it('does not strip inline images when no current user turn boundary exists', () => {
+    const body = {
+      input: [{ type: 'function_call_output', output: [{ type: 'input_image', image_url: 'data:image/png;base64,ONLY' }] }],
+    }
+
+    expect(stripHistoricalResponsesInlineImages(body)).toBe(body)
   })
 
   it('converts Responses input to OpenAI Chat messages and tools', () => {

--- a/tests/server/bootstrap-body-limit.test.ts
+++ b/tests/server/bootstrap-body-limit.test.ts
@@ -1,17 +1,75 @@
+import { Readable } from 'node:stream'
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
+import { createCodexProxyRequestBodyParser } from '../../packages/server/src/modules/studio/middleware/request-body-parser'
 
 describe('bootstrap body parser limits', () => {
-  it('allows MiMo voice-clone JSON payloads advertised by the UI/docs', () => {
+  it('keeps the global parser at 20 MiB and isolates the Codex proxy allowance', () => {
     const source = readFileSync('packages/server/src/modules/studio/middleware/request-body-parser.ts', 'utf8')
+    const bootstrap = readFileSync('packages/server/src/bootstrap/http.ts', 'utf8')
 
     expect(source).toContain("jsonLimit: '20mb'")
     expect(source).toContain("formLimit: '20mb'")
+    expect(source).toContain('/api\\/codex-proxy\\/[^/]+\\/v1\\/responses$')
+    expect(source.indexOf('if (!isAuthorized(ctx))')).toBeLessThan(source.indexOf('return parse(ctx, next)'))
+    expect(source).toContain("jsonLimit: '64mb'")
+    expect(bootstrap.indexOf('createCodexProxyRequestBodyParser(isAuthorizedCodexProxyRequest)')).toBeLessThan(bootstrap.indexOf('createRequestBodyParser()'))
   })
 
   it('parses DELETE request bodies for file operations', () => {
     const source = readFileSync('packages/server/src/modules/studio/middleware/request-body-parser.ts', 'utf8')
 
     expect(source).toMatch(/parsedMethods:\s*\[\s*'POST',\s*'PUT',\s*'PATCH',\s*'DELETE'\s*\]/)
+  })
+
+  it('rejects unauthorized Codex proxy bodies before reading the request stream', async () => {
+    let reads = 0
+    const request = new Readable({
+      read() {
+        reads += 1
+        this.push('{"input":[]}')
+        this.push(null)
+      },
+    }) as any
+    request.headers = { 'content-type': 'application/json' }
+    request.method = 'POST'
+    const ctx: any = {
+      method: 'POST',
+      path: '/api/codex-proxy/unknown/v1/responses',
+      req: request,
+      request: { req: request },
+    }
+    const middleware = createCodexProxyRequestBodyParser(() => false)
+
+    await middleware(ctx, async () => {})
+
+    expect(ctx.status).toBe(401)
+    expect(reads).toBe(0)
+  })
+
+  it('parses an authorized Codex proxy JSON body above the global 20 MiB limit', async () => {
+    const payload = JSON.stringify({ input: 'x'.repeat(20 * 1024 * 1024 + 1) })
+    const request = Readable.from([payload]) as any
+    request.headers = {
+      'content-type': 'application/json',
+      'content-length': String(Buffer.byteLength(payload)),
+    }
+    request.method = 'POST'
+    const ctx: any = {
+      method: 'POST',
+      path: '/api/codex-proxy/authorized/v1/responses',
+      req: request,
+      request: {
+        req: request,
+        get(name: string) {
+          return request.headers[name.toLowerCase()] || ''
+        },
+      },
+    }
+    const middleware = createCodexProxyRequestBodyParser(() => true)
+
+    await middleware(ctx, async () => {})
+
+    expect(ctx.request.body.input).toHaveLength(20 * 1024 * 1024 + 1)
   })
 })

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -4,7 +4,12 @@ import { tmpdir } from 'os'
 import { dirname, join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { claudeProxyMessages, claudeProxyModels, registerClaudeCodeProxyTarget } from '../../packages/server/src/modules/coding-agents/services/claude-code/proxy'
-import { codexProxyModels, codexProxyResponses, registerCodexProxyTarget } from '../../packages/server/src/modules/coding-agents/services/codex/proxy'
+import {
+  codexProxyModels,
+  codexProxyResponses,
+  isAuthorizedCodexProxyRequest,
+  registerCodexProxyTarget,
+} from '../../packages/server/src/modules/coding-agents/services/codex/proxy'
 import {
   codexToolSearchConfig,
   migratePersistedPiRuntimeMcpConfigs,
@@ -1323,6 +1328,94 @@ describe('coding agent launch preparation', () => {
     expect(config).toContain('requires_openai_auth = false')
     expect(config).toMatch(/experimental_bearer_token = "hwui_[^"]+"/)
     expect(result.rootDir).toBe(join(home, 'coding-agent', 'model', 'default', 'anthropic-compatible', 'codex'))
+  })
+
+  it('authenticates the enlarged Codex Responses parser with the registered route token', () => {
+    const target = registerCodexProxyTarget({
+      profile: 'default',
+      provider: 'parser-auth',
+      model: 'test-model',
+      baseUrl: 'https://api.example.com',
+      apiKey: 'sk-upstream',
+      apiMode: 'codex_responses',
+    })
+    const context = (token: string) => ({
+      path: `/api/codex-proxy/${target.routeKey}/v1/responses`,
+      get(name: string) {
+        return name.toLowerCase() === 'authorization' ? `Bearer ${token}` : ''
+      },
+    }) as any
+
+    expect(isAuthorizedCodexProxyRequest(context(target.token))).toBe(true)
+    expect(isAuthorizedCodexProxyRequest(context('wrong-token'))).toBe(false)
+  })
+
+  it.each([
+    ['chat_completions', 'https://chat-history.example.com'],
+    ['anthropic_messages', 'https://anthropic-history.example.com'],
+    ['codex_responses', 'https://responses-history.example.com/v1'],
+  ] as const)('strips historical inline images before %s provider dispatch', async (apiMode, baseUrl) => {
+    const target = registerCodexProxyTarget({
+      profile: 'default',
+      provider: `history-${apiMode}`,
+      model: 'test-model',
+      baseUrl,
+      apiKey: 'sk-upstream',
+      apiMode,
+      agentSessionId: `history-${apiMode}`,
+    })
+    const fetchMock = vi.fn(async () => {
+      if (apiMode === 'chat_completions') {
+        return new Response(JSON.stringify({
+          id: 'chatcmpl_history',
+          choices: [{ finish_reason: 'stop', message: { role: 'assistant', content: 'ok' } }],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      if (apiMode === 'anthropic_messages') {
+        return new Response(JSON.stringify({
+          id: 'msg_history',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'ok' }],
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      return new Response(JSON.stringify({
+        id: 'resp_history',
+        object: 'response',
+        status: 'completed',
+        output: [],
+        usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const historicalImage = 'data:image/png;base64,HISTORICAL'
+    const currentImageA = 'data:image/png;base64,CURRENT_A'
+    const currentImageB = 'data:image/jpeg;base64,CURRENT_B'
+    const body = {
+      input: [
+        { role: 'user', content: [{ type: 'input_image', image_url: historicalImage }] },
+        { role: 'assistant', content: [{ type: 'output_text', text: 'old response' }] },
+        {
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'current request' },
+            { type: 'input_image', image_url: currentImageA },
+            { type: 'input_image', image_url: currentImageB },
+          ],
+        },
+      ],
+    }
+
+    await codexProxyResponses(makeProxyContext(target.routeKey, target.token, body))
+
+    const forwarded = String(fetchMock.mock.calls[0]?.[1]?.body || '')
+    expect(forwarded).not.toContain('HISTORICAL')
+    expect(forwarded).toContain('historical inline image omitted before provider request')
+    expect(forwarded).toContain('CURRENT_A')
+    expect(forwarded).toContain('CURRENT_B')
+    expect(body.input[0].content[0].image_url).toBe(historicalImage)
   })
 
   it('adapts Codex Responses requests to OpenAI Chat Completions', async () => {


### PR DESCRIPTION
## Summary

- remove every inline base64 image before the latest user input in Codex Responses requests
- preserve all images from the active user turn, including subsequent tool-loop items
- sanitize before API-mode dispatch so Responses, Chat Completions, and Anthropic modes behave consistently
- accept authenticated Codex proxy requests up to 64 MiB so oversized replayed history can reach the sanitizer

## Validation

- `PORT=8648 npx vitest run tests/server/agent-runner-adapters.test.ts tests/server/bootstrap-body-limit.test.ts tests/server/coding-agents-launch.test.ts`
- `npx tsc --noEmit -p packages/server/tsconfig.json`
- `npm run harness:check`
- `npm run build`