### PR TITLE
修复代码代理上下文计量回落为单次调用用量

### DIFF
--- a/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
+++ b/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
@@ -5,7 +5,7 @@ import { spawn, type ChildProcess } from 'child_process'
 import { createSession, addMessage, getSession, updateSession, updateSessionStats } from '../../../studio/public/sessions'
 import type { ApiMode, CodingAgentImageInput } from '../../protocol/types'
 import { logger } from '../../../studio/public/logging'
-import { normalizeTokenUsage, recordSessionUsage } from '../../../studio/public/usage'
+import { estimateSessionContextTokens, normalizeTokenUsage, recordSessionUsage } from '../../../studio/public/usage'
 import {
   applyResponseStreamEvent,
   calcAndUpdateUsage,
@@ -1174,12 +1174,20 @@ export class CodingAgentRunManager {
     }
     const usage = await calcAndUpdateUsage(run.launch.sessionId, run.state, emitUsage, {
       nativeSource: 'coding_agent',
+      emit: false,
     })
-    const contextTokens = usage.contextInputTokens != null || usage.contextOutputTokens != null
-      ? (usage.contextInputTokens || 0) + (usage.contextOutputTokens || 0)
-      : undefined
+    const contextTokens = await estimateSessionContextTokens(run.launch.sessionId)
     if (contextTokens != null && contextTokens > 0) {
       updateContextTokenUsage(run.launch.sessionId, run.state, emitUsage, contextTokens, usage)
+    } else {
+      // Keep the last known context value when the local estimate is
+      // unavailable; a model-call usage row is not a context-window size.
+      emitUsage('usage.updated', {
+        event: 'usage.updated',
+        session_id: run.launch.sessionId,
+        inputTokens: usage.inputTokens,
+        outputTokens: usage.outputTokens,
+      })
     }
   }
 

--- a/packages/server/src/modules/studio/public/usage.ts
+++ b/packages/server/src/modules/studio/public/usage.ts
@@ -1,1 +1,2 @@
+export { estimateSessionContextTokens } from '../services/chat-run/usage'
 export * from '../services/usage/usage-recorder'

--- a/packages/server/src/modules/studio/services/chat-run/usage.ts
+++ b/packages/server/src/modules/studio/services/chat-run/usage.ts
@@ -7,7 +7,7 @@ import {
   getSessionDetail,
 } from '../../repositories/session-store'
 import { deleteCompressionSnapshot, getCompressionSnapshot } from '../../repositories/compression-snapshot'
-import { getRecordedUsageTotals, getUsage } from '../../repositories/usage-store'
+import { getRecordedUsageTotals } from '../../repositories/usage-store'
 import { countTokens, SUMMARY_PREFIX } from '../context-compressor'
 import { truncateToolResultForContext } from './tool-result-context'
 import { logger } from '../../public/logging'
