### PR TITLE
fix(studio): isolate upgrade startup crashes

### DIFF
--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -7,8 +7,16 @@ import './styles/global.scss'
 import { desktopBridge } from '@/utils/desktop-bridge'
 
 // Apply theme classes before mount to prevent FOUC (Flash of Unstyled Content)
-const savedBrightness = localStorage.getItem('hermes_brightness') || 'system'
-const savedStyle = localStorage.getItem('hermes_style') || 'ink'
+function storedPreference(key: string, fallback: string): string {
+  try {
+    return localStorage.getItem(key) || fallback
+  } catch {
+    return fallback
+  }
+}
+
+const savedBrightness = storedPreference('hermes_brightness', 'system')
+const savedStyle = storedPreference('hermes_style', 'ink')
 
 // Resolve dark mode
 const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
@@ -48,6 +56,10 @@ if (urlToken) {
 async function mountApp(): Promise<void> {
   const i18n = await i18nReady
   const app = createApp(App)
+  app.config.errorHandler = (error, _instance, info) => {
+    console.error(`[client] uncaught Vue error (${info})`, error)
+    renderFatalError(error)
+  }
   app.use(createPinia())
   app.use(i18n)
   app.use(router)
@@ -55,4 +67,29 @@ async function mountApp(): Promise<void> {
   app.mount('#app')
 }
 
-void mountApp()
+function renderFatalError(error: unknown): void {
+  const root = document.getElementById('app')
+  if (!root || root.dataset.fatalError === 'true') return
+  root.dataset.fatalError = 'true'
+  root.replaceChildren()
+
+  const container = document.createElement('main')
+  container.style.cssText = 'min-height:100vh;box-sizing:border-box;padding:32px;background:#1a1a1a;color:#eee;font-family:system-ui'
+  const title = document.createElement('h2')
+  title.textContent = 'Hermes Studio encountered an unexpected interface error'
+  const details = document.createElement('pre')
+  details.style.cssText = 'white-space:pre-wrap;color:#f88'
+  details.textContent = error instanceof Error ? error.message : String(error)
+  const retry = document.createElement('button')
+  retry.type = 'button'
+  retry.textContent = 'Reload'
+  retry.style.cssText = 'padding:8px 14px;cursor:pointer'
+  retry.addEventListener('click', () => window.location.reload())
+  container.append(title, details, retry)
+  root.append(container)
+}
+
+void mountApp().catch(error => {
+  console.error('[client] failed to mount application', error)
+  renderFatalError(error)
+})

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -58,7 +58,6 @@ async function mountApp(): Promise<void> {
   const app = createApp(App)
   app.config.errorHandler = (error, _instance, info) => {
     console.error(`[client] uncaught Vue error (${info})`, error)
-    renderFatalError(error)
   }
   app.use(createPinia())
   app.use(i18n)

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -17,7 +17,13 @@ import {
 } from 'electron'
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
-import { startWebUiServer, stopWebUiServer, getToken, setWebUiRuntimeRestartHandler } from './webui-server'
+import {
+  getToken,
+  setWebUiRuntimeRestartHandler,
+  setWebUiUnexpectedExitHandler,
+  startWebUiServer,
+  stopWebUiServer,
+} from './webui-server'
 import { bundledNode, desktopIcon, desktopMacTrayIcon, desktopRuntimeVersion, desktopWindowsTrayIcon, hermesBinExists, hermesBin, runtimeStorageRoot, webuiDir, webUiHome } from './paths'
 import { checkForDesktopUpdates, initAutoUpdater } from './updater'
 import { t } from './desktop-i18n'
@@ -52,6 +58,7 @@ const WINDOW_STATE_CHANGE_CHANNEL = 'hermes-desktop:window-state-change'
 const BROWSER_STATE_CHANGE_CHANNEL = 'hermes-desktop:browser-state-change'
 const BROWSER_ANNOTATION_REQUEST_CHANNEL = 'hermes-desktop:browser-annotation-request'
 const DESKTOP_DISABLED_CHROMIUM_FEATURES = ['CompressionDictionaryTransport', 'CompressionDictionaryTransportBackend']
+const FAILURE_RECOVERY_WINDOW_MS = 60_000
 type WindowControlAction = 'minimize' | 'toggle-maximize' | 'close'
 type DesktopWindowBounds = { x: number; y: number; width: number; height: number }
 
@@ -69,6 +76,10 @@ let windowFadeTimer: NodeJS.Timeout | null = null
 let browserManager: BrowserManager | null = null
 let browserBroker: BrowserBroker | null = null
 const activeNotifications = new Set<Notification>()
+let unexpectedWebUiExitCount = 0
+let unexpectedWebUiExitWindowStartedAt = 0
+let rendererRecoveryCount = 0
+let rendererRecoveryWindowStartedAt = 0
 
 // Custom Session paths do not need Chromium's optional compression-dictionary
 // disk cache; disabling it leaves the normal HTTP cache enabled and isolated.
@@ -494,6 +505,25 @@ async function createWindow(): Promise<void> {
 
   mainWindow.once('ready-to-show', () => {
     if (!START_HIDDEN) showWindowWithFade(true)
+  })
+
+  mainWindow.webContents.on('render-process-gone', (_event, details) => {
+    if (isQuitting || !mainWindow || mainWindow.isDestroyed()) return
+    console.error(`[desktop] main renderer exited reason=${details.reason} code=${details.exitCode}`)
+    const now = Date.now()
+    if (now - rendererRecoveryWindowStartedAt > FAILURE_RECOVERY_WINDOW_MS) {
+      rendererRecoveryWindowStartedAt = now
+      rendererRecoveryCount = 0
+    }
+    rendererRecoveryCount += 1
+    if (rendererRecoveryCount > 1) {
+      void loadServiceFailurePage(new Error(`Desktop renderer repeatedly exited (${details.reason})`))
+      return
+    }
+    setTimeout(() => {
+      if (!mainWindow || mainWindow.isDestroyed() || isQuitting) return
+      mainWindow.reload()
+    }, 250).unref?.()
   })
 
   mainWindow.on('close', (event) => {
@@ -941,19 +971,56 @@ async function bootstrap(source?: RuntimeDownloadSource) {
     await loadPetWindowRoute()
   } catch (err) {
     console.error('Failed to start Web UI server:', err)
-    if (mainWindow) {
-      const msg = escapeHtml(String(err instanceof Error ? err.message : err))
-      const pageBackground = process.platform === 'win32' ? 'transparent' : '#1a1a1a'
-      mainWindow.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(
-        `<html><body style="margin:0;font-family:system-ui;background:${pageBackground};color:#eee">
-         <main style="min-height:100vh;padding:32px;background:#1a1a1a">
-         <h2>${escapeHtml(t('desktop.failedStartServices'))}</h2><pre style="white-space:pre-wrap;color:#f88">${msg}</pre></main>
-         </body></html>`,
-      ))
-    }
+    serverUrl = null
+    await loadServiceFailurePage(err)
   } finally {
     isBootstrapping = false
   }
+}
+
+async function loadServiceFailurePage(error: unknown): Promise<void> {
+  if (!mainWindow || mainWindow.isDestroyed()) return
+  const msg = escapeHtml(String(error instanceof Error ? error.message : error))
+  const pageBackground = process.platform === 'win32' ? 'transparent' : '#1a1a1a'
+  const html = `<html><body style="margin:0;font-family:system-ui;background:${pageBackground};color:#eee">
+    <main style="min-height:100vh;padding:32px;background:#1a1a1a;box-sizing:border-box">
+      <h2>${escapeHtml(t('desktop.failedStartServices'))}</h2>
+      <pre style="white-space:pre-wrap;color:#f88">${msg}</pre>
+      <button id="retry" style="padding:8px 14px;cursor:pointer">Retry</button>
+      <script>
+        document.getElementById('retry').addEventListener('click', async function () {
+          this.disabled = true
+          try { await window.hermesDesktop.retryBootstrap() } finally { this.disabled = false }
+        })
+      </script>
+    </main>
+  </body></html>`
+  await mainWindow.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(html)).catch(loadError => {
+    console.error('[desktop] failed to display Web UI failure page:', loadError)
+  })
+}
+
+async function recoverUnexpectedWebUiExit(details: { code: number | null; signal: NodeJS.Signals | null }): Promise<void> {
+  if (isQuitting) return
+  serverUrl = null
+  updateTrayMenu()
+
+  const now = Date.now()
+  if (now - unexpectedWebUiExitWindowStartedAt > FAILURE_RECOVERY_WINDOW_MS) {
+    unexpectedWebUiExitWindowStartedAt = now
+    unexpectedWebUiExitCount = 0
+  }
+  unexpectedWebUiExitCount += 1
+  const error = new Error(`Web UI server exited unexpectedly code=${details.code} signal=${details.signal}`)
+  if (unexpectedWebUiExitCount > 1 || isBootstrapping) {
+    await loadServiceFailurePage(error)
+    return
+  }
+
+  console.warn('[desktop] restarting Web UI once after an unexpected exit')
+  await new Promise(resolveDelay => setTimeout(resolveDelay, 500))
+  await bootstrap()
+  if (!serverUrl) await loadServiceFailurePage(error)
 }
 
 ipcMain.handle('hermes-desktop:get-token', () => getToken())
@@ -1194,6 +1261,9 @@ function runDesktopApp() {
     app.relaunch()
     quitApp()
   })
+  setWebUiUnexpectedExitHandler(details => {
+    void recoverUnexpectedWebUiExit(details)
+  })
   const gotLock = app.requestSingleInstanceLock(QUIT_EXISTING ? { quit: true } : undefined)
   if (!gotLock) {
     app.quit()
@@ -1234,6 +1304,10 @@ function runDesktopApp() {
         showMainWindow()
       }
     })
+  }).catch(error => {
+    console.error('[desktop] failed during Electron startup:', error)
+    dialog.showErrorBox('Hermes Studio', String(error instanceof Error ? error.message : error))
+    app.quit()
   })
 
   app.on('window-all-closed', () => {

--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -39,9 +39,16 @@ let serverProc: ChildProcess | null = null
 let cachedToken: string | null = null
 let currentServerPort = DEFAULT_PORT
 let runtimeRestartHandler: (() => void) | null = null
+let unexpectedExitHandler: ((details: { code: number | null; signal: NodeJS.Signals | null }) => void) | null = null
 
 export function setWebUiRuntimeRestartHandler(handler: (() => void) | null): void {
   runtimeRestartHandler = handler
+}
+
+export function setWebUiUnexpectedExitHandler(
+  handler: ((details: { code: number | null; signal: NodeJS.Signals | null }) => void) | null,
+): void {
+  unexpectedExitHandler = handler
 }
 
 function posixDescendantPids(rootPid: number): number[] {
@@ -480,6 +487,7 @@ async function launchWebUiServer(webUiDirectory: string, entry: string, env: Nod
 
   const launchedProc = serverProc
   const bridgeStartup = createAgentBridgeStartupTracker()
+  let startupReady = false
 
   launchedProc.stdout?.on('data', (chunk: Buffer) => {
     bridgeStartup.observe(chunk)
@@ -502,9 +510,12 @@ async function launchWebUiServer(webUiDirectory: string, entry: string, env: Nod
   launchedProc.on('exit', (code, signal) => {
     console.error(`[webui] server exited code=${code} signal=${signal}`)
     if (serverProc === launchedProc) serverProc = null
-    if (code === 75) runtimeRestartHandler?.()
-    if (!app.isReady() || code !== 0) {
-      // Best-effort: if server dies abnormally during startup, surface to user
+    if (code === 75) {
+      runtimeRestartHandler?.()
+      return
+    }
+    if (startupReady && code !== 0 && app.isReady()) {
+      unexpectedExitHandler?.({ code, signal })
     }
   })
 
@@ -517,6 +528,7 @@ async function launchWebUiServer(webUiDirectory: string, entry: string, env: Nod
   })
   try {
     await Promise.race([waitForReady(port, timeoutMs), exitBeforeReady])
+    startupReady = true
   } catch (err) {
     await terminateLaunchedProcess(launchedProc)
     if (serverProc === launchedProc) serverProc = null
@@ -553,7 +565,7 @@ async function terminateLaunchedProcess(proc: ChildProcess): Promise<void> {
 
 async function waitForReady(port: number, timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs
-  const url = `http://127.0.0.1:${port}/`
+  const url = `http://127.0.0.1:${port}/health/ready`
   while (Date.now() < deadline) {
     try {
       const res = await fetch(url, { signal: AbortSignal.timeout(1000) })

--- a/packages/ekko-agent/src/directories.ts
+++ b/packages/ekko-agent/src/directories.ts
@@ -12,7 +12,7 @@ import {
 } from 'node:fs'
 import { createHash, randomUUID } from 'node:crypto'
 import { homedir } from 'node:os'
-import { basename, join, resolve, sep } from 'node:path'
+import { basename, join, resolve } from 'node:path'
 import {
   EKKO_CONFIG_DIRECTORY_NAME,
   EKKO_CONFIG_FILE_NAME,
@@ -45,9 +45,8 @@ export interface EkkoDirectoryLayout {
 
 export interface EkkoDirectoryInitializationOptions {
   /**
-   * Hermes Agent's root data directory. It is read only during the one-time
-   * removal of legacy Hermes Skill copies from Ekko-owned profile directories.
-   * Hermes Skills are never imported.
+   * Hermes Agent's root data directory. Its presence triggers the one-time
+   * reset of legacy Ekko skill directories. Hermes Skills are never imported.
    */
   hermesRootDirectory?: string
 }
@@ -83,9 +82,10 @@ export class EkkoDirectoryManager {
   initialize(options: EkkoDirectoryInitializationOptions = {}): EkkoDirectoryLayout {
     this.builtinSkills = EkkoBuiltinSkillSynchronizer.createDefault()
     this.initializeConfigDirectory()
-    mkdirSync(this.skillsDirectory, { recursive: true })
     if (options.hermesRootDirectory) {
-      this.removeLegacyHermesSkillCopies(options.hermesRootDirectory)
+      this.resetLegacySkillsDirectory(options.hermesRootDirectory)
+    } else {
+      mkdirSync(this.skillsDirectory, { recursive: true })
     }
     mkdirSync(this.workspaceDirectory, { recursive: true })
     return this.layout()
@@ -178,42 +178,42 @@ export class EkkoDirectoryManager {
     }
   }
 
-  private removeLegacyHermesSkillCopies(hermesRootDirectory: string): void {
+  private resetLegacySkillsDirectory(hermesRootDirectory: string): void {
     const cleanupPath = join(this.rootDirectory, LEGACY_HERMES_SKILL_CLEANUP_FILENAME)
-    if (existsSync(cleanupPath)) return
-
-    const sources = hermesProfileSkillSources(hermesRootDirectory)
-    const removed: Array<{ profile: string; skill: string }> = []
-
-    for (const source of sources) {
-      const profileDirectory = join(this.skillsDirectory, source.profile)
-      if (!isDirectory(profileDirectory)) continue
-      const manifest = readBuiltinSkillManifest(profileDirectory)
-      const managedBuiltinNames = new Set(
-        Object.entries(manifest)
-          .filter(([, entry]) => entry.owner === BUILTIN_SKILL_MANIFEST_OWNER)
-          .map(([name]) => name),
-      )
-
-      for (const skill of findSkillDirectories(source.directory)) {
-        const targetDirectory = join(profileDirectory, ...skill.segments)
-        const isProfileRootSkill = skill.segments.length === 1
-        if (isProfileRootSkill &&
-          (managedBuiltinNames.has(skill.name) ||
-            this.builtinSkills?.matches(skill.name, targetDirectory))) continue
-        if (!isPlainDirectory(targetDirectory) || !isFile(join(targetDirectory, 'SKILL.md'))) continue
-        rmSync(targetDirectory, { recursive: true, force: false })
-        removeEmptySkillParents(profileDirectory, targetDirectory)
-        removed.push({ profile: source.profile, skill: skill.segments.join('/') })
-      }
-      removeSkilllessLegacyCategories(profileDirectory, source.directory)
+    if (existsSync(cleanupPath)) {
+      mkdirSync(this.skillsDirectory, { recursive: true })
+      return
     }
 
-    writeFileSync(cleanupPath, `${JSON.stringify({
+    if (!this.builtinSkills) {
+      throw new Error('Bundled Ekko Skills are unavailable; refusing to reset the existing Skill directory')
+    }
+    const profiles = new Set(['default', ...this.profileNames()])
+    rmSync(this.skillsDirectory, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 200,
+    })
+    mkdirSync(this.skillsDirectory, { recursive: true })
+    for (const profile of profiles) this.profileSkillsDirectory(profile)
+    const marker = `${JSON.stringify({
       version: 2,
       hermesRootDirectory: resolve(hermesRootDirectory),
-      removed,
-    }, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 })
+      resetSkillsDirectory: true,
+    }, null, 2)}\n`
+    const temporaryCleanupPath = `${cleanupPath}.${randomUUID()}.tmp`
+    try {
+      writeFileSync(temporaryCleanupPath, marker, { encoding: 'utf8', mode: 0o600 })
+      renameSync(temporaryCleanupPath, cleanupPath)
+    } catch (error) {
+      try {
+        rmSync(temporaryCleanupPath, { force: true })
+      } catch {
+        // Preserve the marker write failure that caused the cleanup attempt.
+      }
+      throw error
+    }
   }
 }
 
@@ -239,146 +239,6 @@ function safeDirectoryName(value: string, kind: 'profile' | 'session'): string {
   return value
 }
 
-function hermesProfileSkillSources(
-  hermesRootDirectory: string,
-): Array<{ profile: string; directory: string }> {
-  const root = resolve(hermesRootDirectory)
-  const sources: Array<{ profile: string; directory: string }> = []
-  const defaultSkills = join(root, 'skills')
-  if (isDirectory(defaultSkills)) {
-    sources.push({ profile: 'default', directory: defaultSkills })
-  }
-
-  const profilesDirectory = join(root, 'profiles')
-  let entries
-  try {
-    entries = readdirSync(profilesDirectory, { withFileTypes: true })
-  } catch {
-    return sources
-  }
-
-  entries.sort((left, right) => left.name.localeCompare(right.name))
-  for (const entry of entries) {
-    if (!entry.isDirectory() || entry.name.startsWith('.') || entry.name === 'default') continue
-    let profile
-    try {
-      profile = profileDirectoryName(entry.name)
-    } catch {
-      continue
-    }
-    const skillsDirectory = join(profilesDirectory, entry.name, 'skills')
-    if (isDirectory(skillsDirectory)) {
-      sources.push({ profile, directory: skillsDirectory })
-    }
-  }
-  return sources
-}
-
-function findSkillDirectories(
-  rootDirectory: string,
-  segments: string[] = [],
-): Array<{ name: string; segments: string[] }> {
-  const skills: Array<{ name: string; segments: string[] }> = []
-  let entries
-  try {
-    entries = readdirSync(join(rootDirectory, ...segments), { withFileTypes: true })
-  } catch {
-    return skills
-  }
-
-  entries.sort((left, right) => left.name.localeCompare(right.name))
-  for (const entry of entries) {
-    if (!entry.isDirectory() || entry.name.startsWith('.')) continue
-    const nextSegments = [...segments, entry.name]
-    const directory = join(rootDirectory, ...nextSegments)
-    if (isFile(join(directory, 'SKILL.md'))) {
-      skills.push({ name: entry.name, segments: nextSegments })
-    } else {
-      skills.push(...findSkillDirectories(rootDirectory, nextSegments))
-    }
-  }
-  return skills
-}
-
-function removeEmptySkillParents(profileDirectory: string, removedDirectory: string): void {
-  let directory = resolve(removedDirectory, '..')
-  const boundary = resolve(profileDirectory)
-  while (directory !== boundary && directory.startsWith(`${boundary}${sep}`)) {
-    try {
-      if (readdirSync(directory).length > 0) return
-      rmSync(directory)
-    } catch {
-      return
-    }
-    directory = resolve(directory, '..')
-  }
-}
-
-function removeSkilllessLegacyCategories(profileDirectory: string, sourceDirectory: string): void {
-  let entries
-  try {
-    entries = readdirSync(sourceDirectory, { withFileTypes: true })
-  } catch {
-    return
-  }
-  for (const entry of entries) {
-    if (!entry.isDirectory() || entry.name.startsWith('.')) continue
-    const targetDirectory = join(profileDirectory, entry.name)
-    const legacySourceDirectory = join(sourceDirectory, entry.name)
-    if (!isPlainDirectory(targetDirectory) ||
-      containsSkill(targetDirectory) ||
-      !containsOnlyMatchingLegacyFiles(targetDirectory, legacySourceDirectory)) continue
-    rmSync(targetDirectory, { recursive: true, force: false })
-  }
-}
-
-function containsOnlyMatchingLegacyFiles(
-  targetDirectory: string,
-  sourceDirectory: string,
-): boolean {
-  let entries
-  try {
-    entries = readdirSync(targetDirectory, { withFileTypes: true })
-  } catch {
-    return false
-  }
-  for (const entry of entries) {
-    if (entry.name.startsWith('.')) return false
-    const targetPath = join(targetDirectory, entry.name)
-    const sourcePath = join(sourceDirectory, entry.name)
-    if (entry.isDirectory()) {
-      if (!isPlainDirectory(sourcePath) ||
-        !containsOnlyMatchingLegacyFiles(targetPath, sourcePath)) return false
-    } else if (entry.isFile()) {
-      if (!isFile(sourcePath)) return false
-      try {
-        if (!readFileSync(targetPath).equals(readFileSync(sourcePath))) return false
-      } catch {
-        return false
-      }
-    } else {
-      return false
-    }
-  }
-  return true
-}
-
-function containsSkill(directory: string): boolean {
-  let entries
-  try {
-    entries = readdirSync(directory, { withFileTypes: true })
-  } catch {
-    return false
-  }
-  for (const entry of entries) {
-    if (entry.name.startsWith('.')) continue
-    const path = join(directory, entry.name)
-    if (entry.isFile() && entry.name === 'SKILL.md') return true
-    if (entry.isDirectory() && containsSkill(path)) return true
-  }
-  return false
-}
-
 function isDirectory(path: string): boolean {
   try {
     return statSync(path).isDirectory()
@@ -402,15 +262,6 @@ class EkkoBuiltinSkillSynchronizer {
           resolve(process.cwd(), 'packages/ekko-agent/skills'),
         ].find(isDirectory)
     return sourceDirectory ? new EkkoBuiltinSkillSynchronizer(sourceDirectory) : undefined
-  }
-
-  matches(name: string, targetDirectory: string): boolean {
-    const sourceSkillDirectory = join(this.sourceDirectory, name)
-    return isPlainDirectory(targetDirectory) &&
-      isFile(join(targetDirectory, 'SKILL.md')) &&
-      isDirectory(sourceSkillDirectory) &&
-      isFile(join(sourceSkillDirectory, 'SKILL.md')) &&
-      hashBuiltinSkillDirectory(targetDirectory) === hashBuiltinSkillDirectory(sourceSkillDirectory)
   }
 
   sync(targetDirectory: string): void {

--- a/packages/server/src/bootstrap/http.ts
+++ b/packages/server/src/bootstrap/http.ts
@@ -483,6 +483,11 @@ export async function bootstrap() {
   server = listenResult.primary
   servers.splice(0, servers.length, ...listenResult.servers)
   console.log('[bootstrap] app.listen called')
+  // The Desktop shell only needs registered HTTP routes and static assets before
+  // it can render. Keep slower runtime, socket, and recovery work below in the
+  // background startup path, matching the pre-readiness launch behavior.
+  bootstrapReady = true
+  console.log('[bootstrap] web UI shell ready')
 
   const terminalWebSocket = setupTerminalWebSocket(servers)
   if (terminalWebSocket) {
@@ -633,8 +638,7 @@ export async function bootstrap() {
     additionalShutdownSteps,
   )
   startVersionCheck()
-  bootstrapReady = true
-  console.log('[bootstrap] startup ready')
+  console.log('[bootstrap] startup complete')
 }
 
 bootstrap().catch((error) => {

--- a/packages/server/src/bootstrap/http.ts
+++ b/packages/server/src/bootstrap/http.ts
@@ -50,7 +50,12 @@ import { logger } from '../modules/studio/public/logging'
 import { createStaticCompressionMiddleware } from '../modules/studio/middleware/static-compression'
 import { getStaticCacheControl, SPA_ENTRY_CACHE_CONTROL } from '../modules/studio/middleware/static-cache'
 import { requireUserJwt, resolveUserProfile } from '../modules/studio/middleware/auth'
-import { createCorsOriginResolver, securityHeaders } from '../modules/studio/middleware/security'
+import {
+  createCorsOriginResolver,
+  parseUpgradeRequestUrl,
+  securityHeaders,
+  writeBadUpgradeRequest,
+} from '../modules/studio/middleware/security'
 import type { AdditionalShutdownStep, ShutdownHandler } from './lifecycle'
 import { createCodexProxyRequestBodyParser, createRequestBodyParser } from '../modules/studio/middleware/request-body-parser'
 import {
@@ -80,6 +85,7 @@ let groupAgentRelayServer: GroupAgentRelayServer | null = null
 let agentBridgeManager: any = null
 let desktopShutdownHandler: ShutdownHandler | null = null
 let shutdownRequested = false
+let bootstrapReady = false
 const additionalShutdownSteps: AdditionalShutdownStep[] = []
 
 function getShutdownHandler(): ShutdownHandler {
@@ -210,6 +216,25 @@ function registerDesktopShutdownRoute(app: Koa): void {
   })
 }
 
+function registerReadinessRoute(app: Koa): void {
+  app.use(async (ctx, next) => {
+    if ((ctx.method !== 'GET' && ctx.method !== 'HEAD') || ctx.path !== '/health/ready') {
+      await next()
+      return
+    }
+    ctx.status = bootstrapReady ? 200 : 503
+    ctx.body = { status: bootstrapReady ? 'ready' : 'starting' }
+  })
+}
+
+async function ensureStartupDirectory(directory: string, label: string): Promise<void> {
+  try {
+    await mkdir(directory, { recursive: true })
+  } catch (error) {
+    logger.warn(error, '[bootstrap] failed to prepare %s directory; affected operations will report their own errors', label)
+  }
+}
+
 function envFlagEnabled(name: string): boolean {
   const value = String(process.env[name] || '').trim().toLowerCase()
   return ['1', 'true', 'yes', 'on'].includes(value)
@@ -296,13 +321,19 @@ function startLanDiscovery(): void {
 }
 
 export async function bootstrap() {
+  bootstrapReady = false
   console.log(`hermes-web-ui v${APP_VERSION} starting...`)
-  await mkdir(config.uploadDir, { recursive: true })
+  await ensureStartupDirectory(config.uploadDir, 'upload')
   if (shouldCreateWebUiDataDir()) {
-    await mkdir(config.dataDir, { recursive: true })
+    await ensureStartupDirectory(config.dataDir, 'development data')
   }
 
-  const hermesSelection = await configurePreferredHermesRuntime()
+  let hermesSelection = { source: 'none', version: '', path: '' }
+  try {
+    hermesSelection = await configurePreferredHermesRuntime()
+  } catch (error) {
+    logger.warn(error, '[bootstrap] failed to inspect Hermes Runtime; continuing without a selected runtime')
+  }
   console.log(`[bootstrap] Hermes source=${hermesSelection.source} version=${hermesSelection.version || '-'} path=${hermesSelection.path || '-'}`)
   updateAgentStatus('ekko-agent', { version: APP_VERSION })
   const inventoryResults = await Promise.allSettled([
@@ -376,21 +407,26 @@ export async function bootstrap() {
     logger.warn(err, '[bootstrap] failed to restore persisted Pi proxy targets')
   }
 
-  const ekkoSetup = setupGlobalEkkoAgent()
   try {
-    const injection = injectManagedEkkoMcpServers(ekkoSetup)
-    const changed = injection.targets.filter(target => target.status === 'injected' || target.status === 'updated')
-    if (changed.length > 0) {
-      logger.info({
-        serverNames: injection.serverNames,
-        targets: changed,
-      }, '[bootstrap] Studio MCP servers injected into Ekko config')
+    const ekkoSetup = setupGlobalEkkoAgent()
+    try {
+      const injection = injectManagedEkkoMcpServers(ekkoSetup)
+      const changed = injection.targets.filter(target => target.status === 'injected' || target.status === 'updated')
+      if (changed.length > 0) {
+        logger.info({
+          serverNames: injection.serverNames,
+          targets: changed,
+        }, '[bootstrap] Studio MCP servers injected into Ekko config')
+      }
+    } catch (err) {
+      logger.warn(err, '[bootstrap] failed to inject Studio MCP servers into Ekko config')
+      console.warn('[bootstrap] failed to inject Studio MCP servers into Ekko config:', err instanceof Error ? err.message : err)
     }
+    console.log('[bootstrap] ekko-agent setup complete')
   } catch (err) {
-    logger.warn(err, '[bootstrap] failed to inject Studio MCP servers into Ekko config')
-    console.warn('[bootstrap] failed to inject Studio MCP servers into Ekko config:', err instanceof Error ? err.message : err)
+    logger.error(err, '[bootstrap] ekko-agent setup failed; continuing with Ekko unavailable')
+    console.error('[bootstrap] ekko-agent setup failed; continuing without Ekko:', err instanceof Error ? err.message : err)
   }
-  console.log('[bootstrap] ekko-agent setup complete')
 
   agentBridgeManager = getAgentBridgeManager()
   if (!isDesktopRuntime()) {
@@ -416,6 +452,7 @@ export async function bootstrap() {
   app.use(createRequestBodyParser())
   console.log('[bootstrap] cors + bodyParser registered')
 
+  registerReadinessRoute(app)
   registerDesktopShutdownRoute(app)
 
   // Register all routes (handles auth internally)
@@ -547,7 +584,11 @@ export async function bootstrap() {
   // Catch-all: destroy upgrade requests not handled by terminal or Socket.IO
   servers.forEach((httpServer) => {
     httpServer.on('upgrade', (req: any, socket: any) => {
-      const url = new URL(req.url || '', `http://${req.headers.host}`)
+      const url = parseUpgradeRequestUrl(req)
+      if (!url) {
+        writeBadUpgradeRequest(socket)
+        return
+      }
       if (url.pathname !== '/api/hermes/terminal' &&
         url.pathname !== '/api/hermes/kanban/events' &&
         url.pathname !== getLanPeerSocketPath() &&
@@ -592,6 +633,8 @@ export async function bootstrap() {
     additionalShutdownSteps,
   )
   startVersionCheck()
+  bootstrapReady = true
+  console.log('[bootstrap] startup ready')
 }
 
 bootstrap().catch((error) => {

--- a/packages/server/src/modules/hermes/services/runtime/version-manager.ts
+++ b/packages/server/src/modules/hermes/services/runtime/version-manager.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto'
-import { accessSync, constants, createReadStream, createWriteStream, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, statSync, writeFileSync } from 'fs'
+import { accessSync, constants, createReadStream, createWriteStream, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, statSync, writeFileSync, type Dirent } from 'fs'
 import { get as httpGet } from 'http'
 import { get as httpsGet } from 'https'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'path'
@@ -284,11 +284,11 @@ function scanInstalledRuntimeVersions(active = readActiveVersionManifest()): Ins
   const installed: InstalledRuntimeVersion[] = []
 
   if (existsSync(root)) {
-    for (const versionEntry of readdirSync(root, { withFileTypes: true })) {
+    for (const versionEntry of safeReadDirectoryEntries(root)) {
       if (!versionEntry.isDirectory()) continue
       const version = versionEntry.name
       const platformRoot = join(root, version)
-      for (const platformEntry of readdirSync(platformRoot, { withFileTypes: true })) {
+      for (const platformEntry of safeReadDirectoryEntries(platformRoot)) {
         if (!platformEntry.isDirectory()) continue
         const directory = join(platformRoot, platformEntry.name)
         installed.push({
@@ -343,7 +343,7 @@ export function listInstalledWebUiVersions(active = readActiveVersionManifest())
   const activeDir = activeWebUiDirectory(active)
   const installed: InstalledWebUiVersion[] = []
 
-  for (const versionEntry of readdirSync(root, { withFileTypes: true })) {
+  for (const versionEntry of safeReadDirectoryEntries(root)) {
     if (!versionEntry.isDirectory()) continue
     const directory = join(root, versionEntry.name)
     if (!existsSync(join(directory, 'package.json'))) continue
@@ -359,6 +359,14 @@ export function listInstalledWebUiVersions(active = readActiveVersionManifest())
   }
 
   return installed.sort((left, right) => right.version.localeCompare(left.version, undefined, { numeric: true }))
+}
+
+function safeReadDirectoryEntries(directory: string): Dirent[] {
+  try {
+    return readdirSync(directory, { withFileTypes: true })
+  } catch {
+    return []
+  }
 }
 
 function isStudioVersionManifest(value: unknown): value is StudioVersionManifest {

--- a/packages/server/src/modules/hermes/sockets/kanban-events.ts
+++ b/packages/server/src/modules/hermes/sockets/kanban-events.ts
@@ -5,7 +5,12 @@ import type { Duplex } from 'stream'
 import { authenticateUserToken, isAuthEnabled } from '../../studio/public/auth'
 import { config } from '../../studio/public/config'
 import { logger } from '../../studio/public/logging'
-import { shouldRejectUpgradeOrigin, writeForbiddenOrigin } from '../../studio/public/security'
+import {
+  parseUpgradeRequestUrl,
+  shouldRejectUpgradeOrigin,
+  writeBadUpgradeRequest,
+  writeForbiddenOrigin,
+} from '../../studio/public/security'
 import { userCanAccessProfile } from '../../studio/public/users'
 import { killOwnedProcessTree } from '../../studio/public/process-tree'
 import * as kanbanCli from '../services/kanban/kanban-service'
@@ -37,7 +42,11 @@ export function setupKanbanEventsWebSocket(httpServers: HttpServer | HttpServer[
   const servers = Array.isArray(httpServers) ? httpServers : [httpServers]
 
   const onUpgrade = async (req: KanbanEventsRequest, socket: Duplex, head: Buffer) => {
-    const url = new URL(req.url || '', `http://${req.headers.host}`)
+    const url = parseUpgradeRequestUrl(req)
+    if (!url) {
+      writeBadUpgradeRequest(socket)
+      return
+    }
     if (url.pathname !== '/api/hermes/kanban/events') return
 
     if (shouldRejectUpgradeOrigin(req, config.corsOrigins)) {

--- a/packages/server/src/modules/hermes/sockets/terminal.ts
+++ b/packages/server/src/modules/hermes/sockets/terminal.ts
@@ -9,7 +9,12 @@ import { getTerminalConfig, type TerminalConfig } from '../../studio/public/work
 import { authenticateUserToken, isAuthEnabled } from '../../studio/public/auth'
 import { logger } from '../../studio/public/logging'
 import { config } from '../../studio/public/config'
-import { shouldRejectUpgradeOrigin, writeForbiddenOrigin } from '../../studio/public/security'
+import {
+  parseUpgradeRequestUrl,
+  shouldRejectUpgradeOrigin,
+  writeBadUpgradeRequest,
+  writeForbiddenOrigin,
+} from '../../studio/public/security'
 import { killOwnedProcessTree } from '../../studio/public/process-tree'
 
 let pty: any = null
@@ -158,7 +163,11 @@ export function setupTerminalWebSocket(httpServers: HttpServer | HttpServer[]) {
   const servers = Array.isArray(httpServers) ? httpServers : [httpServers]
 
   const onUpgrade = async (req: IncomingMessage, socket: Duplex, head: Buffer) => {
-    const url = new URL(req.url || '', `http://${req.headers.host}`)
+    const url = parseUpgradeRequestUrl(req)
+    if (!url) {
+      writeBadUpgradeRequest(socket)
+      return
+    }
     if (url.pathname !== '/api/hermes/terminal') {
       return
     }

--- a/packages/server/src/modules/studio/infrastructure/database/index.ts
+++ b/packages/server/src/modules/studio/infrastructure/database/index.ts
@@ -38,20 +38,31 @@ export function getDb(): DatabaseSync | null {
   if (!SQLITE_AVAILABLE) return null
   if (!_db) {
     mkdirSync(DB_DIR, { recursive: true })
-    _db = new DatabaseSync(DB_PATH)
-    // Use WAL mode for better concurrency and WSL compatibility
-    if (isTest) {
-      _db.exec('PRAGMA journal_mode=WAL')
-      _db.exec('PRAGMA synchronous=NORMAL')
-      _db.exec('PRAGMA busy_timeout=5000')
-      _db.exec('PRAGMA foreign_keys=ON')
-    } else if (isDev) {
-      _db.exec('PRAGMA journal_mode=DELETE')
-    } else {
-      _db.exec('PRAGMA journal_mode=WAL')
-      _db.exec('PRAGMA synchronous=NORMAL')
-      _db.exec('PRAGMA busy_timeout=5000')
-      _db.exec('PRAGMA foreign_keys=ON')
+    const candidate = new DatabaseSync(DB_PATH)
+    try {
+      // Install the busy handler before changing journal mode so a transient
+      // lock during startup does not immediately abort the whole bootstrap.
+      candidate.exec('PRAGMA busy_timeout=5000')
+      // Use WAL mode for better concurrency and WSL compatibility
+      if (isTest) {
+        candidate.exec('PRAGMA journal_mode=WAL')
+        candidate.exec('PRAGMA synchronous=NORMAL')
+        candidate.exec('PRAGMA foreign_keys=ON')
+      } else if (isDev) {
+        candidate.exec('PRAGMA journal_mode=DELETE')
+      } else {
+        candidate.exec('PRAGMA journal_mode=WAL')
+        candidate.exec('PRAGMA synchronous=NORMAL')
+        candidate.exec('PRAGMA foreign_keys=ON')
+      }
+      _db = candidate
+    } catch (error) {
+      try {
+        candidate.close()
+      } catch {
+        // Preserve the original initialization error.
+      }
+      throw error
     }
   }
   return _db

--- a/packages/server/src/modules/studio/middleware/security.ts
+++ b/packages/server/src/modules/studio/middleware/security.ts
@@ -109,6 +109,27 @@ export function shouldRejectUpgradeOrigin(req: IncomingMessage, corsOrigins = ''
     && !isLocalAppDevelopmentOrigin(selectedOrigin)
 }
 
+export function parseUpgradeRequestUrl(req: IncomingMessage): URL | null {
+  try {
+    return new URL(req.url || '', `http://${req.headers.host}`)
+  } catch {
+    return null
+  }
+}
+
+export function writeBadUpgradeRequest(socket: {
+  destroyed?: boolean
+  write: (chunk: string) => void
+  destroy: () => void
+}): void {
+  if (socket.destroyed) return
+  try {
+    socket.write('HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n')
+  } finally {
+    socket.destroy()
+  }
+}
+
 export function writeForbiddenOrigin(socket: { write: (chunk: string) => void; destroy: () => void }): void {
   socket.write('HTTP/1.1 403 Forbidden\r\n\r\n')
   socket.destroy()

--- a/packages/server/src/modules/studio/public/logging.ts
+++ b/packages/server/src/modules/studio/public/logging.ts
@@ -10,10 +10,35 @@ const CHECK_INTERVAL = 60_000 // Check every minute
 const logDir = process.env.VITEST
   ? resolve(tmpdir(), 'hermes-web-ui-test-logs', String(process.pid))
   : resolve(config.appHome, 'logs')
-mkdirSync(logDir, { recursive: true })
 
 const logFile = resolve(logDir, 'server.log')
 const bridgeLogFile = resolve(logDir, 'bridge.log')
+const VALID_LOG_LEVELS = new Set(['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'])
+
+function logLevel(value: string | undefined, fallback = 'info'): string {
+  const normalized = String(value || '').trim().toLowerCase()
+  return VALID_LOG_LEVELS.has(normalized) ? normalized : fallback
+}
+
+function createDestination(file: string) {
+  try {
+    mkdirSync(logDir, { recursive: true })
+    const destination = pino.destination({ dest: file, sync: true })
+    destination.on('error', error => {
+      console.error(`[logging] write failed for ${file}`, error)
+    })
+    return destination
+  } catch (error) {
+    // Logging must never make Studio unbootable. stderr remains available to
+    // Desktop's child-process capture and to service managers.
+    console.error(`[logging] unable to open ${file}; falling back to stderr`, error)
+    const destination = pino.destination({ dest: 2, sync: true })
+    destination.on('error', destinationError => {
+      console.error('[logging] stderr destination failed', destinationError)
+    })
+    return destination
+  }
+}
 
 function rotateFileIfNeeded(file: string) {
   try {
@@ -42,16 +67,10 @@ rotateIfNeeded()
 setInterval(rotateIfNeeded, CHECK_INTERVAL)
 
 export const logger = pino({
-  level: process.env.LOG_LEVEL || 'info',
-}, pino.destination({
-  dest: logFile,
-  sync: true,
-}))
+  level: logLevel(process.env.LOG_LEVEL),
+}, createDestination(logFile))
 
 export const bridgeLogger = pino({
-  level: process.env.BRIDGE_LOG_LEVEL || process.env.LOG_LEVEL || 'info',
+  level: logLevel(process.env.BRIDGE_LOG_LEVEL, logLevel(process.env.LOG_LEVEL)),
   name: 'bridge',
-}, pino.destination({
-  dest: bridgeLogFile,
-  sync: true,
-}))
+}, createDestination(bridgeLogFile))

--- a/packages/server/src/modules/studio/public/security.ts
+++ b/packages/server/src/modules/studio/public/security.ts
@@ -1,5 +1,7 @@
 export {
   createSocketIoCorsOrigin,
+  parseUpgradeRequestUrl,
   shouldRejectUpgradeOrigin,
+  writeBadUpgradeRequest,
   writeForbiddenOrigin,
 } from '../middleware/security'

--- a/packages/server/src/modules/studio/services/network/lan-peer-socket.ts
+++ b/packages/server/src/modules/studio/services/network/lan-peer-socket.ts
@@ -12,7 +12,12 @@ import type { LanDeviceInfo } from './lan-discovery'
 import { createDeviceSignature, getPublicSystemInfo, verifyDeviceSignature } from '../../public/system-info'
 import { logger } from '../../public/logging'
 import { config } from '../../public/config'
-import { shouldRejectUpgradeOrigin, writeForbiddenOrigin } from '../../middleware/security'
+import {
+  parseUpgradeRequestUrl,
+  shouldRejectUpgradeOrigin,
+  writeBadUpgradeRequest,
+  writeForbiddenOrigin,
+} from '../../middleware/security'
 import { killOwnedProcessTree } from '../../infrastructure/process-tree'
 
 export interface LanPeerFilesystemDependencies {
@@ -940,7 +945,11 @@ export class LanPeerSocketManager {
 
     servers.forEach(httpServer => {
       const onUpgrade = async (req: IncomingMessage, socket: Duplex, head: Buffer) => {
-        const url = new URL(req.url || '', `http://${req.headers.host}`)
+        const url = parseUpgradeRequestUrl(req)
+        if (!url) {
+          writeBadUpgradeRequest(socket)
+          return
+        }
         if (url.pathname !== PEER_SOCKET_PATH) return
 
         if (shouldRejectUpgradeOrigin(req, config.corsOrigins)) {

--- a/tests/ekko-agent/database.test.ts
+++ b/tests/ekko-agent/database.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -118,68 +118,41 @@ describe('EkkoDatabaseManager', () => {
     }
   })
 
-  it('never imports Hermes skills and removes only their legacy non-built-in Ekko copies', async () => {
+  it('resets the complete legacy skills directory once and reinstalls built-in skills', async () => {
     const hermesRoot = join(webUiHome, 'hermes')
     const ekkoBase = join(webUiHome, 'web-ui')
-    const hermesSkill = join(hermesRoot, 'skills', 'legacy-hermes-skill')
-    const ekkoProfile = join(ekkoBase, '.ekko', 'skills', 'default')
-    await mkdir(hermesSkill, { recursive: true })
-    await mkdir(join(hermesRoot, 'skills', 'weather'), { recursive: true })
-    await mkdir(join(hermesRoot, 'skills', 'image-gen'), { recursive: true })
-    await mkdir(join(hermesRoot, 'skills', 'category', 'weather'), { recursive: true })
-    await writeFile(join(hermesSkill, 'SKILL.md'), '# Hermes only\n')
-    await writeFile(join(hermesRoot, 'skills', 'weather', 'SKILL.md'), '# Hermes weather\n')
-    await writeFile(join(hermesRoot, 'skills', 'image-gen', 'SKILL.md'), '# Hermes image gen\n')
-    await writeFile(join(hermesRoot, 'skills', 'category', 'weather', 'SKILL.md'), '# Categorized Hermes weather\n')
-    await writeFile(join(hermesRoot, 'skills', 'category', 'DESCRIPTION.md'), '# Hermes category\n')
     const directories = new EkkoDirectoryManager(ekkoBase)
     directories.initialize()
-    directories.profileSkillsDirectory('default')
-    const builtinManifestPath = join(ekkoProfile, '.ekko-builtin-skills.json')
-    const builtinManifest = JSON.parse(await readFile(builtinManifestPath, 'utf8'))
-    delete builtinManifest['image-gen']
-    await writeFile(builtinManifestPath, `${JSON.stringify(builtinManifest, null, 2)}\n`)
-    await mkdir(join(ekkoProfile, 'legacy-hermes-skill'), { recursive: true })
-    await mkdir(join(ekkoProfile, 'category', 'weather'), { recursive: true })
-    await mkdir(join(ekkoProfile, 'ekko-local'), { recursive: true })
-    await writeFile(join(ekkoProfile, 'legacy-hermes-skill', 'SKILL.md'), '# Modified after import\n')
-    await writeFile(join(ekkoProfile, 'weather', 'SKILL.md'), '# Modified Ekko built-in\n')
-    await writeFile(join(ekkoProfile, 'image-gen', 'SKILL.md'), '# Hermes image gen\n')
-    await writeFile(join(ekkoProfile, 'category', 'weather', 'SKILL.md'), '# Categorized Hermes weather\n')
-    await writeFile(join(ekkoProfile, 'category', 'DESCRIPTION.md'), '# Hermes category\n')
-    await writeFile(join(ekkoProfile, 'ekko-local', 'SKILL.md'), '# Ekko local\n')
+    const defaultProfile = directories.profileSkillsDirectory('default')
+    const workProfile = directories.profileSkillsDirectory('work')
+    await mkdir(join(defaultProfile, 'web-access', '.git'), { recursive: true })
+    await mkdir(join(workProfile, 'custom-skill'), { recursive: true })
+    await writeFile(join(defaultProfile, 'web-access', 'SKILL.md'), '# Web access\n')
+    const gitHead = join(defaultProfile, 'web-access', '.git', 'HEAD')
+    await writeFile(gitHead, 'ref: refs/heads/main\n')
+    await chmod(gitHead, 0o444)
+    await writeFile(join(workProfile, 'custom-skill', 'SKILL.md'), '# Custom skill\n')
 
     directories.initialize({ hermesRootDirectory: hermesRoot })
 
-    expect(existsSync(join(ekkoProfile, 'legacy-hermes-skill'))).toBe(false)
-    await expect(readFile(join(ekkoProfile, 'weather', 'SKILL.md'), 'utf8'))
-      .resolves.toBe('# Modified Ekko built-in\n')
-    expect(existsSync(join(ekkoProfile, 'image-gen'))).toBe(false)
-    expect(existsSync(join(ekkoProfile, 'category'))).toBe(false)
-    await expect(readFile(join(ekkoProfile, 'ekko-local', 'SKILL.md'), 'utf8'))
-      .resolves.toBe('# Ekko local\n')
-    await expect(readFile(join(hermesSkill, 'SKILL.md'), 'utf8'))
-      .resolves.toBe('# Hermes only\n')
+    expect(existsSync(join(defaultProfile, 'web-access'))).toBe(false)
+    expect(existsSync(join(workProfile, 'custom-skill'))).toBe(false)
+    expect(existsSync(join(defaultProfile, 'weather', 'SKILL.md'))).toBe(true)
+    expect(existsSync(join(workProfile, 'weather', 'SKILL.md'))).toBe(true)
     await expect(readFile(
       join(ekkoBase, '.ekko', '.ekko-hermes-skill-cleanup-v2.json'),
       'utf8',
     ).then(JSON.parse)).resolves.toMatchObject({
       version: 2,
-      removed: expect.arrayContaining([
-        { profile: 'default', skill: 'legacy-hermes-skill' },
-        { profile: 'default', skill: 'image-gen' },
-        { profile: 'default', skill: 'category/weather' },
-      ]),
+      hermesRootDirectory: hermesRoot,
+      resetSkillsDirectory: true,
     })
-    directories.profileSkillsDirectory('default')
-    await expect(readFile(join(ekkoProfile, 'image-gen', 'SKILL.md'), 'utf8'))
-      .resolves.not.toBe('# Hermes image gen\n')
 
-    await mkdir(join(ekkoProfile, 'legacy-hermes-skill'), { recursive: true })
-    await writeFile(join(ekkoProfile, 'legacy-hermes-skill', 'SKILL.md'), '# Created after cleanup\n')
+    await mkdir(join(defaultProfile, 'created-after-reset'), { recursive: true })
+    await writeFile(join(defaultProfile, 'created-after-reset', 'SKILL.md'), '# Keep me\n')
     directories.initialize({ hermesRootDirectory: hermesRoot })
-    await expect(readFile(join(ekkoProfile, 'legacy-hermes-skill', 'SKILL.md'), 'utf8'))
-      .resolves.toBe('# Created after cleanup\n')
+    await expect(readFile(join(defaultProfile, 'created-after-reset', 'SKILL.md'), 'utf8'))
+      .resolves.toBe('# Keep me\n')
   })
 
   it('installs only Ekko built-ins when the skills root does not exist', async () => {

--- a/tests/server/crash-isolation.test.ts
+++ b/tests/server/crash-isolation.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('Studio crash isolation wiring', () => {
+  it('uses guarded URL parsing in every raw WebSocket upgrade handler', () => {
+    const files = [
+      'packages/server/src/bootstrap/http.ts',
+      'packages/server/src/modules/hermes/sockets/terminal.ts',
+      'packages/server/src/modules/hermes/sockets/kanban-events.ts',
+      'packages/server/src/modules/studio/services/network/lan-peer-socket.ts',
+    ]
+
+    for (const file of files) {
+      const source = readFileSync(file, 'utf8')
+      expect(source, file).toContain('parseUpgradeRequestUrl(req)')
+      expect(source, file).not.toContain("new URL(req.url || '', `http://${req.headers.host}`)")
+    }
+  })
+
+  it('reports ready only after late bootstrap services complete', () => {
+    const bootstrap = readFileSync('packages/server/src/bootstrap/http.ts', 'utf8')
+    const listen = bootstrap.indexOf('await listenWithFallback(')
+    const recovery = bootstrap.indexOf('recoverActiveRuns()', listen)
+    const versionCheck = bootstrap.indexOf('startVersionCheck()', recovery)
+    const ready = bootstrap.indexOf('bootstrapReady = true', versionCheck)
+
+    expect(listen).toBeGreaterThan(-1)
+    expect(recovery).toBeGreaterThan(listen)
+    expect(versionCheck).toBeGreaterThan(recovery)
+    expect(ready).toBeGreaterThan(versionCheck)
+  })
+
+  it('makes Desktop poll readiness and recover one unexpected server exit', () => {
+    const server = readFileSync('packages/desktop/src/main/webui-server.ts', 'utf8')
+    const desktop = readFileSync('packages/desktop/src/main/index.ts', 'utf8')
+
+    expect(server).toContain('/health/ready')
+    expect(server).toContain('setWebUiUnexpectedExitHandler')
+    expect(desktop).toContain('recoverUnexpectedWebUiExit')
+    expect(desktop).toContain('unexpectedWebUiExitCount > 1')
+  })
+
+  it('keeps logger initialization and client mounting on explicit fallback paths', () => {
+    const logging = readFileSync('packages/server/src/modules/studio/public/logging.ts', 'utf8')
+    const client = readFileSync('packages/client/src/main.ts', 'utf8')
+
+    expect(logging).toContain('falling back to stderr')
+    expect(logging).toContain("pino.destination({ dest: 2, sync: true })")
+    expect(client).toContain('app.config.errorHandler')
+    expect(client).toContain('mountApp().catch')
+  })
+})

--- a/tests/server/crash-isolation.test.ts
+++ b/tests/server/crash-isolation.test.ts
@@ -17,17 +17,17 @@ describe('Studio crash isolation wiring', () => {
     }
   })
 
-  it('reports ready only after late bootstrap services complete', () => {
+  it('reports the HTTP shell ready without waiting for late bootstrap services', () => {
     const bootstrap = readFileSync('packages/server/src/bootstrap/http.ts', 'utf8')
     const listen = bootstrap.indexOf('await listenWithFallback(')
-    const recovery = bootstrap.indexOf('recoverActiveRuns()', listen)
+    const ready = bootstrap.indexOf('bootstrapReady = true', listen)
+    const recovery = bootstrap.indexOf('recoverActiveRuns()', ready)
     const versionCheck = bootstrap.indexOf('startVersionCheck()', recovery)
-    const ready = bootstrap.indexOf('bootstrapReady = true', versionCheck)
 
     expect(listen).toBeGreaterThan(-1)
-    expect(recovery).toBeGreaterThan(listen)
+    expect(ready).toBeGreaterThan(listen)
+    expect(recovery).toBeGreaterThan(ready)
     expect(versionCheck).toBeGreaterThan(recovery)
-    expect(ready).toBeGreaterThan(versionCheck)
   })
 
   it('makes Desktop poll readiness and recover one unexpected server exit', () => {

--- a/tests/server/crash-isolation.test.ts
+++ b/tests/server/crash-isolation.test.ts
@@ -48,5 +48,13 @@ describe('Studio crash isolation wiring', () => {
     expect(logging).toContain("pino.destination({ dest: 2, sync: true })")
     expect(client).toContain('app.config.errorHandler')
     expect(client).toContain('mountApp().catch')
+
+    const runtimeErrorHandler = client.slice(
+      client.indexOf('app.config.errorHandler'),
+      client.indexOf('app.use(createPinia())'),
+    )
+    const mountFailureHandler = client.slice(client.indexOf('mountApp().catch'))
+    expect(runtimeErrorHandler).not.toContain('renderFatalError')
+    expect(mountFailureHandler).toContain('renderFatalError(error)')
   })
 })

--- a/tests/server/runtime-install-restart-wiring.test.ts
+++ b/tests/server/runtime-install-restart-wiring.test.ts
@@ -21,7 +21,8 @@ describe('Runtime install restart wiring', () => {
 
     expect(bootstrap).toContain("getShutdownHandler()('runtime-installed', 75)")
     expect(bootstrap).toContain('scheduleWebUiRestart()')
-    expect(desktopServer).toContain('if (code === 75) runtimeRestartHandler?.()')
+    expect(desktopServer).toContain('if (code === 75) {')
+    expect(desktopServer).toContain('runtimeRestartHandler?.()')
     expect(desktopMain).toContain('setWebUiRuntimeRestartHandler(() => {')
     expect(desktopMain).toContain('app.relaunch()')
     expect(desktopMain).toContain('quitApp()')

--- a/tests/server/runtime-version-manager.test.ts
+++ b/tests/server/runtime-version-manager.test.ts
@@ -159,6 +159,21 @@ describe('runtime version manager storage migration', () => {
     expect(status.hermes.remoteVersions).toEqual([])
   })
 
+  it('ignores Runtime storage entries that cannot be read as directories', async () => {
+    const storageRoot = join(state.appHome, 'desktop-runtime')
+    mkdirSync(storageRoot, { recursive: true })
+    writeFileSync(join(storageRoot, 'hermes'), 'not a directory')
+    writeFileSync(join(storageRoot, 'webui'), 'not a directory')
+
+    const {
+      listInstalledRuntimeVersions,
+      listInstalledWebUiVersions,
+    } = await import('../../packages/server/src/modules/hermes/services/runtime/version-manager')
+
+    expect(listInstalledRuntimeVersions()).toEqual([])
+    expect(listInstalledWebUiVersions()).toEqual([])
+  })
+
   it('probes local Runtime storage without loading remote versions in Web UI mode', async () => {
     delete process.env.HERMES_DESKTOP
     const platform = runtimePlatformKey()

--- a/tests/server/security-policy.test.ts
+++ b/tests/server/security-policy.test.ts
@@ -1,11 +1,13 @@
 import http from 'http'
 import Koa from 'koa'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   createCorsOriginResolver,
   isOriginAllowed,
+  parseUpgradeRequestUrl,
   securityHeaders,
   shouldRejectUpgradeOrigin,
+  writeBadUpgradeRequest,
 } from '../../packages/server/src/modules/studio/middleware/security'
 
 function fakeCtx(origin: string, host: string) {
@@ -49,6 +51,21 @@ describe('server security policy', () => {
     expect(shouldRejectUpgradeOrigin({ headers: { origin: 'http://localhost', host: '192.168.10.102:8647' } } as any, '')).toBe(false)
     expect(shouldRejectUpgradeOrigin({ headers: { origin: 'http://localhost:5173', host: '192.168.10.102:8647' } } as any, '')).toBe(false)
     expect(shouldRejectUpgradeOrigin({ headers: { host: '127.0.0.1:8648' } } as any, '')).toBe(false)
+  })
+
+  it('rejects malformed websocket upgrade URLs without throwing', () => {
+    expect(parseUpgradeRequestUrl({ url: '/socket', headers: { host: '127.0.0.1:8648' } } as any)?.pathname)
+      .toBe('/socket')
+    expect(parseUpgradeRequestUrl({ url: '/socket', headers: { host: '[' } } as any)).toBeNull()
+
+    const socket = {
+      destroyed: false,
+      write: vi.fn(),
+      destroy: vi.fn(),
+    }
+    writeBadUpgradeRequest(socket)
+    expect(socket.write).toHaveBeenCalledWith('HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n')
+    expect(socket.destroy).toHaveBeenCalledOnce()
   })
 
   it('adds baseline browser security headers', async () => {


### PR DESCRIPTION
## Summary

- reset the user skill directory once during the upgrade, reinstall bundled skills, and persist an atomic completion marker
- reject malformed WebSocket upgrades without allowing URL parsing errors to terminate the server
- isolate optional Ekko, runtime, logging, and startup-directory failures from the main Studio process
- add a real readiness endpoint and bounded Desktop backend and renderer recovery
- add frontend fatal-error fallback UI and database initialization cleanup

## Behavior guarantees

- successful request, routing, authentication, runtime selection, and application flows are unchanged
- no database is deleted, rebuilt, quarantined, or silently repaired
- the skill reset runs only when the marker is absent and bundled skills are available

## Validation

- focused crash-isolation suite: 40 tests passed
- Ekko Agent suite: 272 tests passed
- affected Server and Desktop suites: 47 tests passed
- root build, Ekko build, Desktop main build, API harness, and git diff checks passed
- live integration check confirmed that a malformed HTTP Upgrade request returns an isolated error while readiness remains 200

## Full-suite note

The concurrent full suite completed with 4,643 passed, 53 failed, and 6 skipped. The failures show existing cross-file environment and module-cache contamination, primarily Desktop port 8748 leaking into tests expecting 8648 plus unrelated Vue stubs. The affected scopes pass when run in isolation; this PR does not change unrelated business logic to mask those races.