### PR TITLE
[codex] support DeepSeek thinking tool calls in Ekko

### DIFF
--- a/packages/ekko-agent/src/model/providers/openai-compatible.ts
+++ b/packages/ekko-agent/src/model/providers/openai-compatible.ts
@@ -355,17 +355,19 @@ function isUnsupportedImageError(error: unknown): boolean {
 export function toOpenAIChatPayload(config: ModelProviderConfig, request: ModelRequest): OpenAIChatPayload {
   const isQwenOAuth = config.id === 'qwen-oauth'
   const supportsVision = config.capabilities?.vision !== false
+  const model = request.model ?? config.defaultModel
   const reasoningReplayField = openAIReasoningReplayField(
     config,
-    request.model ?? config.defaultModel,
+    model,
   )
   const requiresAssistantContent = requiresNonNullAssistantContent(
     config,
-    request.model ?? config.defaultModel,
+    model,
   )
+  const supportsToolChoice = supportsOpenAIChatToolChoice(model)
   const tools = request.tools?.length ? request.tools.map(toOpenAIToolDefinition) : undefined
   return {
-    model: request.model ?? config.defaultModel,
+    model,
     messages: request.messages.flatMap(message =>
       toOpenAIChatMessages(message, isQwenOAuth, reasoningReplayField, requiresAssistantContent, supportsVision)),
     temperature: request.temperature,
@@ -373,13 +375,23 @@ export function toOpenAIChatPayload(config: ModelProviderConfig, request: ModelR
     ...(tools
       ? {
           tools,
-          ...(request.toolChoice ? { tool_choice: request.toolChoice } : {}),
+          ...(request.toolChoice && supportsToolChoice ? { tool_choice: request.toolChoice } : {}),
         }
       : {}),
     stream: request.stream,
     stream_options: request.stream ? { include_usage: true } : undefined,
     vl_high_resolution_images: isQwenOAuth && supportsVision ? true : undefined,
   }
+}
+
+function supportsOpenAIChatToolChoice(model: string): boolean {
+  // DeepSeek Chat thinking mode rejects the tool_choice parameter. V4 models
+  // enable thinking by default; the legacy deepseek-reasoner alias does too.
+  const modelId = model.trim().toLowerCase()
+  return !(
+    modelId.includes('deepseek-v4') ||
+    modelId.endsWith('deepseek-reasoner')
+  )
 }
 
 export function normalizeOpenAIChatResponse(provider: string, response: OpenAIChatResponse): ModelResponse {
@@ -436,8 +448,8 @@ function toOpenAIChatMessages(
     ? {}
     : reasoningReplayField === 'reasoning' && reasoningText
       ? { reasoning: reasoningText }
-      : reasoningReplayField === 'reasoning_content' && reasoningText
-        ? { reasoning_content: reasoningText }
+      : reasoningReplayField === 'reasoning_content'
+        ? { reasoning_content: reasoningText || '' }
         : reasoningReplayField === 'reasoning_details' && reasoningDetails
           ? { reasoning_details: reasoningDetails }
           : reasoningReplayField === 'reasoning_details' && reasoningText

--- a/tests/ekko-agent/model-request.test.ts
+++ b/tests/ekko-agent/model-request.test.ts
@@ -570,6 +570,36 @@ describe('ekko-agent model requests', () => {
     })
   })
 
+  it('omits tool choice for DeepSeek thinking models across providers', () => {
+    const request = {
+      messages: [{ role: 'user' as const, content: 'Remember this.' }],
+      tools: [{ name: 'memory_write', parameters: { type: 'object' } }],
+      toolChoice: 'required' as const,
+    }
+    const thinkingPayload = toOpenAIChatPayload({
+      id: 'custom:deepseek-relay',
+      type: 'openai-compatible',
+      requestStyle: 'openai-chat',
+      baseUrl: 'https://relay.example/v1',
+      defaultModel: 'deepseek/deepseek-v4-flash',
+    }, request)
+    const legacyNonThinkingPayload = toOpenAIChatPayload({
+      id: 'custom:deepseek-relay',
+      type: 'openai-compatible',
+      requestStyle: 'openai-chat',
+      baseUrl: 'https://relay.example/v1',
+      defaultModel: 'deepseek-chat',
+    }, request)
+
+    expect(thinkingPayload).toMatchObject({
+      tools: [expect.objectContaining({
+        function: expect.objectContaining({ name: 'memory_write' }),
+      })],
+    })
+    expect(thinkingPayload).not.toHaveProperty('tool_choice')
+    expect(legacyNonThinkingPayload.tool_choice).toBe('required')
+  })
+
   it('strips tool choice inside AgentRuntime when its tool registry is empty', async () => {
     const create = vi.fn(async () => ({ content: 'done' }))
     const runtime = new AgentRuntime({
@@ -764,6 +794,37 @@ describe('ekko-agent model requests', () => {
       tool_calls: [expect.objectContaining({ id: 'call_weather' })],
     })
     expect(payload.messages[1]).not.toHaveProperty('reasoning')
+  })
+
+  it('includes empty reasoning_content for synthetic DeepSeek tool-call messages', () => {
+    const payload = toOpenAIChatPayload(providerConfig, {
+      messages: [
+        { role: 'user', content: 'Use the matched skill.' },
+        {
+          role: 'assistant',
+          content: '',
+          toolCalls: [{
+            id: 'skill-auto-1',
+            name: 'skill_view',
+            arguments: { name: 'matched-skill' },
+          }],
+        },
+        {
+          role: 'tool',
+          content: 'Matched skill instructions.',
+          toolCallId: 'skill-auto-1',
+          name: 'skill_view',
+        },
+      ],
+      tools: [{ name: 'memory_search' }],
+    })
+
+    expect(payload.messages[1]).toMatchObject({
+      role: 'assistant',
+      content: '',
+      reasoning_content: '',
+      tool_calls: [expect.objectContaining({ id: 'skill-auto-1' })],
+    })
   })
 
   it.each([


### PR DESCRIPTION
## Summary
- replay an explicit empty `reasoning_content` for synthetic assistant tool-call messages when the Chat Completions dialect requires that field
- omit `tool_choice` for DeepSeek thinking model IDs, including models served through third-party relays, while preserving it for `deepseek-chat` and unrelated models
- add focused regression coverage for automatic Skill replay and model-based DeepSeek tool-choice compatibility

This fixes the DeepSeek thinking-mode errors `The reasoning_content in the thinking mode must be passed back to the API` and `Thinking mode does not support this tool_choice` during Ekko tool-enabled runs.

## Validation
- `npx vitest run tests/ekko-agent --reporter=dot` (22 files, 272 tests)
- `npm run harness:check`
- `npm run build`
- live `deepseek-v4-flash` streaming smoke request with synthetic `skill_view` history and an internal `toolChoice: required`