@@ -84,6 +84,7 @@ export async function calcAndUpdateUsage(
   options: {
     truncateToolResultsForContext?: boolean
     nativeSource?: 'coding_agent'
+    emit?: boolean
   } = {},
 ): Promise<{
   inputTokens: number
@@ -94,27 +95,20 @@ export async function calcAndUpdateUsage(
   try {
     if (options.nativeSource) {
       const totals = getRecordedUsageTotals(sid, options.nativeSource)
-      const latest = getUsage(sid)
       const usage = {
         inputTokens: totals.inputTokens,
         outputTokens: totals.outputTokens,
       }
       state.inputTokens = usage.inputTokens
       state.outputTokens = usage.outputTokens
-      emit('usage.updated', {
-        event: 'usage.updated',
-        session_id: sid,
-        ...usage,
-      })
-      return {
-        ...usage,
-        ...(latest
-          ? {
-              contextInputTokens: Number(latest.input_tokens || 0),
-              contextOutputTokens: Number(latest.output_tokens || 0),
-            }
-          : {}),
+      if (options.emit !== false) {
+        emit('usage.updated', {
+          event: 'usage.updated',
+          session_id: sid,
+          ...usage,
+        })
       }
+      return usage
     }
 
     const snapshot = getCompressionSnapshot(sid)
@@ -204,6 +198,52 @@ export async function calcAndUpdateUsage(
   } catch (err: any) {
     logger.warn(err, '[chat-run-socket] failed to calculate usage for session %s', sid)
     return { inputTokens: 0, outputTokens: 0 }
+  }
+}
+
+/**
+ * Estimate the complete Studio-visible context without using the most recent
+ * model-call usage row. Coding-agent model-call usage is a single request
+ * snapshot, while this meter represents the persisted conversation context.
+ */
+export async function estimateSessionContextTokens(sid: string): Promise<number | undefined> {
+  try {
+    const snapshot = getCompressionSnapshot(sid)
+    if (snapshot?.compressedThroughMessageId != null) {
+      const cursorRead = readCursorSnapshotParts(sid, snapshot, {
+        truncateToolResults: false,
+      })
+      if (cursorRead.status === 'usable') {
+        const usage = estimateUsageTokensFromMessages(
+          assembleCursorSnapshotHistory(snapshot, cursorRead.parts, SUMMARY_PREFIX),
+        )
+        const contextTokens = usage.inputTokens + usage.outputTokens
+        return contextTokens > 0 ? contextTokens : undefined
+      }
+    }
+
+    const detail = getSessionDetail(sid)
+    const storedMessages = detail?.messages
+      ?.filter(m => m.role === 'user' || m.role === 'assistant' || m.role === 'tool') || []
+    if (
+      snapshot
+      && storedMessages.length
+      && snapshot.lastMessageIndex >= 0
+      && snapshot.lastMessageIndex < storedMessages.length
+    ) {
+      const newUsage = estimateUsageTokensFromMessages(storedMessages.slice(snapshot.lastMessageIndex + 1))
+      const contextTokens = countTokens(SUMMARY_PREFIX + snapshot.summary)
+        + newUsage.inputTokens
+        + newUsage.outputTokens
+      return contextTokens > 0 ? contextTokens : undefined
+    }
+
+    const usage = estimateUsageTokensFromMessages(storedMessages)
+    const contextTokens = usage.inputTokens + usage.outputTokens
+    return contextTokens > 0 ? contextTokens : undefined
+  } catch (err: any) {
+    logger.warn(err, '[chat-run-socket] failed to estimate context for session %s', sid)
+    return undefined
   }
 }
 

--- a/tests/server/agent-runner-utils.test.ts
+++ b/tests/server/agent-runner-utils.test.ts
@@ -1149,6 +1149,12 @@ describe('coding agent run state', () => {
       workspaceDir: process.cwd(),
       state,
     })
+    addMessage({
+      session_id: chatSessionId,
+      role: 'user',
+      content: 'This earlier turn is intentionally much longer than the final model-call usage.',
+      timestamp: Math.floor(Date.now() / 1000),
+    })
     const run = (manager as any).runs.get(agentSessionId)
     run.printResponseId = 'resp_codex_1'
     run.printMessageId = 'msg_resp_codex_1'
@@ -1184,9 +1190,13 @@ describe('coding agent run state', () => {
 
     expect(emitted.map(event => event.event)).toContain('message.delta')
     expect(emitted.map(event => event.event)).toContain('usage.updated')
-    expect(emitted.find(event => event.event === 'usage.updated' && event.payload.contextTokens != null)?.payload).toEqual(expect.objectContaining({
+    const usageUpdates = emitted.filter(event => event.event === 'usage.updated')
+    expect(usageUpdates).toHaveLength(1)
+    const contextUpdate = emitted.find(event => event.event === 'usage.updated' && event.payload.contextTokens != null)?.payload
+    expect(contextUpdate).toEqual(expect.objectContaining({
       contextTokens: expect.any(Number),
     }))
+    expect(contextUpdate.contextTokens).toBeGreaterThan(19)
     expect(emitted.find(event => event.event === 'run.completed')?.payload).not.toHaveProperty('usage')
     const eventNames = emitted.map(event => event.event)
     expect(eventNames.lastIndexOf('usage.updated')).toBeLessThan(eventNames.indexOf('run.completed'))

--- a/tests/server/run-chat-usage-cursor.test.ts
+++ b/tests/server/run-chat-usage-cursor.test.ts
@@ -81,7 +81,6 @@ describe('cursor-aware chat usage', () => {
 
   it('uses native Coding Agent usage without consulting messages or compression snapshots', async () => {
     getRecordedUsageTotalsMock.mockReturnValue({ inputTokens: 100, outputTokens: 40 })
-    getUsageMock.mockReturnValue({ input_tokens: 70, output_tokens: 10 })
     const { calcAndUpdateUsage } = await import('../../packages/server/src/modules/studio/services/chat-run/usage')
     const state: any = { messages: [], events: [], queue: [], isWorking: false }
 
@@ -92,9 +91,8 @@ describe('cursor-aware chat usage', () => {
     expect(usage).toEqual({
       inputTokens: 100,
       outputTokens: 40,
-      contextInputTokens: 70,
-      contextOutputTokens: 10,
     })
+    expect(getUsageMock).not.toHaveBeenCalled()
     expect(getCompressionSnapshotMock).not.toHaveBeenCalled()
     expect(getSessionDetailMock).not.toHaveBeenCalled()
     expect(getSessionContextMessagesMock).not.toHaveBeenCalled()


### PR DESCRIPTION
﻿## 问题
Hermes Studio 的代码代理会话上下文计量在一次终端用量刷新后突然回落。例如会话显示曾从约 120.2K 回落到 5.8K。

根因是 `calcAndUpdateUsage(..., { nativeSource: 'coding_agent' })` 使用 `getUsage()` 返回的最近一条 `model_call` 记录作为 `contextInputTokens/contextOutputTokens`。该记录代表单次模型调用，而不是完整会话上下文；终端刷新随后用它覆盖了上下文计量器。

## 修复
- native coding-agent 用量只读取 `getRecordedUsageTotals()` 的累计输入/输出用量。
- 删除把最近单次调用用量解释为完整上下文的逻辑。
- 终端刷新改为从 Studio 持久化会话和压缩快照估算完整上下文；估算不可用时保留已有上下文值。
- 刷新期间先静默更新累计用量，再发送包含上下文值的单个 `usage.updated` 事件，避免客户端看到中间状态跳变。
- 增加回归断言，确保较长历史上下文不会被 19 token 的单次调用值覆盖。

## 验证
- `npm test -- --run tests/server/run-chat-usage.test.ts tests/server/run-chat-usage-cursor.test.ts --reporter=dot`
- `npm test -- --run tests/server/agent-runner-utils.test.ts -t "maps Codex exec JSONL assistant deltas into chat messages" --reporter=dot`
- `npx tsc --noEmit -p tsconfig.json`
- `npx tsc --noEmit -p packages/server/tsconfig.json`

上述针对性测试和类型检查通过。完整 `agent-runner-utils.test.ts` 仍有一个与本改动无关的既有 Claude stdout 关闭时序用例失败；该失败发生在本 PR 未修改的测试/终端关闭路径。

完整 build 已生成 client/server bundle，随后 server 构建脚本在当前 Node 22（项目要求 Node >=23）环境中以 Windows 进程异常退出，未发现 TypeScript 编译错误。
