### PR TITLE
[codex] recover invalid Ekko startup config

### DIFF
--- a/packages/ekko-agent/README.md
+++ b/packages/ekko-agent/README.md
@@ -213,8 +213,12 @@ runtime limits, model defaults and providers, tools, approvals, profile-scoped
 MCP servers, delegation, context compression, memory, skills, logging, and
 prompt instructions. Configuration upgrades merge
 new defaults one field at a time: existing user values, arrays, and unknown
-forward-compatible fields are never replaced as a whole module. A configured
-profile uses
+forward-compatible fields are never replaced as a whole module. Startup
+validation upgrades older schemas in place. A malformed config or one written
+by a newer schema is copied to `config.invalid-<timestamp>-<uuid>.json` before
+the current defaults are restored, so startup continues without a restart;
+filesystem read failures remain fatal and never trigger replacement. A
+configured profile uses
 `<base>/.ekko/skills/<profile>` for its skills and
 `<base>/.ekko/logs/<profile>` for its log. Its default per-session workspace is
 `<base>/.ekko/workspace/<profile>/<session-id>`; an explicitly supplied

--- a/packages/ekko-agent/docs/API.md
+++ b/packages/ekko-agent/docs/API.md
@@ -44,6 +44,8 @@ JavaScript 运行时也会为不与根字段冲突的 Profile 安装直接属性
 
 启动时会扫描 `.ekko/skills`、`.ekko/logs`、`.ekko/workspace` 下的一级实体目录，并取合法 Profile 名的并集。自动发现项、Hermes 首次导入项与显式 `profiles` 会合并，因此已有 Profile 不要求调用方再次传入。隐藏目录、普通文件、软链接和非法目录名会被忽略。
 
+安装级初始化会预检全局配置。旧 schema 会原地升级并保留用户字段；JSON 损坏、结构无效或 schema 高于当前程序支持版本时，原文件会先备份为 `config.invalid-<timestamp>-<uuid>.json`，随后恢复当前默认配置并在同一次启动中继续。文件权限、磁盘和其他读取错误不会触发重建。
+
 创建 Profile Agent 前会执行以下检查：
 
 - 调用 `config.ensureDefaults()`，解析、迁移并验证完整配置。

