### PR TITLE
feat(ekko): support global agent configuration

### DIFF
--- a/packages/client/src/api/ekko/config.ts
+++ b/packages/client/src/api/ekko/config.ts
@@ -43,6 +43,13 @@ export interface EkkoSettingsConfig {
     backgroundEnabled: boolean
     subtaskMaxSteps: number
   }
+  compression: {
+    enabled: boolean
+    threshold: number
+    targetRatio: number
+    protectLastN: number
+    protectFirstN: number
+  }
   memory: {
     enabled: boolean
     recentMessageLimit: number

--- a/packages/client/src/views/ekko/SettingsView.vue
+++ b/packages/client/src/views/ekko/SettingsView.vue
@@ -197,6 +197,30 @@ onBeforeUnmount(() => {
             </section>
           </NTabPane>
 
+          <!-- Ekko compression settings stay hidden until Studio delegates its
+          compression policy to the agent-level config. Studio currently owns
+          this configuration through the main Hermes settings.
+          <NTabPane name="compression" :tab="t('settings.tabs.compression')">
+            <section class="settings-section">
+              <SettingRow :label="t('settings.compression.enabled')" :hint="t('settings.compression.enabledHint')">
+                <NSwitch v-model:value="form.compression.enabled" @update:value="saveImmediateChange" />
+              </SettingRow>
+              <SettingRow :label="t('settings.compression.threshold')" :hint="t('settings.compression.thresholdHint')">
+                <NInputNumber v-model:value="form.compression.threshold" :min="0.1" :max="0.95" :step="0.05" size="small" class="input-sm" @update:value="value => value != null && saveDebouncedChange()" />
+              </SettingRow>
+              <SettingRow :label="t('settings.compression.targetRatio')" :hint="t('settings.compression.targetRatioHint')">
+                <NInputNumber v-model:value="form.compression.targetRatio" :min="0.05" :max="0.8" :step="0.05" size="small" class="input-sm" @update:value="value => value != null && saveDebouncedChange()" />
+              </SettingRow>
+              <SettingRow :label="t('settings.compression.protectLastN')" :hint="t('settings.compression.protectLastNHint')">
+                <NInputNumber v-model:value="form.compression.protectLastN" :min="0" :max="200" size="small" class="input-sm" @update:value="value => value != null && saveDebouncedChange()" />
+              </SettingRow>
+              <SettingRow :label="t('settings.compression.protectFirstN')" :hint="t('settings.compression.protectFirstNHint')">
+                <NInputNumber v-model:value="form.compression.protectFirstN" :min="0" :max="50" size="small" class="input-sm" @update:value="value => value != null && saveDebouncedChange()" />
+              </SettingRow>
+            </section>
+          </NTabPane>
+          -->
+
           <NTabPane name="tools" :tab="t('ekkoConfig.settingsTools')">
             <section class="settings-section">
               <SettingRow :label="t('ekkoConfig.toolsEnabled')" :hint="t('ekkoConfig.featureToggleHint')">

--- a/packages/ekko-agent/README.md
+++ b/packages/ekko-agent/README.md
@@ -171,7 +171,11 @@ When Ekko runs inside a host that owns conversation persistence, the host also
 owns context compression. `estimateContext()` exposes the provider-visible
 system, tool, message, and provider-context estimate needed for that external
 threshold decision without starting a model call. A standalone Ekko host can
-instead implement and own its internal compression lifecycle.
+instead implement and own its internal compression lifecycle. The global
+`compression` config provides a host policy surface for future integrations:
+`enabled`, `threshold`, `targetRatio`, `protectLastN`, and `protectFirstN`.
+Hermes Studio currently continues to read compression policy from its main
+configuration and does not apply this Ekko config section.
 
 Model context and memory evidence are separate inputs. A host that adds derived
 summaries, retrieved context, routing instructions, or other application-owned
@@ -205,7 +209,8 @@ and opens and migrates the SQLite database. Development uses the package-local
 the shared database-backed memory and conversation stores and closes that
 process-level resource through `setup.close()`. The global JSON file drives
 runtime limits, model defaults and providers, tools, approvals, profile-scoped
-MCP servers, delegation, memory, skills, logging, and prompt instructions. Configuration upgrades merge
+MCP servers, delegation, context compression, memory, skills, logging, and
+prompt instructions. Configuration upgrades merge
 new defaults one field at a time: existing user values, arrays, and unknown
 forward-compatible fields are never replaced as a whole module. A configured
 profile uses
@@ -263,6 +268,10 @@ import { EkkoAgent } from 'ekko-agent'
 const ekko = new EkkoAgent({
   baseDirectory: '/path/to/base',
   profiles: ['work'],
+  config: {
+    runtime: { maxSteps: 60 },
+    compression: { threshold: 0.6, protectLastN: 16 },
+  },
 })
 ekko.config.setModelProvider('deepseek', {
   type: 'openai-compatible',
@@ -302,6 +311,11 @@ container. Every Profile gets an independent Agent instance with bound
 modules. Shared config, model Provider, authorization, and database modules are
 also reachable through each Profile Agent. `setupEkkoAgent(options)` returns
 the same facade for compatibility with the existing setup style.
+
+Pass `config: EkkoConfigPatch` to either constructor style to apply and persist
+installation-wide values before Profile agents and runtime services are
+created. Every top-level config section supports nested partial values;
+explicit per-run runtime options still take precedence over these defaults.
 
 `setup.config` is an `EkkoConfigStore`. It exposes `read`, `update`, `replace`,
 `reset`, MCP server CRUD, provider-preset CRUD, configured-provider CRUD,

--- a/packages/ekko-agent/docs/API.md
+++ b/packages/ekko-agent/docs/API.md
@@ -14,6 +14,10 @@ import { EkkoAgent } from 'ekko-agent'
 const ekko = new EkkoAgent({
   baseDirectory: '/srv/ekko',
   profiles: ['work', 'personal'],
+  config: {
+    runtime: { maxSteps: 60 },
+    compression: { threshold: 0.6, protectLastN: 16 },
+  },
 })
 
 // default 是有静态类型的快捷属性。
@@ -58,6 +62,7 @@ JavaScript 运行时也会为不与根字段冲突的 Profile 安装直接属性
 | --- | --- | --- |
 | `baseDirectory` | `string?` | 数据根目录；实际数据位于 `<base>/.ekko`。默认使用用户主目录。 |
 | `profiles` | `string[]?` | 额外创建的命名 Profile；`default` 总会创建。省略时仍会从已有 Profile 目录自动发现。 |
+| `config` | `EkkoConfigPatch?` | 在创建 Profile Agent 和 runtime 服务前合并并持久化的安装级配置；支持下表全部配置段的局部字段。 |
 | `hermesRootDirectory` | `string?` | 首次初始化时导入 Hermes 的 default 与命名 Profile skills。 |
 | `env` | `Record<string, string \| undefined>?` | 路径和开发/生产数据库策略使用的环境变量。 |
 | `packageRoot` | `string?` | 开发模式下 `sql-data` 的包根目录。 |
@@ -330,7 +335,7 @@ API mode 固定映射：`chat_completions` → `openai-chat`，`codex_responses`
 
 | 路径 | 类型 | 说明 |
 | --- | --- | --- |
-| `schemaVersion` | `number` | 当前为 6；读取旧配置时补齐新字段。 |
+| `schemaVersion` | `number` | 当前为 7；读取旧配置时补齐新字段。 |
 | `runtime.maxSteps` | `number` | 单次主循环最大步数。 |
 | `runtime.maxModelRetries` | `number` | 单次模型步骤最大重试。 |
 | `runtime.maxConsecutiveToolFailures` | `number` | 连续工具失败终止阈值。 |
@@ -362,6 +367,11 @@ API mode 固定映射：`chat_completions` → `openai-chat`，`codex_responses`
 | `mcp.profiles.<profile>.servers` | `Record<string, EkkoMcpServerConfig>` | 每个 Profile 的 stdio 或 Streamable HTTP MCP 服务。 |
 | `delegation.backgroundEnabled` | `boolean` | 默认允许后台子任务。 |
 | `delegation.subtaskMaxSteps` | `number` | 子任务步数。 |
+| `compression.enabled` | `boolean` | Host 是否自动压缩持久会话上下文。 |
+| `compression.threshold` | `number` | 触发阈值占模型上下文窗口的比例，范围 0.05–0.95，默认 0.5。 |
+| `compression.targetRatio` | `number` | 摘要预算占上下文窗口的比例，范围 0.01–0.8，默认 0.2。 |
+| `compression.protectLastN` | `number` | 压缩后原样保留的最近消息数，范围 0–500，默认 20。 |
+| `compression.protectFirstN` | `number` | 压缩后原样保留的最早消息数，范围 0–100，默认 3。 |
 | `memory.enabled` | `boolean` | memory 总开关。 |
 | `memory.recentMessageLimit` | `number` | recall 携带近期消息数。 |
 | `memory.automaticRecallTokenBudget` | `number` | 自动 memory 提示 token 预算。 |
@@ -377,6 +387,8 @@ API mode 固定映射：`chat_completions` → `openai-chat`，`codex_responses`
 `EkkoModelProviderSettings` 字段：可选 `label`；必填 `type` 和 `defaultModel`；可选 `apiMode`、`requestStyle`、`openAIChatReasoningReplayFormat`、`baseUrl`、`endpointPath`、`models`、`authType`、`source`、`apiKey`、`headers`、`timeoutMs`、`capabilities`。`capabilities` 可覆盖 `streaming`、`tools`、`vision`、`jsonMode`、`systemPrompt`、`maxInputTokens`。
 
 `EkkoMcpServerConfig` 支持两种传输：stdio 使用 `command`，可选 `args` 和字符串 `env`；远程服务使用 `type: "streamable_http"`、`url` 和可选字符串 `headers`。`enabled` 控制是否加载。两种传输均使用官方 MCP Client；新 runtime 自动读取所选 Profile 的配置，显式 run-level `toolContext.mcpServers` 仍可覆盖它。
+
+`compression` 是供 Host 集成的策略配置，不属于 `AgentRuntime` 内部会话存储。独立 Host 可以读取 `ekko.readConfig().compression` 实现压缩生命周期；Hermes Studio 当前仍统一读取主配置中的压缩策略，暂不应用 Ekko 的该配置段。一次 Run 显式提供的消息和 runtime options 仍优先于安装级默认值。
 
 ## 文档 harness
 
@@ -685,7 +697,7 @@ export function normalizeEkkoConfig(value: unknown): EkkoConfig
 ### `src/config.ts`
 
 ```ts
-export const EKKO_CONFIG_SCHEMA_VERSION = 6
+export const EKKO_CONFIG_SCHEMA_VERSION = 7
 
 export const EKKO_CONFIG_DIRECTORY_NAME = 'config'
 
@@ -730,6 +742,14 @@ export const DEFAULT_MEMORY_REVIEW_EVERY_USER_MESSAGES = 8
 export const DEFAULT_SKILL_REVIEW_TOOL_CALL_INTERVAL = 10
 
 export const DEFAULT_EKKO_LOG_MAX_BYTES = 10 * 1024 * 1024
+
+export const DEFAULT_COMPRESSION_THRESHOLD = 0.5
+
+export const DEFAULT_COMPRESSION_TARGET_RATIO = 0.2
+
+export const DEFAULT_COMPRESSION_PROTECT_LAST_N = 20
+
+export const DEFAULT_COMPRESSION_PROTECT_FIRST_N = 3
 
 export interface EkkoRuntimeConfig {
   maxSteps: number
@@ -832,6 +852,14 @@ export interface EkkoDelegationConfig {
   subtaskMaxSteps: number
 }
 
+export interface EkkoCompressionConfig {
+  enabled: boolean
+  threshold: number
+  targetRatio: number
+  protectLastN: number
+  protectFirstN: number
+}
+
 export interface EkkoMemoryConfig {
   enabled: boolean
   recentMessageLimit: number
@@ -866,15 +894,16 @@ export interface EkkoConfig {
   tools: EkkoToolsConfig
   mcp: EkkoMcpConfig
   delegation: EkkoDelegationConfig
+  compression: EkkoCompressionConfig
   memory: EkkoMemoryConfig
   skills: EkkoSkillsConfig
   logging: EkkoLoggingConfig
   prompt: EkkoPromptConfig
 }
 
-export type EkkoConfigPatch = { schemaVersion?: number runtime?: Partial<EkkoRuntimeConfig> model?: Partial<Omit<EkkoModelConfig, 'providerCatalog' | 'disabledProviderPresets' | 'providers' | 'authorizations'>> & { providerCatalog?: Record<string, EkkoModelProviderPreset> disabledProviderPresets?: string[] providers?: Record<string, EkkoModelProviderSettings> authorizations?: Record<string, EkkoModelAuthorizationSettings> } tools?: Partial<Omit<EkkoToolsConfig, 'approvals' | 'codeExec'>> & { approvals?: Partial<EkkoToolApprovalConfig> codeExec?: Partial<EkkoCodeExecConfig> } mcp?: Partial<Omit<EkkoMcpConfig, 'profiles'>> & { profiles?: Record<string, EkkoMcpProfileConfig> } delegation?: Partial<EkkoDelegationConfig> memory?: Partial<EkkoMemoryConfig> skills?: Partial<Omit<EkkoSkillsConfig, 'profiles'>> & { profiles?: Record<string, Partial<EkkoSkillsProfileConfig>> } logging?: Partial<EkkoLoggingConfig> prompt?: Partial<EkkoPromptConfig> }
+export type EkkoConfigPatch = { schemaVersion?: number runtime?: Partial<EkkoRuntimeConfig> model?: Partial<Omit<EkkoModelConfig, 'providerCatalog' | 'disabledProviderPresets' | 'providers' | 'authorizations'>> & { providerCatalog?: Record<string, EkkoModelProviderPreset> disabledProviderPresets?: string[] providers?: Record<string, EkkoModelProviderSettings> authorizations?: Record<string, EkkoModelAuthorizationSettings> } tools?: Partial<Omit<EkkoToolsConfig, 'approvals' | 'codeExec'>> & { approvals?: Partial<EkkoToolApprovalConfig> codeExec?: Partial<EkkoCodeExecConfig> } mcp?: Partial<Omit<EkkoMcpConfig, 'profiles'>> & { profiles?: Record<string, EkkoMcpProfileConfig> } delegation?: Partial<EkkoDelegationConfig> compression?: Partial<EkkoCompressionConfig> memory?: Partial<EkkoMemoryConfig> skills?: Partial<Omit<EkkoSkillsConfig, 'profiles'>> & { profiles?: Record<string, Partial<EkkoSkillsProfileConfig>> } logging?: Partial<EkkoLoggingConfig> prompt?: Partial<EkkoPromptConfig> }
 
-export const DEFAULT_EKKO_CONFIG: EkkoConfig = { schemaVersion: EKKO_CONFIG_SCHEMA_VERSION, runtime: { maxSteps: DEFAULT_AGENT_MAX_STEPS, maxModelRetries: DEFAULT_AGENT_MODEL_MAX_RETRIES, maxConsecutiveToolFailures: DEFAULT_AGENT_MAX_CONSECUTIVE_TOOL_FAILURES, }, model: { defaultProvider: '', defaultModel: '', requestTimeoutMs: DEFAULT_MODEL_REQUEST_TIMEOUT_MS, reasoningEffort: 'medium', reasoningSummary: 'auto', authorizationRefreshLeewayMs: DEFAULT_MODEL_AUTHORIZATION_REFRESH_LEEWAY_MS, providerCatalog: structuredClone(BUILTIN_MODEL_PROVIDER_PRESETS), disabledProviderPresets: [], providers: {}, authorizations: {}, }, tools: { enabled: true, executionTimeoutMs: DEFAULT_TOOL_EXECUTION_TIMEOUT_MS, approvals: { enabled: true, timeoutMs: DEFAULT_TOOL_APPROVAL_TIMEOUT_MS, permanentAllow: [], }, codeExec: { enabled: true, languages: [...DEFAULT_CODE_EXEC_LANGUAGES], timeoutMs: DEFAULT_TOOL_EXECUTION_TIMEOUT_MS, maxToolCalls: DEFAULT_CODE_EXEC_MAX_TOOL_CALLS, maxOutputBytes: DEFAULT_CODE_EXEC_MAX_OUTPUT_BYTES, maxStderrBytes: DEFAULT_CODE_EXEC_MAX_STDERR_BYTES, maxSourceBytes: DEFAULT_CODE_EXEC_MAX_SOURCE_BYTES, }, }, mcp: { enabled: true, profiles: {}, }, delegation: { backgroundEnabled: true, subtaskMaxSteps: DEFAULT_AGENT_SUBTASK_MAX_STEPS, }, memory: { enabled: true, recentMessageLimit: DEFAULT_MEMORY_RECENT_MESSAGE_LIMIT, automaticRecallTokenBudget: DEFAULT_AUTOMATIC_MEMORY_TOKEN_BUDGET, searchResultLimit: DEFAULT_MEMORY_SEARCH_RESULT_LIMIT, reviewEveryUserMessages: DEFAULT_MEMORY_REVIEW_EVERY_USER_MESSAGES, }, skills: { enabled: true, reviewEveryToolCalls: DEFAULT_SKILL_REVIEW_TOOL_CALL_INTERVAL, profiles: {}, }, logging: { maxBytes: DEFAULT_EKKO_LOG_MAX_BYTES, }, prompt: { instructions: [], }, }
+export const DEFAULT_EKKO_CONFIG: EkkoConfig = { schemaVersion: EKKO_CONFIG_SCHEMA_VERSION, runtime: { maxSteps: DEFAULT_AGENT_MAX_STEPS, maxModelRetries: DEFAULT_AGENT_MODEL_MAX_RETRIES, maxConsecutiveToolFailures: DEFAULT_AGENT_MAX_CONSECUTIVE_TOOL_FAILURES, }, model: { defaultProvider: '', defaultModel: '', requestTimeoutMs: DEFAULT_MODEL_REQUEST_TIMEOUT_MS, reasoningEffort: 'medium', reasoningSummary: 'auto', authorizationRefreshLeewayMs: DEFAULT_MODEL_AUTHORIZATION_REFRESH_LEEWAY_MS, providerCatalog: structuredClone(BUILTIN_MODEL_PROVIDER_PRESETS), disabledProviderPresets: [], providers: {}, authorizations: {}, }, tools: { enabled: true, executionTimeoutMs: DEFAULT_TOOL_EXECUTION_TIMEOUT_MS, approvals: { enabled: true, timeoutMs: DEFAULT_TOOL_APPROVAL_TIMEOUT_MS, permanentAllow: [], }, codeExec: { enabled: true, languages: [...DEFAULT_CODE_EXEC_LANGUAGES], timeoutMs: DEFAULT_TOOL_EXECUTION_TIMEOUT_MS, maxToolCalls: DEFAULT_CODE_EXEC_MAX_TOOL_CALLS, maxOutputBytes: DEFAULT_CODE_EXEC_MAX_OUTPUT_BYTES, maxStderrBytes: DEFAULT_CODE_EXEC_MAX_STDERR_BYTES, maxSourceBytes: DEFAULT_CODE_EXEC_MAX_SOURCE_BYTES, }, }, mcp: { enabled: true, profiles: {}, }, delegation: { backgroundEnabled: true, subtaskMaxSteps: DEFAULT_AGENT_SUBTASK_MAX_STEPS, }, compression: { enabled: true, threshold: DEFAULT_COMPRESSION_THRESHOLD, targetRatio: DEFAULT_COMPRESSION_TARGET_RATIO, protectLastN: DEFAULT_COMPRESSION_PROTECT_LAST_N, protectFirstN: DEFAULT_COMPRESSION_PROTECT_FIRST_N, }, memory: { enabled: true, recentMessageLimit: DEFAULT_MEMORY_RECENT_MESSAGE_LIMIT, automaticRecallTokenBudget: DEFAULT_AUTOMATIC_MEMORY_TOKEN_BUDGET, searchResultLimit: DEFAULT_MEMORY_SEARCH_RESULT_LIMIT, reviewEveryUserMessages: DEFAULT_MEMORY_REVIEW_EVERY_USER_MESSAGES, }, skills: { enabled: true, reviewEveryToolCalls: DEFAULT_SKILL_REVIEW_TOOL_CALL_INTERVAL, profiles: {}, }, logging: { maxBytes: DEFAULT_EKKO_LOG_MAX_BYTES, }, prompt: { instructions: [], }, }
 
 export function serializeDefaultEkkoConfig(): string
 ```
@@ -2580,6 +2609,7 @@ export interface AgentRuntimeRunResult {
 export interface SetupEkkoAgentOptions extends EkkoDirectoryInitializationOptions {
   baseDirectory?: string
   profiles?: string[]
+  config?: EkkoConfigPatch
   env?: Record<string, string | undefined>
   packageRoot?: string
   authorizationRefresher?: EkkoModelAuthorizationRefresher

--- a/packages/ekko-agent/src/config-store.ts
+++ b/packages/ekko-agent/src/config-store.ts
@@ -540,6 +540,7 @@ export function normalizeEkkoConfig(value: unknown): EkkoConfig {
   const codeExec = record(tools.codeExec, 'tools.codeExec', true)
   const mcp = record(source.mcp, 'mcp', true)
   const delegation = record(source.delegation, 'delegation', true)
+  const compression = record(source.compression, 'compression', true)
   const memory = record(source.memory, 'memory', true)
   const skills = record(source.skills, 'skills', true)
   const logging = record(source.logging, 'logging', true)
@@ -667,6 +668,42 @@ export function normalizeEkkoConfig(value: unknown): EkkoConfig {
         1,
       ),
     },
+    compression: {
+      ...compression,
+      enabled: booleanValue(
+        compression.enabled,
+        DEFAULT_EKKO_CONFIG.compression.enabled,
+        'compression.enabled',
+      ),
+      threshold: boundedNumber(
+        compression.threshold,
+        DEFAULT_EKKO_CONFIG.compression.threshold,
+        'compression.threshold',
+        0.05,
+        0.95,
+      ),
+      targetRatio: boundedNumber(
+        compression.targetRatio,
+        DEFAULT_EKKO_CONFIG.compression.targetRatio,
+        'compression.targetRatio',
+        0.01,
+        0.8,
+      ),
+      protectLastN: boundedInteger(
+        compression.protectLastN,
+        DEFAULT_EKKO_CONFIG.compression.protectLastN,
+        'compression.protectLastN',
+        0,
+        500,
+      ),
+      protectFirstN: boundedInteger(
+        compression.protectFirstN,
+        DEFAULT_EKKO_CONFIG.compression.protectFirstN,
+        'compression.protectFirstN',
+        0,
+        100,
+      ),
+    },
     memory: {
       ...memory,
       enabled: booleanValue(memory.enabled, DEFAULT_EKKO_CONFIG.memory.enabled, 'memory.enabled'),
@@ -754,6 +791,7 @@ function mergeConfigPatch(current: EkkoConfig, patch: EkkoConfigPatch): JsonReco
       },
     },
     delegation: { ...current.delegation, ...patch.delegation },
+    compression: { ...current.compression, ...patch.compression },
     memory: { ...current.memory, ...patch.memory },
     skills: {
       ...current.skills,
@@ -1087,6 +1125,36 @@ function finiteNumber(value: unknown, path: string, minimum: number): number {
   const parsed = Number(value)
   if (!Number.isFinite(parsed) || parsed < minimum) {
     throw new EkkoConfigError(`must be a number greater than or equal to ${minimum}`, path)
+  }
+  return parsed
+}
+
+function boundedNumber(
+  value: unknown,
+  fallback: number,
+  path: string,
+  minimum: number,
+  maximum: number,
+): number {
+  if (value === undefined) return fallback
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed < minimum || parsed > maximum) {
+    throw new EkkoConfigError(`must be a number between ${minimum} and ${maximum}`, path)
+  }
+  return parsed
+}
+
+function boundedInteger(
+  value: unknown,
+  fallback: number,
+  path: string,
+  minimum: number,
+  maximum: number,
+): number {
+  if (value === undefined) return fallback
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw new EkkoConfigError(`must be an integer between ${minimum} and ${maximum}`, path)
   }
   return parsed
 }

--- a/packages/ekko-agent/src/config.ts
+++ b/packages/ekko-agent/src/config.ts
@@ -13,7 +13,7 @@ import {
   type EkkoModelProviderPreset,
 } from './model/provider-presets'
 
-export const EKKO_CONFIG_SCHEMA_VERSION = 6
+export const EKKO_CONFIG_SCHEMA_VERSION = 7
 export const EKKO_CONFIG_DIRECTORY_NAME = 'config'
 export const EKKO_CONFIG_FILE_NAME = 'config.json'
 
@@ -37,6 +37,10 @@ export const DEFAULT_MEMORY_SEARCH_RESULT_LIMIT = 50
 export const DEFAULT_MEMORY_REVIEW_EVERY_USER_MESSAGES = 8
 export const DEFAULT_SKILL_REVIEW_TOOL_CALL_INTERVAL = 10
 export const DEFAULT_EKKO_LOG_MAX_BYTES = 10 * 1024 * 1024
+export const DEFAULT_COMPRESSION_THRESHOLD = 0.5
+export const DEFAULT_COMPRESSION_TARGET_RATIO = 0.2
+export const DEFAULT_COMPRESSION_PROTECT_LAST_N = 20
+export const DEFAULT_COMPRESSION_PROTECT_FIRST_N = 3
 
 export interface EkkoRuntimeConfig {
   maxSteps: number
@@ -144,6 +148,19 @@ export interface EkkoDelegationConfig {
   subtaskMaxSteps: number
 }
 
+/**
+ * Host-owned conversation compression policy. Ekko exposes the policy through
+ * its global config; a host with durable conversation history applies it
+ * before starting a runtime turn.
+ */
+export interface EkkoCompressionConfig {
+  enabled: boolean
+  threshold: number
+  targetRatio: number
+  protectLastN: number
+  protectFirstN: number
+}
+
 export interface EkkoMemoryConfig {
   enabled: boolean
   recentMessageLimit: number
@@ -180,6 +197,7 @@ export interface EkkoConfig {
   tools: EkkoToolsConfig
   mcp: EkkoMcpConfig
   delegation: EkkoDelegationConfig
+  compression: EkkoCompressionConfig
   memory: EkkoMemoryConfig
   skills: EkkoSkillsConfig
   logging: EkkoLoggingConfig
@@ -203,6 +221,7 @@ export type EkkoConfigPatch = {
     profiles?: Record<string, EkkoMcpProfileConfig>
   }
   delegation?: Partial<EkkoDelegationConfig>
+  compression?: Partial<EkkoCompressionConfig>
   memory?: Partial<EkkoMemoryConfig>
   skills?: Partial<Omit<EkkoSkillsConfig, 'profiles'>> & {
     profiles?: Record<string, Partial<EkkoSkillsProfileConfig>>
@@ -259,6 +278,13 @@ export const DEFAULT_EKKO_CONFIG: EkkoConfig = {
   delegation: {
     backgroundEnabled: true,
     subtaskMaxSteps: DEFAULT_AGENT_SUBTASK_MAX_STEPS,
+  },
+  compression: {
+    enabled: true,
+    threshold: DEFAULT_COMPRESSION_THRESHOLD,
+    targetRatio: DEFAULT_COMPRESSION_TARGET_RATIO,
+    protectLastN: DEFAULT_COMPRESSION_PROTECT_LAST_N,
+    protectFirstN: DEFAULT_COMPRESSION_PROTECT_FIRST_N,
   },
   memory: {
     enabled: true,

--- a/packages/ekko-agent/src/setup.ts
+++ b/packages/ekko-agent/src/setup.ts
@@ -51,6 +51,11 @@ import { EkkoProfileAgent } from './agent/profile-agent'
 export interface SetupEkkoAgentOptions extends EkkoDirectoryInitializationOptions {
   baseDirectory?: string
   profiles?: string[]
+  /**
+   * Installation-wide config patch applied to the canonical config before
+   * Profile agents and runtime services are created.
+   */
+  config?: EkkoConfigPatch
   env?: Record<string, string | undefined>
   packageRoot?: string
   authorizationRefresher?: EkkoModelAuthorizationRefresher
@@ -120,7 +125,9 @@ export class EkkoAgentSetup {
     }
     this.skillImport = this.directories.lastSkillImport
     this.config = new EkkoConfigStore({ configPath: this.layout.configPath })
-    const config = this.config.ensureDefaults()
+    const config = options.config
+      ? this.config.update(options.config)
+      : this.config.ensureDefaults()
     this.authorizations = new EkkoModelAuthorizationManager({
       config: this.config,
       refresher: options.authorizationRefresher,

--- a/packages/server/src/modules/ekko/services/config.ts
+++ b/packages/server/src/modules/ekko/services/config.ts
@@ -32,6 +32,7 @@ export interface EkkoSettingsConfig {
   tools: EkkoConfig['tools']
   mcp: Pick<EkkoConfig['mcp'], 'enabled'>
   delegation: EkkoConfig['delegation']
+  compression: EkkoConfig['compression']
   memory: EkkoConfig['memory']
   skills: Pick<EkkoConfig['skills'], 'enabled' | 'reviewEveryToolCalls'>
   logging: EkkoConfig['logging']
@@ -70,6 +71,13 @@ const CODE_EXEC_KEYS = [
   'maxSourceBytes',
 ] as const
 const DELEGATION_KEYS = ['backgroundEnabled', 'subtaskMaxSteps'] as const
+const COMPRESSION_KEYS = [
+  'enabled',
+  'threshold',
+  'targetRatio',
+  'protectLastN',
+  'protectFirstN',
+] as const
 const MEMORY_KEYS = [
   'enabled',
   'recentMessageLimit',
@@ -111,6 +119,7 @@ function editableConfig(config: EkkoConfig): EkkoSettingsConfig {
     tools: structuredClone(config.tools),
     mcp: { enabled: config.mcp.enabled },
     delegation: structuredClone(config.delegation),
+    compression: structuredClone(config.compression),
     memory: structuredClone(config.memory),
     skills: {
       enabled: config.skills.enabled,
@@ -170,6 +179,7 @@ export function updateEkkoSettings(
 
   assignKnown(next.mcp, record(source.mcp), ['enabled'])
   assignKnown(next.delegation, record(source.delegation), DELEGATION_KEYS)
+  assignKnown(next.compression, record(source.compression), COMPRESSION_KEYS)
   assignKnown(next.memory, record(source.memory), MEMORY_KEYS)
   assignKnown(next.skills, record(source.skills), ['enabled', 'reviewEveryToolCalls'])
   assignKnown(next.logging, record(source.logging), ['maxBytes'])

--- a/packages/server/src/modules/ekko/services/manager.ts
+++ b/packages/server/src/modules/ekko/services/manager.ts
@@ -10,6 +10,8 @@ import {
   type AgentRuntimeBoundaryInterruptResult,
   type AgentRuntimeContextEstimate,
   type AgentRuntimeOptions,
+  type EkkoConfig,
+  type EkkoConfigPatch,
 } from '../../../../../ekko-agent/src'
 import { config } from '../../studio/public/config'
 import { logger } from '../../studio/public/logging'
@@ -21,6 +23,8 @@ export interface GlobalEkkoAgentOptions {
   setup: EkkoAgentSetup
   profile?: string
   memory?: MemoryService | false
+  /** Installation-wide values applied before this global agent is created. */
+  config?: EkkoConfigPatch
 }
 
 export class GlobalEkkoAgent {
@@ -32,7 +36,7 @@ export class GlobalEkkoAgent {
   private readonly skillDirectory: string
   private readonly logDirectory: string
   private readonly workspaceDirectory: string
-  private readonly fileLogger: EkkoFileLogger
+  private fileLogger: EkkoFileLogger
   private runtime?: AgentRuntime
   private activeRuns = 0
   private runtimeRefreshPending = false
@@ -42,11 +46,12 @@ export class GlobalEkkoAgent {
   constructor(options: GlobalEkkoAgentOptions) {
     this.options = options
     this.setup = options.setup
+    if (options.config) this.setup.config.update(options.config)
     const profileLayout = this.setup.profile(options.profile)
     this.skillDirectory = profileLayout.skillDirectory
     this.logDirectory = profileLayout.logDirectory
     this.workspaceDirectory = profileLayout.workspaceDirectory
-    this.fileLogger = new EkkoFileLogger({ directory: this.logDirectory })
+    this.fileLogger = this.createFileLogger()
     this.memory = options.memory === false ? undefined : options.memory ?? this.setup.memory
     this.memoryDatabasePath = this.memory === this.setup.memory
       ? this.setup.layout.databasePath
@@ -115,6 +120,7 @@ export class GlobalEkkoAgent {
       return 'deferred'
     }
     this.runtime = undefined
+    this.fileLogger = this.createFileLogger()
     this.runtimeRefreshPending = false
     return 'refreshed'
   }
@@ -137,6 +143,10 @@ export class GlobalEkkoAgent {
     }
   }
 
+  readConfig(): EkkoConfig {
+    return this.setup.config.read()
+  }
+
   private runtimeInstance(): AgentRuntime {
     this.applyPendingRuntimeRefresh()
     if (this.runtime) return this.runtime
@@ -152,7 +162,15 @@ export class GlobalEkkoAgent {
   private applyPendingRuntimeRefresh(): void {
     if (!this.runtimeRefreshPending || this.activeRuns > 0 || this.hasBackgroundTasks()) return
     this.runtime = undefined
+    this.fileLogger = this.createFileLogger()
     this.runtimeRefreshPending = false
+  }
+
+  private createFileLogger(): EkkoFileLogger {
+    return new EkkoFileLogger({
+      directory: this.logDirectory,
+      maxBytes: this.setup.config.read().logging.maxBytes,
+    })
   }
 
   private withDefaultWorkspace(input: AgentRuntimeRunInput): AgentRuntimeRunInput {
@@ -184,6 +202,7 @@ export function createGlobalEkkoAgent(
 export interface SetupGlobalEkkoAgentOptions {
   baseDirectory?: string
   profiles?: string[]
+  config?: EkkoConfigPatch
   env?: Record<string, string | undefined>
 }
 
@@ -198,6 +217,7 @@ export function setupGlobalEkkoAgent(
     baseDirectory: options.baseDirectory ?? config.appHome,
     hermesRootDirectory: getProfilesBaseDir(),
     profiles: options.profiles ?? listProfileNames(),
+    config: options.config,
     env: options.env,
   })
   if (globalEkkoSetup.skillImport) {

--- a/packages/server/src/modules/studio/services/context-compressor/index.ts
+++ b/packages/server/src/modules/studio/services/context-compressor/index.ts
@@ -623,6 +623,9 @@ async function callEkkoSummarizer(
       toolsEnabled: false,
       skillsEnabled: false,
       systemPrompt: EKKO_SUMMARIZER_SYSTEM_PROMPT,
+      // Keep installation-wide prompt instructions out of the summarizer while
+      // still allowing harmless model-generation defaults to be inherited.
+      runtimeInstructions: [],
       maxSteps: 1,
       maxModelRetries: 0,
       modelDefaults: {

--- a/tests/client/ekko-settings-view.test.ts
+++ b/tests/client/ekko-settings-view.test.ts
@@ -91,6 +91,13 @@ const config = {
   },
   mcp: { enabled: true },
   delegation: { backgroundEnabled: false, subtaskMaxSteps: 40 },
+  compression: {
+    enabled: true,
+    threshold: 0.5,
+    targetRatio: 0.2,
+    protectLastN: 20,
+    protectFirstN: 3,
+  },
   memory: {
     enabled: true,
     recentMessageLimit: 24,

--- a/tests/ekko-agent/config-store.test.ts
+++ b/tests/ekko-agent/config-store.test.ts
@@ -22,6 +22,43 @@ afterEach(async () => {
 })
 
 describe('EkkoConfigStore', () => {
+  it('applies constructor config before creating global Profile agents', async () => {
+    const agent = new EkkoAgent({
+      baseDirectory,
+      env: { NODE_ENV: 'test' },
+      config: {
+        runtime: { maxSteps: 42 },
+        compression: {
+          enabled: true,
+          threshold: 0.7,
+          targetRatio: 0.3,
+          protectLastN: 16,
+          protectFirstN: 4,
+        },
+        prompt: { instructions: ['Keep responses concise.'] },
+      },
+    })
+    try {
+      expect(agent.readConfig()).toMatchObject({
+        runtime: { maxSteps: 42 },
+        compression: {
+          enabled: true,
+          threshold: 0.7,
+          targetRatio: 0.3,
+          protectLastN: 16,
+          protectFirstN: 4,
+        },
+        prompt: { instructions: ['Keep responses concise.'] },
+      })
+      expect(JSON.parse(await readFile(agent.layout.configPath, 'utf8'))).toMatchObject({
+        runtime: { maxSteps: 42 },
+        compression: { threshold: 0.7 },
+      })
+    } finally {
+      agent.close()
+    }
+  })
+
   it('collects model and authorization management on new EkkoAgent()', () => {
     const agent = new EkkoAgent({ baseDirectory, env: { NODE_ENV: 'test' } })
     try {
@@ -98,8 +135,20 @@ describe('EkkoConfigStore', () => {
 
     const config = new EkkoConfigStore({ configPath }).ensureDefaults()
 
-    expect(config.schemaVersion).toBe(6)
+    expect(config.schemaVersion).toBe(7)
     expect(config.memory.reviewEveryUserMessages).toBe(8)
+  })
+
+  it('validates context compression policy bounds', () => {
+    const setup = setupEkkoAgent({ baseDirectory, env: { NODE_ENV: 'test' } })
+    try {
+      expect(() => setup.config.update({ compression: { threshold: 1 } }))
+        .toThrow('compression.threshold: must be a number between 0.05 and 0.95')
+      expect(() => setup.config.update({ compression: { protectLastN: -1 } }))
+        .toThrow('compression.protectLastN: must be an integer between 0 and 500')
+    } finally {
+      setup.close()
+    }
   })
 
   it('patches nested leaves without replacing their sibling settings', () => {

--- a/tests/ekko-agent/profile-agent.test.ts
+++ b/tests/ekko-agent/profile-agent.test.ts
@@ -34,7 +34,7 @@ describe('profile agent facade', () => {
       expect(work.memory).not.toBe(personal.memory)
       expect(work.validation).toMatchObject({
         profile: 'work',
-        configSchemaVersion: 6,
+        configSchemaVersion: 7,
         directories: {
           skill: join(baseDirectory, '.ekko', 'skills', 'work'),
           log: join(baseDirectory, '.ekko', 'logs', 'work'),

--- a/tests/server/context-compressor.test.ts
+++ b/tests/server/context-compressor.test.ts
@@ -112,7 +112,7 @@ describe('ChatContextCompressor', () => {
     global.fetch = originalFetch
   })
 
-  it('uses a fresh one-step tool-free and skill-free Ekko agent for summarization', async () => {
+  it('uses a fresh prompt-isolated, tool-free, skill-free Ekko agent for summarization', async () => {
     const { callSummarizer } = await import('../../packages/server/src/modules/studio/services/context-compressor')
     ekkoRuntimeRunMock.mockResolvedValue({
       output: { role: 'assistant', content: 'ekko summary', finishReason: 'stop' },
@@ -140,6 +140,7 @@ describe('ChatContextCompressor', () => {
       }),
       toolsEnabled: false,
       skillsEnabled: false,
+      runtimeInstructions: [],
       maxSteps: 1,
       maxModelRetries: 0,
       modelDefaults: expect.objectContaining({

--- a/tests/server/ekko-agent-manager.test.ts
+++ b/tests/server/ekko-agent-manager.test.ts
@@ -75,6 +75,10 @@ describe('GlobalEkkoAgent', () => {
     const setup = setupGlobalEkkoAgent({
       baseDirectory,
       profiles: ['default', 'work'],
+      config: {
+        runtime: { maxSteps: 48 },
+        compression: { threshold: 0.65 },
+      },
       env: { NODE_ENV: 'test' },
     })
 
@@ -84,6 +88,30 @@ describe('GlobalEkkoAgent', () => {
     expect(existsSync(join(baseDirectory, '.ekko', 'logs', 'work'))).toBe(true)
     expect(existsSync(join(baseDirectory, '.ekko', 'workspace', 'work'))).toBe(true)
     expect(setup.memory.isEnabled).toBe(true)
+    expect(setup.config.read()).toMatchObject({
+      runtime: { maxSteps: 48 },
+      compression: { threshold: 0.65 },
+    })
+  })
+
+  it('accepts a config patch when creating a Studio global agent', () => {
+    const agent = createGlobalEkkoAgent({
+      setup: createTestSetup(),
+      memory: false,
+      config: {
+        compression: {
+          enabled: false,
+          threshold: 0.75,
+          protectLastN: 8,
+        },
+        prompt: { instructions: ['Studio global instruction.'] },
+      },
+    })
+
+    expect(agent.readConfig()).toMatchObject({
+      compression: { enabled: false, threshold: 0.75, protectLastN: 8 },
+      prompt: { instructions: ['Studio global instruction.'] },
+    })
   })
 
   it('is created once and handles repeated runs through the same runtime', async () => {
@@ -109,10 +137,12 @@ describe('GlobalEkkoAgent', () => {
 
     await agent.run({ messages: ['first'], modelClient: modelClient('first') })
     expect(createRuntime).toHaveBeenCalledTimes(1)
+    setup.config.update({ logging: { maxBytes: 2_048 } })
     expect(agent.refreshRuntime()).toBe('refreshed')
     await agent.run({ messages: ['second'], modelClient: modelClient('second') })
 
     expect(createRuntime).toHaveBeenCalledTimes(2)
+    expect(createRuntime.mock.calls[1]?.[0]?.logWriter).toMatchObject({ maxBytes: 2_048 })
   })
 
   it('exposes the runtime-owned boundary interrupt without creating queue policy', async () => {

--- a/tests/server/ekko-configuration-services.test.ts
+++ b/tests/server/ekko-configuration-services.test.ts
@@ -91,6 +91,11 @@ describe('Ekko configuration services', () => {
       mcp: { enabled: false, profiles: { work: { servers: {} } } },
       skills: { enabled: false, reviewEveryToolCalls: 4, profiles: {} },
       memory: { ...initial.config.memory, enabled: false, recentMessageLimit: 12 },
+      compression: {
+        ...initial.config.compression,
+        threshold: 0.65,
+        protectLastN: 14,
+      },
     }, setup)
 
     expect(updated.config).toMatchObject({
@@ -99,6 +104,7 @@ describe('Ekko configuration services', () => {
       mcp: { enabled: false },
       skills: { enabled: false, reviewEveryToolCalls: 4 },
       memory: { enabled: false, recentMessageLimit: 12 },
+      compression: { threshold: 0.65, protectLastN: 14 },
     })
     expect(setup.memory.isEnabled).toBe(false)
     const stored = setup.config.read()


### PR DESCRIPTION
## Summary

- add a versioned Ekko context-compression config section and allow setup/global agent creation to accept and persist config patches
- expose installation-wide configuration through Studio's Ekko manager, including refreshed logging limits
- keep Studio context compression owned by the main Hermes configuration and leave the Ekko compression settings tab commented out for now
- keep the isolated Ekko summarizer free of global prompt instructions, tools, skills, and memory while preserving its compression-specific prompt
- update API documentation and coverage for config migration, validation, persistence, and Studio integration

## Validation

- npm run harness:check
- npm run build
- npm --prefix packages/ekko-agent run harness:check
- npx vitest run tests/server/context-compressor.test.ts tests/server/run-chat-ekko-context.test.ts tests/client/ekko-settings-view.test.ts tests/server/ekko-configuration-services.test.ts
