### PR TITLE
[codex] default desktop runtime to Hermes 0.20.6

### DIFF
--- a/packages/desktop/build/runtime-release.json
+++ b/packages/desktop/build/runtime-release.json
@@ -1,9 +1,9 @@
 {
-  "tag": "hermes-0.20.0-runtime",
-  "hermesAgentVersion": "0.20.0",
+  "tag": "hermes-0.20.6-runtime",
+  "hermesAgentVersion": "0.20.6",
   "hermesSource": {
     "repository": "https://github.com/NousResearch/hermes-agent.git",
-    "ref": "v2026.8.3",
-    "commit": "3c27eb6234bf91b8ceee9e9071591b31e9b148cb"
+    "ref": "v2026.8.27",
+    "commit": "5fc308a70719a83cccdbba4c0e39c23f5a8239d5"
   }
 }

--- a/packages/desktop/scripts/runtime-config.mjs
+++ b/packages/desktop/scripts/runtime-config.mjs
@@ -1,7 +1,7 @@
-export const DEFAULT_HERMES_VERSION = '0.20.0'
+export const DEFAULT_HERMES_VERSION = '0.20.6'
 export const DEFAULT_HERMES_SOURCE_REPOSITORY = 'https://github.com/NousResearch/hermes-agent.git'
-export const DEFAULT_HERMES_SOURCE_REF = 'v2026.8.3'
-export const DEFAULT_HERMES_SOURCE_COMMIT = '3c27eb6234bf91b8ceee9e9071591b31e9b148cb'
+export const DEFAULT_HERMES_SOURCE_REF = 'v2026.8.27'
+export const DEFAULT_HERMES_SOURCE_COMMIT = '5fc308a70719a83cccdbba4c0e39c23f5a8239d5'
 
 export function hermesVersion(env = process.env) {
   return env.HERMES_VERSION || DEFAULT_HERMES_VERSION

--- a/packages/desktop/src/main/paths.ts
+++ b/packages/desktop/src/main/paths.ts
@@ -10,7 +10,7 @@ import {
 import { hermesAgentVersionFromRuntimeTag } from './runtime-version'
 
 const isWin = platform() === 'win32'
-const DEFAULT_HERMES_AGENT_VERSION = '0.20.0'
+const DEFAULT_HERMES_AGENT_VERSION = '0.20.6'
 const PACKAGED_RUNTIME_RELEASE_NAME = 'runtime-release.json'
 const ACTIVE_RUNTIME_VERSION_NAME = 'active-version.json'
 let incompleteActiveWebUiWarningPath = ''

--- a/tests/desktop/runtime-config.test.ts
+++ b/tests/desktop/runtime-config.test.ts
@@ -9,6 +9,9 @@ import {
 
 describe('desktop Hermes source configuration', () => {
   it('pins an immutable upstream release by default', () => {
+    expect(DEFAULT_HERMES_VERSION).toBe('0.20.6')
+    expect(DEFAULT_HERMES_SOURCE_REF).toBe('v2026.8.27')
+    expect(DEFAULT_HERMES_SOURCE_COMMIT).toBe('5fc308a70719a83cccdbba4c0e39c23f5a8239d5')
     expect(hermesSource({})).toEqual({
       version: DEFAULT_HERMES_VERSION,
       repository: DEFAULT_HERMES_SOURCE_REPOSITORY,

--- a/tests/desktop/runtime-paths.test.ts
+++ b/tests/desktop/runtime-paths.test.ts
@@ -185,7 +185,7 @@ describe('desktop runtime paths', () => {
 
     expect(desktopRuntimeDir()).toBe(runtimeDir)
     expect(webuiDir()).toBe(webUiDir)
-    expect(targetDesktopRuntimeDir()).toBe(join(storageRoot, 'hermes', '0.20.0', runtimePlatformKey()))
+    expect(targetDesktopRuntimeDir()).toBe(join(storageRoot, 'hermes', '0.20.6', runtimePlatformKey()))
   })
 
   it('falls back to the bundled Web UI when the active Web UI directory is incomplete', async () => {
@@ -333,7 +333,7 @@ describe('desktop runtime paths', () => {
 
     const { runtimePlatformKey } = await import('../../packages/desktop/src/main/runtime-paths')
     const runtimeDir = join(homeDir, 'desktop-runtime', 'hermes', '0.15.2', runtimePlatformKey())
-    const targetRuntimeDir = join(homeDir, 'desktop-runtime', 'hermes', '0.20.0', runtimePlatformKey())
+    const targetRuntimeDir = join(homeDir, 'desktop-runtime', 'hermes', '0.20.6', runtimePlatformKey())
     createRuntimeWithoutManifest(runtimeDir)
 
     const { desktopRuntimeDir, targetDesktopRuntimeDir } = await import('../../packages/desktop/src/main/paths')


### PR DESCRIPTION
## Summary
- point the desktop runtime release metadata at `hermes-0.20.6-runtime`
- pin the verified Hermes `v2026.8.27` source commit
- align the desktop runtime directory fallback with Hermes 0.20.6

## Why
The v0.7.0 desktop packages would otherwise continue embedding the 0.20.0 runtime metadata even though the 0.20.6 runtime assets are ready.

## Validation
- `npm run test -- tests/desktop/runtime-config.test.ts tests/desktop/runtime-manager.test.ts`
- `npm run harness:check`
- `npm run build`