--- a/packages/ekko-agent/src/config-store.ts
+++ b/packages/ekko-agent/src/config-store.ts
@@ -134,7 +134,7 @@ export class EkkoConfigStore {
   /** Add newly introduced default leaves without replacing user-owned values. */
   ensureDefaults(): EkkoConfig {
     const currentText = readFileSync(this.configPath, 'utf8')
-    const normalized = loadEkkoConfig(this.configPath)
+    const normalized = parseEkkoConfig(currentText)
     const normalizedText = `${JSON.stringify(normalized, null, 2)}\n`
     if (currentText !== normalizedText) return writeEkkoConfig(this.configPath, normalized)
     return normalized
@@ -486,6 +486,10 @@ export function loadEkkoConfig(configPath: string): EkkoConfig {
       `could not read config: ${error instanceof Error ? error.message : String(error)}`,
     )
   }
+  return parseEkkoConfig(raw)
+}
+
+function parseEkkoConfig(raw: string): EkkoConfig {
   try {
     return normalizeEkkoConfig(JSON.parse(raw))
   } catch (error) {

--- a/packages/ekko-agent/src/setup.ts
+++ b/packages/ekko-agent/src/setup.ts
@@ -1,5 +1,7 @@
+import { randomUUID } from 'node:crypto'
+import { chmodSync, copyFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
 import { EkkoDatabaseManager } from './database'
-import { dirname } from 'node:path'
 import {
   EkkoDirectoryManager,
   type EkkoDirectoryInitializationOptions,
@@ -11,6 +13,7 @@ import { resolveEkkoDataDirectory } from './memory/paths'
 import { SqliteMemoryStore } from './memory/store'
 import { EkkoToolApprovalService } from './tools/approval'
 import {
+  EkkoConfigError,
   EkkoConfigStore,
   type ConfiguredModelAuthorizationEntry,
   type ConfiguredModelProviderEntry,
@@ -81,6 +84,32 @@ export interface CreateEkkoRuntimeOptions extends Omit<AgentRuntimeOptions, 'mem
   memory?: AgentRuntimeOptions['memory'] | false
 }
 
+function ensureStartupConfig(config: EkkoConfigStore): EkkoConfig {
+  try {
+    return config.ensureDefaults()
+  } catch (error) {
+    if (!(error instanceof EkkoConfigError)) throw error
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+    const backupPath = join(
+      dirname(config.configPath),
+      `config.invalid-${timestamp}-${randomUUID()}.json`,
+    )
+    copyFileSync(config.configPath, backupPath)
+    try {
+      chmodSync(backupPath, 0o600)
+    } catch {
+      // Some filesystems do not expose POSIX permissions.
+    }
+
+    const recovered = config.reset()
+    console.warn(
+      `[ekko-agent] invalid config was backed up to ${backupPath}; defaults restored: ${error.message}`,
+    )
+    return recovered
+  }
+}
+
 /**
  * Process-level Ekko resources created before any agent run.
  *
@@ -124,9 +153,10 @@ export class EkkoAgentSetup {
     })
     this.skillImport = this.directories.lastSkillImport
     this.config = new EkkoConfigStore({ configPath: this.layout.configPath })
+    const startupConfig = ensureStartupConfig(this.config)
     const config = options.config
       ? this.config.update(options.config)
-      : this.config.ensureDefaults()
+      : startupConfig
     this.authorizations = new EkkoModelAuthorizationManager({
       config: this.config,
       refresher: options.authorizationRefresher,

--- a/tests/ekko-agent/config-store.test.ts
+++ b/tests/ekko-agent/config-store.test.ts
@@ -1,9 +1,10 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   DEFAULT_EKKO_CONFIG,
+  EKKO_CONFIG_SCHEMA_VERSION,
   EkkoAgent,
   EkkoConfigError,
   EkkoConfigStore,
@@ -18,8 +19,15 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
+  vi.restoreAllMocks()
   await rm(baseDirectory, { recursive: true, force: true })
 })
+
+async function configBackups(configPath: string): Promise<string[]> {
+  return (await readdir(dirname(configPath)))
+    .filter(name => name.startsWith('config.invalid-') && name.endsWith('.json'))
+    .sort()
+}
 
 describe('EkkoConfigStore', () => {
   it('applies constructor config before creating global Profile agents', async () => {
@@ -118,6 +126,94 @@ describe('EkkoConfigStore', () => {
     expect(persisted.runtime.maxSteps).toBe(17)
     expect(persisted.runtime.maxModelRetries).toBe(DEFAULT_EKKO_CONFIG.runtime.maxModelRetries)
     expect(persisted.futureModule).toEqual({ userOwned: true })
+  })
+
+  it('upgrades schema version 6 in place without creating a recovery backup', async () => {
+    const initial = setupEkkoAgent({ baseDirectory, env: { NODE_ENV: 'test' } })
+    const configPath = initial.layout.configPath
+    initial.close()
+    await writeFile(configPath, JSON.stringify({
+      ...DEFAULT_EKKO_CONFIG,
+      schemaVersion: 6,
+      runtime: { ...DEFAULT_EKKO_CONFIG.runtime, maxSteps: 61 },
+      futureModule: { userOwned: true },
+    }, null, 2))
+
+    const upgraded = setupEkkoAgent({ baseDirectory, env: { NODE_ENV: 'test' } })
+    try {
+      expect(upgraded.config.read()).toMatchObject({
+        schemaVersion: EKKO_CONFIG_SCHEMA_VERSION,
+        runtime: { maxSteps: 61 },
+        futureModule: { userOwned: true },
+      })
+      expect(await configBackups(configPath)).toEqual([])
+    } finally {
+      upgraded.close()
+    }
+  })
+
+  it('backs up a future schema and restores defaults during the same startup', async () => {
+    const initial = setupEkkoAgent({ baseDirectory, env: { NODE_ENV: 'test' } })
+    const configPath = initial.layout.configPath
+    initial.close()
+    const futureConfig = {
+      ...structuredClone(DEFAULT_EKKO_CONFIG),
+      schemaVersion: EKKO_CONFIG_SCHEMA_VERSION + 1,
+      runtime: { ...DEFAULT_EKKO_CONFIG.runtime, maxSteps: 99 },
+      futureModule: { userOwned: true },
+    }
+    await writeFile(configPath, JSON.stringify(futureConfig, null, 2))
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const recovered = setupEkkoAgent({
+      baseDirectory,
+      env: { NODE_ENV: 'test' },
+      config: { runtime: { maxSteps: 42 } },
+    })
+    try {
+      expect(recovered.config.read()).toMatchObject({
+        schemaVersion: EKKO_CONFIG_SCHEMA_VERSION,
+        runtime: { maxSteps: 42 },
+      })
+      expect(recovered.config.read()).not.toHaveProperty('futureModule')
+      const backups = await configBackups(configPath)
+      expect(backups).toHaveLength(1)
+      await expect(readFile(join(dirname(configPath), backups[0]), 'utf8'))
+        .resolves.toBe(JSON.stringify(futureConfig, null, 2))
+      expect(warning).toHaveBeenCalledWith(expect.stringContaining('defaults restored'))
+    } finally {
+      recovered.close()
+    }
+  })
+
+  it('backs up malformed JSON and continues startup with current defaults', async () => {
+    const initial = setupEkkoAgent({ baseDirectory, env: { NODE_ENV: 'test' } })
+    const configPath = initial.layout.configPath
+    initial.close()
+    const malformed = '{"schemaVersion": 7, "runtime":'
+    await writeFile(configPath, malformed)
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const recovered = setupEkkoAgent({ baseDirectory, env: { NODE_ENV: 'test' } })
+    try {
+      expect(recovered.config.read()).toEqual(DEFAULT_EKKO_CONFIG)
+      const backups = await configBackups(configPath)
+      expect(backups).toHaveLength(1)
+      await expect(readFile(join(dirname(configPath), backups[0]), 'utf8')).resolves.toBe(malformed)
+    } finally {
+      recovered.close()
+    }
+  })
+
+  it('does not replace the config when the filesystem read fails', async () => {
+    const initial = setupEkkoAgent({ baseDirectory, env: { NODE_ENV: 'test' } })
+    const configPath = initial.layout.configPath
+    initial.close()
+    await rm(configPath)
+    await mkdir(configPath)
+
+    expect(() => setupEkkoAgent({ baseDirectory, env: { NODE_ENV: 'test' } })).toThrow()
+    expect(await configBackups(configPath)).toEqual([])
   })
 
   it('migrates the former per-turn memory review default to the batched default', async () => {


### PR DESCRIPTION
## Summary
- preflight the global Ekko config during the existing eager startup flow
- migrate older schemas in place without creating recovery backups
- back up malformed, structurally invalid, or future-schema configs before restoring current defaults
- continue the same startup without requiring an application restart
- leave filesystem and disk read failures fatal so they cannot trigger destructive recovery

## Why
A config written by a newer development build could prevent the packaged Web UI server from starting. Startup should recover from config incompatibility without hiding unrelated I/O failures or discarding the original config.

## Impact
Users with an incompatible or damaged Ekko config can still start Hermes Studio. The original config remains available as `config.invalid-<timestamp>-<uuid>.json`. Normal schema upgrades preserve user settings.

## Validation
- `npm run test -- tests/ekko-agent/config-store.test.ts`
- `npm --prefix packages/ekko-agent run check`
- `npm --prefix packages/ekko-agent test`
- `npm --prefix packages/ekko-agent run api:docs:check`
- `npm run harness:check`
- `npm run build`
- development server hot restart