### PR TITLE
[codex] isolate Ekko development data

### DIFF
--- a/packages/ekko-agent/.gitignore
+++ b/packages/ekko-agent/.gitignore
@@ -6,5 +6,5 @@ coverage/
 .env
 .env.local
 
-sql-data/*
-!sql-data/.gitkeep
+.ekko/
+sql-data/

--- a/packages/ekko-agent/README.md
+++ b/packages/ekko-agent/README.md
@@ -204,8 +204,9 @@ Call `new EkkoAgent()` (or the compatible `setupEkkoAgent()`) once during host
 startup, before accepting agent work.
 The setup entry owns `EkkoDirectoryManager`, creates
 `<base>/.ekko/config/config.json`, the skills, logs, and workspace directories,
-and opens and migrates the SQLite database. Development uses the package-local
-`sql-data/ekko-agent.db`; production uses `<base>/.ekko/ekko.db`. It returns
+and opens and migrates the SQLite database. Development keeps the complete
+layout under the package-local `.ekko` directory, including `.ekko/ekko.db`;
+production uses `<base>/.ekko/ekko.db`. It returns
 the shared database-backed memory and conversation stores and closes that
 process-level resource through `setup.close()`. The global JSON file drives
 runtime limits, model defaults and providers, tools, approvals, profile-scoped

--- a/packages/ekko-agent/docs/API.md
+++ b/packages/ekko-agent/docs/API.md
@@ -65,7 +65,7 @@ JavaScript 运行时也会为不与根字段冲突的 Profile 安装直接属性
 | `config` | `EkkoConfigPatch?` | 在创建 Profile Agent 和 runtime 服务前合并并持久化的安装级配置；支持下表全部配置段的局部字段。 |
 | `hermesRootDirectory` | `string?` | 首次初始化时导入 Hermes 的 default 与命名 Profile skills。 |
 | `env` | `Record<string, string \| undefined>?` | 路径和开发/生产数据库策略使用的环境变量。 |
-| `packageRoot` | `string?` | 开发模式下 `sql-data` 的包根目录。 |
+| `packageRoot` | `string?` | 开发模式下包内 `.ekko` 数据目录所在的包根目录。 |
 | `authorizationRefresher` | `EkkoModelAuthorizationRefresher?` | Provider-aware OAuth 刷新回调。 |
 | `authorizationFetch` | `FetchLike?` | 标准 OAuth refresh-token 请求使用的 fetch。 |
 | `authorizationNow` | `() => number?` | OAuth 到期判断使用的时钟，主要用于测试。 |

--- a/packages/ekko-agent/sql-data/.gitkeep
+++ b/packages/ekko-agent/sql-data/.gitkeep
@@ -1,1 +1,0 @@
-# Keep the development SQLite data directory in the repository.

--- a/packages/ekko-agent/src/memory/paths.ts
+++ b/packages/ekko-agent/src/memory/paths.ts
@@ -12,16 +12,13 @@ export interface EkkoDataPathOptions {
 export function resolveEkkoDataDirectory(options: EkkoDataPathOptions = {}): string {
   if (isEkkoDevelopmentEnvironment(options.env ?? process.env)) {
     const packageRoot = options.packageRoot || resolve(__dirname, '..', '..')
-    return join(packageRoot, 'sql-data')
+    return join(packageRoot, '.ekko')
   }
   return new EkkoDirectoryManager(options.baseDirectory || options.homeDir || homedir()).rootDirectory
 }
 
 export function resolveEkkoDatabasePath(options: EkkoDataPathOptions = {}): string {
-  const databaseName = isEkkoDevelopmentEnvironment(options.env ?? process.env)
-    ? 'ekko-agent.db'
-    : 'ekko.db'
-  return join(resolveEkkoDataDirectory(options), databaseName)
+  return join(resolveEkkoDataDirectory(options), 'ekko.db')
 }
 
 export function isEkkoDevelopmentEnvironment(env: Record<string, string | undefined> = process.env): boolean {

--- a/packages/ekko-agent/src/setup.ts
+++ b/packages/ekko-agent/src/setup.ts
@@ -1,4 +1,5 @@
 import { EkkoDatabaseManager } from './database'
+import { dirname } from 'node:path'
 import {
   EkkoDirectoryManager,
   type EkkoDirectoryInitializationOptions,
@@ -6,7 +7,7 @@ import {
   type EkkoSkillImportResult,
 } from './directories'
 import { MemoryService } from './memory/service'
-import { resolveEkkoDatabasePath } from './memory/paths'
+import { resolveEkkoDataDirectory } from './memory/paths'
 import { SqliteMemoryStore } from './memory/store'
 import { EkkoToolApprovalService } from './tools/approval'
 import {
@@ -112,17 +113,15 @@ export class EkkoAgentSetup {
   private closed = false
 
   constructor(options: SetupEkkoAgentOptions = {}) {
-    this.directories = new EkkoDirectoryManager(options.baseDirectory)
-    this.layout = {
-      ...this.directories.initialize({
-        hermesRootDirectory: options.hermesRootDirectory,
-      }),
-      databasePath: resolveEkkoDatabasePath({
-        baseDirectory: options.baseDirectory,
-        env: options.env,
-        packageRoot: options.packageRoot,
-      }),
-    }
+    const dataDirectory = resolveEkkoDataDirectory({
+      baseDirectory: options.baseDirectory,
+      env: options.env,
+      packageRoot: options.packageRoot,
+    })
+    this.directories = new EkkoDirectoryManager(dirname(dataDirectory))
+    this.layout = this.directories.initialize({
+      hermesRootDirectory: options.hermesRootDirectory,
+    })
     this.skillImport = this.directories.lastSkillImport
     this.config = new EkkoConfigStore({ configPath: this.layout.configPath })
     const config = options.config

--- a/tests/ekko-agent/database.test.ts
+++ b/tests/ekko-agent/database.test.ts
@@ -30,7 +30,7 @@ describe('EkkoDatabaseManager', () => {
     expect(new EkkoDirectoryManager().baseDirectory).toBe(homedir())
   })
 
-  it('uses the package-local SQL data directory in development', () => {
+  it('uses the package-local Ekko directory in development', () => {
     const packageRoot = join(webUiHome, 'ekko-agent')
     const options = {
       baseDirectory: join(webUiHome, 'production-home'),
@@ -38,8 +38,8 @@ describe('EkkoDatabaseManager', () => {
       packageRoot,
     }
 
-    expect(resolveEkkoDataDirectory(options)).toBe(join(packageRoot, 'sql-data'))
-    expect(resolveEkkoDatabasePath(options)).toBe(join(packageRoot, 'sql-data', 'ekko-agent.db'))
+    expect(resolveEkkoDataDirectory(options)).toBe(join(packageRoot, '.ekko'))
+    expect(resolveEkkoDatabasePath(options)).toBe(join(packageRoot, '.ekko', 'ekko.db'))
   })
 
   it('initializes the Ekko root with its global config, skills, and workspace directories', async () => {
@@ -162,13 +162,15 @@ describe('EkkoDatabaseManager', () => {
     }
     const manager = new EkkoDatabaseManager(options)
     expect(manager.connection.prepare('PRAGMA journal_mode').get()).toMatchObject({ journal_mode: 'delete' })
-    expect(manager.databasePath).toBe(join(packageRoot, 'sql-data', 'ekko-agent.db'))
-    expect(existsSync(join(packageRoot, 'sql-data', 'ekko-agent.db'))).toBe(true)
+    expect(manager.databasePath).toBe(join(packageRoot, '.ekko', 'ekko.db'))
+    expect(existsSync(join(packageRoot, '.ekko', 'ekko.db'))).toBe(true)
     expect(existsSync(join(webUiHome, 'production-home', '.ekko', 'ekko.db'))).toBe(false)
     manager.close()
+    expect(existsSync(join(packageRoot, '.ekko', 'ekko.db-wal'))).toBe(false)
+    expect(existsSync(join(packageRoot, '.ekko', 'ekko.db-shm'))).toBe(false)
   })
 
-  it('reports and opens the package-local database path during development setup', () => {
+  it('keeps every development artifact in the package-local Ekko directory', () => {
     const packageRoot = join(webUiHome, 'ekko-agent')
     const setup = setupEkkoAgent({
       baseDirectory: join(webUiHome, 'production-home'),
@@ -177,10 +179,16 @@ describe('EkkoDatabaseManager', () => {
     })
 
     try {
-      expect(setup.layout.databasePath).toBe(join(packageRoot, 'sql-data', 'ekko-agent.db'))
+      expect(setup.layout.rootDirectory).toBe(join(packageRoot, '.ekko'))
+      expect(setup.layout.configPath).toBe(join(packageRoot, '.ekko', 'config', 'config.json'))
+      expect(setup.layout.skillsDirectory).toBe(join(packageRoot, '.ekko', 'skills'))
+      expect(setup.layout.logsDirectory).toBe(join(packageRoot, '.ekko', 'logs'))
+      expect(setup.layout.workspaceDirectory).toBe(join(packageRoot, '.ekko', 'workspace'))
+      expect(setup.layout.databasePath).toBe(join(packageRoot, '.ekko', 'ekko.db'))
       expect(setup.database.databasePath).toBe(setup.layout.databasePath)
       expect(existsSync(setup.layout.databasePath)).toBe(true)
       expect(existsSync(join(webUiHome, 'production-home', '.ekko', 'ekko.db'))).toBe(false)
+      expect(existsSync(join(webUiHome, 'production-home', '.ekko', 'config', 'config.json'))).toBe(false)
     } finally {
       setup.close()
     }


### PR DESCRIPTION
## Summary
- keep all Ekko development state under `packages/ekko-agent/.ekko`
- store development memory and conversations in a single `ekko.db` using DELETE journaling for direct Navicat access
- remove the legacy `sql-data` layout and document the package-local development boundary
- add coverage that prevents development config, skills, logs, workspace, and database state from falling back to the production Web UI home

## Why
Development previously isolated only the SQLite database. Configuration and other Ekko state still used the production Web UI home, allowing a newer development schema to break the released desktop app.

## Impact
Development and packaged desktop runs now use independent Ekko state directories. Production path behavior remains unchanged.

## Validation
- `npm run test -- tests/ekko-agent/database.test.ts`
- `npm --prefix packages/ekko-agent test`
- `npm --prefix packages/ekko-agent run check`
- `npm --prefix packages/ekko-agent run api:docs:check`
- `npm run harness:check`
- `npm run build`