### PR TITLE
fix: standardize Hermes home on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,10 +271,7 @@ Download the latest **Hermes Studio** desktop installer from
 
 Desktop builds are published for macOS, Windows, and Linux, with separate
 architecture assets where applicable. The desktop app bundles the Studio
-runtime and stores Hermes Agent data in the native Hermes location:
-
-- Windows: `~/.hermes` when it contains recognizable Hermes data; otherwise `%LOCALAPPDATA%\hermes` (falls back to `%APPDATA%\hermes` when `LOCALAPPDATA` is unavailable)
-- macOS/Linux: `~/.hermes`
+runtime and stores Hermes Agent data in `~/.hermes` on Windows, macOS, and Linux.
 
 The desktop wrapper stores its own Studio state separately in
 `~/.hermes-web-ui` unless `HERMES_WEB_UI_HOME` is set.
@@ -366,7 +363,7 @@ These variables configure Hermes Studio, its local Hermes runtime integration, a
 | `MAX_DOWNLOAD_SIZE` | `200MB` | Maximum file download size. |
 | `MAX_EDIT_SIZE` | `10MB` | Maximum editable file size. |
 | `WORKSPACE_BASE` | current user's home directory | Base directory for workspace browsing. |
-| `HERMES_HOME` | platform default | Hermes data home. Windows prefers `~/.hermes` when it contains recognizable Hermes data, then uses `%LOCALAPPDATA%\hermes`; macOS/Linux uses `~/.hermes`. |
+| `HERMES_HOME` | `~/.hermes` | Hermes data home on Windows, macOS, and Linux. |
 | `HERMES_BIN` | `hermes` | Custom Hermes CLI binary path. |
 | `HERMES_AGENT_ROOT` | auto-discovered | Hermes Agent source checkout containing `run_agent.py`. |
 | `HERMES_AGENT_BRIDGE_PYTHON` | auto-discovered | Python interpreter used to launch the agent bridge. |

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Desktop builds are published for macOS, Windows, and Linux, with separate
 architecture assets where applicable. The desktop app bundles the Studio
 runtime and stores Hermes Agent data in the native Hermes location:
 
-- Windows: `~/.hermes` when it contains recognizable Hermes data; otherwise `%LOCALAPPDATA%\hermes` (falls back to `%APPDATA%\hermes` when `LOCALAPPDATA` is unavailable)
+- Windows: `%LOCALAPPDATA%\hermes` (falls back to `%APPDATA%\hermes`)
 - macOS/Linux: `~/.hermes`
 
 The desktop wrapper stores its own Studio state separately in
@@ -366,7 +366,7 @@ These variables configure Hermes Studio, its local Hermes runtime integration, a
 | `MAX_DOWNLOAD_SIZE` | `200MB` | Maximum file download size. |
 | `MAX_EDIT_SIZE` | `10MB` | Maximum editable file size. |
 | `WORKSPACE_BASE` | current user's home directory | Base directory for workspace browsing. |
-| `HERMES_HOME` | platform default | Hermes data home. Windows prefers `~/.hermes` when it contains recognizable Hermes data, then uses `%LOCALAPPDATA%\hermes`; macOS/Linux uses `~/.hermes`. |
+| `HERMES_HOME` | platform default | Hermes data home. Windows uses `%LOCALAPPDATA%\hermes`; macOS/Linux uses `~/.hermes`. |
 | `HERMES_BIN` | `hermes` | Custom Hermes CLI binary path. |
 | `HERMES_AGENT_ROOT` | auto-discovered | Hermes Agent source checkout containing `run_agent.py`. |
 | `HERMES_AGENT_BRIDGE_PYTHON` | auto-discovered | Python interpreter used to launch the agent bridge. |

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Desktop builds are published for macOS, Windows, and Linux, with separate
 architecture assets where applicable. The desktop app bundles the Studio
 runtime and stores Hermes Agent data in the native Hermes location:
 
-- Windows: `%LOCALAPPDATA%\hermes` (falls back to `%APPDATA%\hermes`)
+- Windows: `~/.hermes` when it contains recognizable Hermes data; otherwise `%LOCALAPPDATA%\hermes` (falls back to `%APPDATA%\hermes` when `LOCALAPPDATA` is unavailable)
 - macOS/Linux: `~/.hermes`
 
 The desktop wrapper stores its own Studio state separately in
@@ -366,7 +366,7 @@ These variables configure Hermes Studio, its local Hermes runtime integration, a
 | `MAX_DOWNLOAD_SIZE` | `200MB` | Maximum file download size. |
 | `MAX_EDIT_SIZE` | `10MB` | Maximum editable file size. |
 | `WORKSPACE_BASE` | current user's home directory | Base directory for workspace browsing. |
-| `HERMES_HOME` | platform default | Hermes data home. Windows uses `%LOCALAPPDATA%\hermes`; macOS/Linux uses `~/.hermes`. |
+| `HERMES_HOME` | platform default | Hermes data home. Windows prefers `~/.hermes` when it contains recognizable Hermes data, then uses `%LOCALAPPDATA%\hermes`; macOS/Linux uses `~/.hermes`. |
 | `HERMES_BIN` | `hermes` | Custom Hermes CLI binary path. |
 | `HERMES_AGENT_ROOT` | auto-discovered | Hermes Agent source checkout containing `run_agent.py`. |
 | `HERMES_AGENT_BRIDGE_PYTHON` | auto-discovered | Python interpreter used to launch the agent bridge. |

--- a/README_zh.md
+++ b/README_zh.md
@@ -276,10 +276,7 @@ hermes-web-ui reset-default-login
 下载最新的 **Hermes Studio** 桌面安装包。
 
 桌面版会发布 macOS、Windows 和 Linux 构建；适用时会区分不同 CPU 架构。
-桌面应用内置 Studio 运行时，Hermes Agent 数据会保存到原生 Hermes 目录：
-
-- Windows：当 `~/.hermes` 包含可识别的 Hermes 数据时优先使用该目录；否则使用 `%LOCALAPPDATA%\hermes`（`LOCALAPPDATA` 不可用时回退到 `%APPDATA%\hermes`）
-- macOS/Linux：`~/.hermes`
+桌面应用内置 Studio 运行时；在 Windows、macOS 和 Linux 上，Hermes Agent 数据统一保存到 `~/.hermes`。
 
 桌面壳自身的 Studio 状态会单独保存到 `~/.hermes-web-ui`，除非设置了
 `HERMES_WEB_UI_HOME`。
@@ -368,7 +365,7 @@ Studio 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源
 | `MAX_DOWNLOAD_SIZE` | `200MB` | 最大文件下载大小。 |
 | `MAX_EDIT_SIZE` | `10MB` | 最大可编辑文件大小。 |
 | `WORKSPACE_BASE` | 当前用户 Home 目录 | Workspace 浏览根目录。 |
-| `HERMES_HOME` | 平台默认值 | Hermes 数据目录。Windows 优先使用包含可识别 Hermes 数据的 `~/.hermes`，然后使用 `%LOCALAPPDATA%\hermes`；macOS/Linux 使用 `~/.hermes`。 |
+| `HERMES_HOME` | `~/.hermes` | Windows、macOS 和 Linux 上的 Hermes 数据目录。 |
 | `HERMES_BIN` | `hermes` | 自定义 Hermes CLI 二进制路径。 |
 | `HERMES_AGENT_ROOT` | 自动发现 | 包含 `run_agent.py` 的 Hermes Agent 源码目录。 |
 | `HERMES_AGENT_BRIDGE_PYTHON` | 自动发现 | 用于启动 agent bridge 的 Python 解释器。 |

--- a/README_zh.md
+++ b/README_zh.md
@@ -278,7 +278,7 @@ hermes-web-ui reset-default-login
 桌面版会发布 macOS、Windows 和 Linux 构建；适用时会区分不同 CPU 架构。
 桌面应用内置 Studio 运行时，Hermes Agent 数据会保存到原生 Hermes 目录：
 
-- Windows：当 `~/.hermes` 包含可识别的 Hermes 数据时优先使用该目录；否则使用 `%LOCALAPPDATA%\hermes`（`LOCALAPPDATA` 不可用时回退到 `%APPDATA%\hermes`）
+- Windows：`%LOCALAPPDATA%\hermes`（找不到时回退到 `%APPDATA%\hermes`）
 - macOS/Linux：`~/.hermes`
 
 桌面壳自身的 Studio 状态会单独保存到 `~/.hermes-web-ui`，除非设置了
@@ -368,7 +368,7 @@ Studio 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源
 | `MAX_DOWNLOAD_SIZE` | `200MB` | 最大文件下载大小。 |
 | `MAX_EDIT_SIZE` | `10MB` | 最大可编辑文件大小。 |
 | `WORKSPACE_BASE` | 当前用户 Home 目录 | Workspace 浏览根目录。 |
-| `HERMES_HOME` | 平台默认值 | Hermes 数据目录。Windows 优先使用包含可识别 Hermes 数据的 `~/.hermes`，然后使用 `%LOCALAPPDATA%\hermes`；macOS/Linux 使用 `~/.hermes`。 |
+| `HERMES_HOME` | 平台默认值 | Hermes 数据目录。Windows 使用 `%LOCALAPPDATA%\hermes`；macOS/Linux 使用 `~/.hermes`。 |
 | `HERMES_BIN` | `hermes` | 自定义 Hermes CLI 二进制路径。 |
 | `HERMES_AGENT_ROOT` | 自动发现 | 包含 `run_agent.py` 的 Hermes Agent 源码目录。 |
 | `HERMES_AGENT_BRIDGE_PYTHON` | 自动发现 | 用于启动 agent bridge 的 Python 解释器。 |

--- a/README_zh.md
+++ b/README_zh.md
@@ -278,7 +278,7 @@ hermes-web-ui reset-default-login
 桌面版会发布 macOS、Windows 和 Linux 构建；适用时会区分不同 CPU 架构。
 桌面应用内置 Studio 运行时，Hermes Agent 数据会保存到原生 Hermes 目录：
 
-- Windows：`%LOCALAPPDATA%\hermes`（找不到时回退到 `%APPDATA%\hermes`）
+- Windows：当 `~/.hermes` 包含可识别的 Hermes 数据时优先使用该目录；否则使用 `%LOCALAPPDATA%\hermes`（`LOCALAPPDATA` 不可用时回退到 `%APPDATA%\hermes`）
 - macOS/Linux：`~/.hermes`
 
 桌面壳自身的 Studio 状态会单独保存到 `~/.hermes-web-ui`，除非设置了
@@ -368,7 +368,7 @@ Studio 启动后端聊天能力时，会优先使用包含 `run_agent.py` 的源
 | `MAX_DOWNLOAD_SIZE` | `200MB` | 最大文件下载大小。 |
 | `MAX_EDIT_SIZE` | `10MB` | 最大可编辑文件大小。 |
 | `WORKSPACE_BASE` | 当前用户 Home 目录 | Workspace 浏览根目录。 |
-| `HERMES_HOME` | 平台默认值 | Hermes 数据目录。Windows 使用 `%LOCALAPPDATA%\hermes`；macOS/Linux 使用 `~/.hermes`。 |
+| `HERMES_HOME` | 平台默认值 | Hermes 数据目录。Windows 优先使用包含可识别 Hermes 数据的 `~/.hermes`，然后使用 `%LOCALAPPDATA%\hermes`；macOS/Linux 使用 `~/.hermes`。 |
 | `HERMES_BIN` | `hermes` | 自定义 Hermes CLI 二进制路径。 |
 | `HERMES_AGENT_ROOT` | 自动发现 | 包含 `run_agent.py` 的 Hermes Agent 源码目录。 |
 | `HERMES_AGENT_BRIDGE_PYTHON` | 自动发现 | 用于启动 agent bridge 的 Python 解释器。 |

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -31,7 +31,7 @@ Use `hermes-studio cli -h` for Hermes Agent CLI help and
 Hermes Agent data is stored in the same platform-specific location as native
 Hermes installs:
 
-- Windows: `~/.hermes` when it contains recognizable Hermes data; otherwise `%LOCALAPPDATA%\hermes` (falls back to `%APPDATA%\hermes` when `LOCALAPPDATA` is unavailable)
+- Windows: `%LOCALAPPDATA%\hermes` (falls back to `%APPDATA%\hermes`)
 - macOS/Linux: `~/.hermes`
 
 The desktop wrapper's own Web UI state is stored separately in

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -28,11 +28,7 @@ Use `hermes-studio cli -h` for Hermes Agent CLI help and
 
 ## Data directories
 
-Hermes Agent data is stored in the same platform-specific location as native
-Hermes installs:
-
-- Windows: `~/.hermes` when it contains recognizable Hermes data; otherwise `%LOCALAPPDATA%\hermes` (falls back to `%APPDATA%\hermes` when `LOCALAPPDATA` is unavailable)
-- macOS/Linux: `~/.hermes`
+Hermes Agent data is stored in `~/.hermes` on Windows, macOS, and Linux.
 
 The desktop wrapper's own Web UI state is stored separately in
 `~/.hermes-web-ui` unless `HERMES_WEB_UI_HOME` is set.

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -31,7 +31,7 @@ Use `hermes-studio cli -h` for Hermes Agent CLI help and
 Hermes Agent data is stored in the same platform-specific location as native
 Hermes installs:
 
-- Windows: `%LOCALAPPDATA%\hermes` (falls back to `%APPDATA%\hermes`)
+- Windows: `~/.hermes` when it contains recognizable Hermes data; otherwise `%LOCALAPPDATA%\hermes` (falls back to `%APPDATA%\hermes` when `LOCALAPPDATA` is unavailable)
 - macOS/Linux: `~/.hermes`
 
 The desktop wrapper's own Web UI state is stored separately in

--- a/packages/desktop/src/main/paths.ts
+++ b/packages/desktop/src/main/paths.ts
@@ -1,5 +1,5 @@
 import { app } from 'electron'
-import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
 import { join, relative, resolve } from 'node:path'
 import { homedir, platform } from 'node:os'
 import {
@@ -10,8 +10,6 @@ import {
 import { hermesAgentVersionFromRuntimeTag } from './runtime-version'
 
 const isWin = platform() === 'win32'
-const HERMES_HOME_FILE_MARKERS = ['config.yaml', '.env', 'SOUL.md', 'active_profile'] as const
-const HERMES_HOME_DIRECTORY_MARKERS = ['profiles', 'sessions', 'skills', 'memories', 'cron'] as const
 const DEFAULT_HERMES_AGENT_VERSION = '0.20.6'
 const PACKAGED_RUNTIME_RELEASE_NAME = 'runtime-release.json'
 const ACTIVE_RUNTIME_VERSION_NAME = 'active-version.json'
@@ -457,46 +455,24 @@ export function webUiHome(): string {
   return process.env.HERMES_WEB_UI_HOME?.trim() || resolve(homedir(), '.hermes-web-ui')
 }
 
-function isHermesDataHome(directory: string): boolean {
-  try {
-    if (!statSync(directory).isDirectory()) return false
-  } catch {
-    return false
-  }
-
-  const hasFileMarker = HERMES_HOME_FILE_MARKERS.some((marker) => {
-    try {
-      return statSync(join(directory, marker)).isFile()
-    } catch {
-      return false
-    }
-  })
-  if (hasFileMarker) return true
-
-  return HERMES_HOME_DIRECTORY_MARKERS.some((marker) => {
-    try {
-      return statSync(join(directory, marker)).isDirectory()
-    } catch {
-      return false
-    }
-  })
-}
-
 export function hermesHome(): string {
   const override = process.env.HERMES_HOME?.trim()
   if (override) return resolve(override)
 
-  const userHome = isWin ? process.env.USERPROFILE?.trim() || homedir() : homedir()
-  const defaultHome = resolve(userHome, '.hermes')
+  const defaultHome = resolve(homedir(), '.hermes')
 
   if (isWin) {
-    if (isHermesDataHome(defaultHome)) return defaultHome
+    const candidates = [
+      process.env.LOCALAPPDATA,
+      process.env.APPDATA,
+    ]
+      .map(value => value?.trim())
+      .filter((value): value is string => !!value)
+      .map(value => resolve(value, 'hermes'))
 
-    const localAppData = process.env.LOCALAPPDATA?.trim()
-    if (localAppData) return resolve(localAppData, 'hermes')
-
-    const appData = process.env.APPDATA?.trim()
-    if (appData) return resolve(appData, 'hermes')
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) return candidate
+    }
   }
 
   return defaultHome

--- a/packages/desktop/src/main/paths.ts
+++ b/packages/desktop/src/main/paths.ts
@@ -1,5 +1,5 @@
 import { app } from 'electron'
-import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs'
 import { join, relative, resolve } from 'node:path'
 import { homedir, platform } from 'node:os'
 import {
@@ -10,6 +10,8 @@ import {
 import { hermesAgentVersionFromRuntimeTag } from './runtime-version'
 
 const isWin = platform() === 'win32'
+const HERMES_HOME_FILE_MARKERS = ['config.yaml', '.env', 'SOUL.md', 'active_profile'] as const
+const HERMES_HOME_DIRECTORY_MARKERS = ['profiles', 'sessions', 'skills', 'memories', 'cron'] as const
 const DEFAULT_HERMES_AGENT_VERSION = '0.20.6'
 const PACKAGED_RUNTIME_RELEASE_NAME = 'runtime-release.json'
 const ACTIVE_RUNTIME_VERSION_NAME = 'active-version.json'
@@ -455,24 +457,46 @@ export function webUiHome(): string {
   return process.env.HERMES_WEB_UI_HOME?.trim() || resolve(homedir(), '.hermes-web-ui')
 }
 
+function isHermesDataHome(directory: string): boolean {
+  try {
+    if (!statSync(directory).isDirectory()) return false
+  } catch {
+    return false
+  }
+
+  const hasFileMarker = HERMES_HOME_FILE_MARKERS.some((marker) => {
+    try {
+      return statSync(join(directory, marker)).isFile()
+    } catch {
+      return false
+    }
+  })
+  if (hasFileMarker) return true
+
+  return HERMES_HOME_DIRECTORY_MARKERS.some((marker) => {
+    try {
+      return statSync(join(directory, marker)).isDirectory()
+    } catch {
+      return false
+    }
+  })
+}
+
 export function hermesHome(): string {
   const override = process.env.HERMES_HOME?.trim()
   if (override) return resolve(override)
 
-  const defaultHome = resolve(homedir(), '.hermes')
+  const userHome = isWin ? process.env.USERPROFILE?.trim() || homedir() : homedir()
+  const defaultHome = resolve(userHome, '.hermes')
 
   if (isWin) {
-    const candidates = [
-      process.env.LOCALAPPDATA,
-      process.env.APPDATA,
-    ]
-      .map(value => value?.trim())
-      .filter((value): value is string => !!value)
-      .map(value => resolve(value, 'hermes'))
+    if (isHermesDataHome(defaultHome)) return defaultHome
 
-    for (const candidate of candidates) {
-      if (existsSync(candidate)) return candidate
-    }
+    const localAppData = process.env.LOCALAPPDATA?.trim()
+    if (localAppData) return resolve(localAppData, 'hermes')
+
+    const appData = process.env.APPDATA?.trim()
+    if (appData) return resolve(appData, 'hermes')
   }
 
   return defaultHome

--- a/packages/desktop/src/main/paths.ts
+++ b/packages/desktop/src/main/paths.ts
@@ -1,5 +1,5 @@
 import { app } from 'electron'
-import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
 import { join, relative, resolve } from 'node:path'
 import { homedir, platform } from 'node:os'
 import {
@@ -10,8 +10,6 @@ import {
 import { hermesAgentVersionFromRuntimeTag } from './runtime-version'
 
 const isWin = platform() === 'win32'
-const HERMES_HOME_FILE_MARKERS = ['config.yaml', '.env', 'SOUL.md', 'active_profile'] as const
-const HERMES_HOME_DIRECTORY_MARKERS = ['profiles', 'sessions', 'skills', 'memories', 'cron'] as const
 const DEFAULT_HERMES_AGENT_VERSION = '0.20.6'
 const PACKAGED_RUNTIME_RELEASE_NAME = 'runtime-release.json'
 const ACTIVE_RUNTIME_VERSION_NAME = 'active-version.json'
@@ -457,49 +455,12 @@ export function webUiHome(): string {
   return process.env.HERMES_WEB_UI_HOME?.trim() || resolve(homedir(), '.hermes-web-ui')
 }
 
-function isHermesDataHome(directory: string): boolean {
-  try {
-    if (!statSync(directory).isDirectory()) return false
-  } catch {
-    return false
-  }
-
-  const hasFileMarker = HERMES_HOME_FILE_MARKERS.some((marker) => {
-    try {
-      return statSync(join(directory, marker)).isFile()
-    } catch {
-      return false
-    }
-  })
-  if (hasFileMarker) return true
-
-  return HERMES_HOME_DIRECTORY_MARKERS.some((marker) => {
-    try {
-      return statSync(join(directory, marker)).isDirectory()
-    } catch {
-      return false
-    }
-  })
-}
-
 export function hermesHome(): string {
   const override = process.env.HERMES_HOME?.trim()
   if (override) return resolve(override)
 
   const userHome = isWin ? process.env.USERPROFILE?.trim() || homedir() : homedir()
-  const defaultHome = resolve(userHome, '.hermes')
-
-  if (isWin) {
-    if (isHermesDataHome(defaultHome)) return defaultHome
-
-    const localAppData = process.env.LOCALAPPDATA?.trim()
-    if (localAppData) return resolve(localAppData, 'hermes')
-
-    const appData = process.env.APPDATA?.trim()
-    if (appData) return resolve(appData, 'hermes')
-  }
-
-  return defaultHome
+  return resolve(userHome, '.hermes')
 }
 
 export function tokenFile(): string {

--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -450,9 +450,9 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
     // HERMES_HOME/.env or by configuring per-platform allowlists.
     GATEWAY_ALLOW_ALL_USERS: process.env.GATEWAY_ALLOW_ALL_USERS ?? 'true',
     // Keep the bundled Hermes Agent, bridge, gateway, and Web UI path helpers
-    // on the same data directory. Native Windows uses an existing
-    // %LOCALAPPDATA%\hermes or %APPDATA%\hermes; otherwise all platforms keep
-    // the standard ~/.hermes layout.
+    // on the same data directory. Native Windows prefers a ~/.hermes with
+    // recognizable Hermes data and otherwise uses %LOCALAPPDATA%\hermes (or
+    // %APPDATA%\hermes when LOCALAPPDATA is unavailable).
     HERMES_HOME: agentHome,
     HERMES_WEB_UI_HOME: home,
     HERMES_WEBUI_STATE_DIR: home,

--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -450,9 +450,9 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
     // HERMES_HOME/.env or by configuring per-platform allowlists.
     GATEWAY_ALLOW_ALL_USERS: process.env.GATEWAY_ALLOW_ALL_USERS ?? 'true',
     // Keep the bundled Hermes Agent, bridge, gateway, and Web UI path helpers
-    // on the same data directory. Native Windows prefers a ~/.hermes with
-    // recognizable Hermes data and otherwise uses %LOCALAPPDATA%\hermes (or
-    // %APPDATA%\hermes when LOCALAPPDATA is unavailable).
+    // on the same data directory. Native Windows uses an existing
+    // %LOCALAPPDATA%\hermes or %APPDATA%\hermes; otherwise all platforms keep
+    // the standard ~/.hermes layout.
     HERMES_HOME: agentHome,
     HERMES_WEB_UI_HOME: home,
     HERMES_WEBUI_STATE_DIR: home,

--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -450,9 +450,7 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
     // HERMES_HOME/.env or by configuring per-platform allowlists.
     GATEWAY_ALLOW_ALL_USERS: process.env.GATEWAY_ALLOW_ALL_USERS ?? 'true',
     // Keep the bundled Hermes Agent, bridge, gateway, and Web UI path helpers
-    // on the same data directory. Native Windows prefers a ~/.hermes with
-    // recognizable Hermes data and otherwise uses %LOCALAPPDATA%\hermes (or
-    // %APPDATA%\hermes when LOCALAPPDATA is unavailable).
+    // on the same ~/.hermes data directory on every platform.
     HERMES_HOME: agentHome,
     HERMES_WEB_UI_HOME: home,
     HERMES_WEBUI_STATE_DIR: home,

--- a/packages/ekko-agent/skills/hermes-studio-installation/references/studio.md
+++ b/packages/ekko-agent/skills/hermes-studio-installation/references/studio.md
@@ -93,7 +93,7 @@ For an existing checkout, preserve local changes. Inspect `git status`, update o
 ## Installation-owned paths
 
 - Studio state: `HERMES_WEB_UI_HOME`, default `~/.hermes-web-ui`.
-- Hermes data: `HERMES_HOME`; default `~/.hermes` on macOS/Linux. Windows prefers `~/.hermes` when it contains recognizable Hermes data, then uses `%LOCALAPPDATA%\hermes` (or `%APPDATA%\hermes` when `LOCALAPPDATA` is unavailable).
+- Hermes data: `HERMES_HOME`; default `~/.hermes` on macOS/Linux, and an existing `%LOCALAPPDATA%\hermes` or `%APPDATA%\hermes` on Windows.
 - npm daemon PID, log, token, and database are stored under the Studio home.
 - Docker maps Hermes and Studio state to separate container directories even when both originate below `./hermes_data` on the host.
 

--- a/packages/ekko-agent/skills/hermes-studio-installation/references/studio.md
+++ b/packages/ekko-agent/skills/hermes-studio-installation/references/studio.md
@@ -93,7 +93,7 @@ For an existing checkout, preserve local changes. Inspect `git status`, update o
 ## Installation-owned paths
 
 - Studio state: `HERMES_WEB_UI_HOME`, default `~/.hermes-web-ui`.
-- Hermes data: `HERMES_HOME`; default `~/.hermes` on macOS/Linux, and an existing `%LOCALAPPDATA%\hermes` or `%APPDATA%\hermes` on Windows.
+- Hermes data: `HERMES_HOME`; default `~/.hermes` on macOS/Linux. Windows prefers `~/.hermes` when it contains recognizable Hermes data, then uses `%LOCALAPPDATA%\hermes` (or `%APPDATA%\hermes` when `LOCALAPPDATA` is unavailable).
 - npm daemon PID, log, token, and database are stored under the Studio home.
 - Docker maps Hermes and Studio state to separate container directories even when both originate below `./hermes_data` on the host.
 

--- a/packages/ekko-agent/skills/hermes-studio-installation/references/studio.md
+++ b/packages/ekko-agent/skills/hermes-studio-installation/references/studio.md
@@ -93,7 +93,7 @@ For an existing checkout, preserve local changes. Inspect `git status`, update o
 ## Installation-owned paths
 
 - Studio state: `HERMES_WEB_UI_HOME`, default `~/.hermes-web-ui`.
-- Hermes data: `HERMES_HOME`; default `~/.hermes` on macOS/Linux. Windows prefers `~/.hermes` when it contains recognizable Hermes data, then uses `%LOCALAPPDATA%\hermes` (or `%APPDATA%\hermes` when `LOCALAPPDATA` is unavailable).
+- Hermes data: `HERMES_HOME`; defaults to `~/.hermes` on Windows, macOS, and Linux.
 - npm daemon PID, log, token, and database are stored under the Studio home.
 - Docker maps Hermes and Studio state to separate container directories even when both originate below `./hermes_data` on the host.
 

--- a/packages/server/src/modules/hermes/services/runtime/path.ts
+++ b/packages/server/src/modules/hermes/services/runtime/path.ts
@@ -1,53 +1,20 @@
 /**
  * Hermes 路径检测工具 - 跨平台兼容
  *
- * Hermes 数据目录在不同平台上的位置：
- * - Windows 原生安装: ~/.hermes with recognizable Hermes data, otherwise %LOCALAPPDATA%\hermes
- * - Linux/macOS/WSL2: ~/.hermes
+ * Hermes 数据目录在所有平台上的默认位置：~/.hermes
  * - 用户自定义: HERMES_HOME 环境变量
  */
 
-import { statSync } from 'fs'
 import { realpath } from 'fs/promises'
 import { basename, dirname, isAbsolute, relative, resolve, join, win32 as pathWin32 } from 'path'
 import { homedir } from 'os'
 
-const HERMES_HOME_FILE_MARKERS = ['config.yaml', '.env', 'SOUL.md', 'active_profile'] as const
-const HERMES_HOME_DIRECTORY_MARKERS = ['profiles', 'sessions', 'skills', 'memories', 'cron'] as const
-
-function isHermesDataHome(directory: string): boolean {
-  try {
-    if (!statSync(directory).isDirectory()) return false
-  } catch {
-    return false
-  }
-
-  const hasFileMarker = HERMES_HOME_FILE_MARKERS.some((marker) => {
-    try {
-      return statSync(join(directory, marker)).isFile()
-    } catch {
-      return false
-    }
-  })
-  if (hasFileMarker) return true
-
-  return HERMES_HOME_DIRECTORY_MARKERS.some((marker) => {
-    try {
-      return statSync(join(directory, marker)).isDirectory()
-    } catch {
-      return false
-    }
-  })
-}
-
 /**
- * 智能检测 Hermes 数据目录
+ * 获取 Hermes 数据目录
  *
- * 检测优先级：
+ * 解析优先级：
  * 1. HERMES_HOME 环境变量（用户自定义）
- * 2. Windows: ~/.hermes with recognizable Hermes data
- * 3. Windows: %LOCALAPPDATA%\hermes, or %APPDATA%\hermes when LOCALAPPDATA is unavailable
- * 4. 默认: ~/.hermes（Linux/macOS/WSL2）
+ * 2. 默认: ~/.hermes（Windows/Linux/macOS/WSL2）
  *
  * @returns Hermes 数据目录的绝对路径
  */
@@ -60,21 +27,7 @@ export function detectHermesHome(): string {
   const userHome = process.platform === 'win32'
     ? process.env.USERPROFILE?.trim() || homedir()
     : homedir()
-  const defaultHome = resolve(userHome, '.hermes')
-
-  // 2. Windows：优先复用用户主目录中有 Hermes 标志的 CLI 数据。
-  if (process.platform === 'win32') {
-    if (isHermesDataHome(defaultHome)) return defaultHome
-
-    const localAppData = process.env.LOCALAPPDATA?.trim()
-    if (localAppData) return resolve(localAppData, 'hermes')
-
-    const appData = process.env.APPDATA?.trim()
-    if (appData) return resolve(appData, 'hermes')
-  }
-
-  // 4. Linux/macOS，或 Windows 缺少 AppData 环境变量：~/.hermes
-  return defaultHome
+  return resolve(userHome, '.hermes')
 }
 
 /**

--- a/packages/server/src/modules/hermes/services/runtime/path.ts
+++ b/packages/server/src/modules/hermes/services/runtime/path.ts
@@ -2,52 +2,23 @@
  * Hermes 路径检测工具 - 跨平台兼容
  *
  * Hermes 数据目录在不同平台上的位置：
- * - Windows 原生安装: ~/.hermes with recognizable Hermes data, otherwise %LOCALAPPDATA%\hermes
+ * - Windows 原生安装: %LOCALAPPDATA%\hermes when it exists
  * - Linux/macOS/WSL2: ~/.hermes
  * - 用户自定义: HERMES_HOME 环境变量
  */
 
-import { statSync } from 'fs'
+import { existsSync } from 'fs'
 import { realpath } from 'fs/promises'
 import { basename, dirname, isAbsolute, relative, resolve, join, win32 as pathWin32 } from 'path'
 import { homedir } from 'os'
-
-const HERMES_HOME_FILE_MARKERS = ['config.yaml', '.env', 'SOUL.md', 'active_profile'] as const
-const HERMES_HOME_DIRECTORY_MARKERS = ['profiles', 'sessions', 'skills', 'memories', 'cron'] as const
-
-function isHermesDataHome(directory: string): boolean {
-  try {
-    if (!statSync(directory).isDirectory()) return false
-  } catch {
-    return false
-  }
-
-  const hasFileMarker = HERMES_HOME_FILE_MARKERS.some((marker) => {
-    try {
-      return statSync(join(directory, marker)).isFile()
-    } catch {
-      return false
-    }
-  })
-  if (hasFileMarker) return true
-
-  return HERMES_HOME_DIRECTORY_MARKERS.some((marker) => {
-    try {
-      return statSync(join(directory, marker)).isDirectory()
-    } catch {
-      return false
-    }
-  })
-}
 
 /**
  * 智能检测 Hermes 数据目录
  *
  * 检测优先级：
  * 1. HERMES_HOME 环境变量（用户自定义）
- * 2. Windows: ~/.hermes with recognizable Hermes data
- * 3. Windows: %LOCALAPPDATA%\hermes, or %APPDATA%\hermes when LOCALAPPDATA is unavailable
- * 4. 默认: ~/.hermes（Linux/macOS/WSL2）
+ * 2. Windows: existing %LOCALAPPDATA%\hermes or %APPDATA%\hermes
+ * 3. 默认: ~/.hermes（Linux/macOS/WSL2）
  *
  * @returns Hermes 数据目录的绝对路径
  */
@@ -57,23 +28,24 @@ export function detectHermesHome(): string {
     return resolve(process.env.HERMES_HOME)
   }
 
-  const userHome = process.platform === 'win32'
-    ? process.env.USERPROFILE?.trim() || homedir()
-    : homedir()
-  const defaultHome = resolve(userHome, '.hermes')
+  const defaultHome = resolve(homedir(), '.hermes')
 
-  // 2. Windows：优先复用用户主目录中有 Hermes 标志的 CLI 数据。
+  // 2. Windows：优先使用存在的原生安装数据目录；不存在时回退到 ~/.hermes。
   if (process.platform === 'win32') {
-    if (isHermesDataHome(defaultHome)) return defaultHome
+    const candidates = [
+      process.env.LOCALAPPDATA,
+      process.env.APPDATA,
+    ]
+      .map(value => value?.trim())
+      .filter((value): value is string => !!value)
+      .map(value => resolve(value, 'hermes'))
 
-    const localAppData = process.env.LOCALAPPDATA?.trim()
-    if (localAppData) return resolve(localAppData, 'hermes')
-
-    const appData = process.env.APPDATA?.trim()
-    if (appData) return resolve(appData, 'hermes')
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) return candidate
+    }
   }
 
-  // 4. Linux/macOS，或 Windows 缺少 AppData 环境变量：~/.hermes
+  // 3. Linux/macOS：~/.hermes
   return defaultHome
 }
 

--- a/packages/server/src/modules/hermes/services/runtime/path.ts
+++ b/packages/server/src/modules/hermes/services/runtime/path.ts
@@ -2,23 +2,52 @@
  * Hermes 路径检测工具 - 跨平台兼容
  *
  * Hermes 数据目录在不同平台上的位置：
- * - Windows 原生安装: %LOCALAPPDATA%\hermes when it exists
+ * - Windows 原生安装: ~/.hermes with recognizable Hermes data, otherwise %LOCALAPPDATA%\hermes
  * - Linux/macOS/WSL2: ~/.hermes
  * - 用户自定义: HERMES_HOME 环境变量
  */
 
-import { existsSync } from 'fs'
+import { statSync } from 'fs'
 import { realpath } from 'fs/promises'
 import { basename, dirname, isAbsolute, relative, resolve, join, win32 as pathWin32 } from 'path'
 import { homedir } from 'os'
+
+const HERMES_HOME_FILE_MARKERS = ['config.yaml', '.env', 'SOUL.md', 'active_profile'] as const
+const HERMES_HOME_DIRECTORY_MARKERS = ['profiles', 'sessions', 'skills', 'memories', 'cron'] as const
+
+function isHermesDataHome(directory: string): boolean {
+  try {
+    if (!statSync(directory).isDirectory()) return false
+  } catch {
+    return false
+  }
+
+  const hasFileMarker = HERMES_HOME_FILE_MARKERS.some((marker) => {
+    try {
+      return statSync(join(directory, marker)).isFile()
+    } catch {
+      return false
+    }
+  })
+  if (hasFileMarker) return true
+
+  return HERMES_HOME_DIRECTORY_MARKERS.some((marker) => {
+    try {
+      return statSync(join(directory, marker)).isDirectory()
+    } catch {
+      return false
+    }
+  })
+}
 
 /**
  * 智能检测 Hermes 数据目录
  *
  * 检测优先级：
  * 1. HERMES_HOME 环境变量（用户自定义）
- * 2. Windows: existing %LOCALAPPDATA%\hermes or %APPDATA%\hermes
- * 3. 默认: ~/.hermes（Linux/macOS/WSL2）
+ * 2. Windows: ~/.hermes with recognizable Hermes data
+ * 3. Windows: %LOCALAPPDATA%\hermes, or %APPDATA%\hermes when LOCALAPPDATA is unavailable
+ * 4. 默认: ~/.hermes（Linux/macOS/WSL2）
  *
  * @returns Hermes 数据目录的绝对路径
  */
@@ -28,24 +57,23 @@ export function detectHermesHome(): string {
     return resolve(process.env.HERMES_HOME)
   }
 
-  const defaultHome = resolve(homedir(), '.hermes')
+  const userHome = process.platform === 'win32'
+    ? process.env.USERPROFILE?.trim() || homedir()
+    : homedir()
+  const defaultHome = resolve(userHome, '.hermes')
 
-  // 2. Windows：优先使用存在的原生安装数据目录；不存在时回退到 ~/.hermes。
+  // 2. Windows：优先复用用户主目录中有 Hermes 标志的 CLI 数据。
   if (process.platform === 'win32') {
-    const candidates = [
-      process.env.LOCALAPPDATA,
-      process.env.APPDATA,
-    ]
-      .map(value => value?.trim())
-      .filter((value): value is string => !!value)
-      .map(value => resolve(value, 'hermes'))
+    if (isHermesDataHome(defaultHome)) return defaultHome
 
-    for (const candidate of candidates) {
-      if (existsSync(candidate)) return candidate
-    }
+    const localAppData = process.env.LOCALAPPDATA?.trim()
+    if (localAppData) return resolve(localAppData, 'hermes')
+
+    const appData = process.env.APPDATA?.trim()
+    if (appData) return resolve(appData, 'hermes')
   }
 
-  // 3. Linux/macOS：~/.hermes
+  // 4. Linux/macOS，或 Windows 缺少 AppData 环境变量：~/.hermes
   return defaultHome
 }
 

--- a/tests/server/hermes-path.test.ts
+++ b/tests/server/hermes-path.test.ts
@@ -1,5 +1,5 @@
-import { mkdirSync, mkdtempSync, rmSync } from 'fs'
-import { homedir, tmpdir } from 'os'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
 import { join, resolve } from 'path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { detectHermesHome } from '../../packages/server/src/modules/hermes/services/runtime/path'
@@ -12,6 +12,7 @@ describe('Hermes path detection', () => {
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'hermes-path-'))
     process.env = { ...originalEnv }
+    process.env.USERPROFILE = join(tempDir, 'User')
     delete process.env.HERMES_HOME
     delete process.env.LOCALAPPDATA
     delete process.env.APPDATA
@@ -30,32 +31,67 @@ describe('Hermes path detection', () => {
     expect(detectHermesHome()).toBe(resolve(tempDir, 'custom-home'))
   })
 
-  it('falls back to ~/.hermes on Windows when LOCALAPPDATA hermes is missing', () => {
+  it('uses ~/.hermes with a Hermes config before LOCALAPPDATA and APPDATA', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
+    const userHermes = join(process.env.USERPROFILE!, '.hermes')
+    mkdirSync(userHermes, { recursive: true })
+    writeFileSync(join(userHermes, 'config.yaml'), 'model: test\n')
     process.env.LOCALAPPDATA = join(tempDir, 'Local')
+    process.env.APPDATA = join(tempDir, 'Roaming')
 
-    expect(detectHermesHome()).toBe(resolve(homedir(), '.hermes'))
+    expect(detectHermesHome()).toBe(resolve(userHermes))
   })
 
-  it('uses existing Windows LOCALAPPDATA hermes before APPDATA', () => {
+  it('uses a legacy ~/.hermes with a known data directory', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    const userHermes = join(process.env.USERPROFILE!, '.hermes')
+    mkdirSync(join(userHermes, 'sessions'), { recursive: true })
+    process.env.LOCALAPPDATA = join(tempDir, 'Local')
+
+    expect(detectHermesHome()).toBe(resolve(userHermes))
+  })
+
+  it('ignores an empty ~/.hermes directory', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    const userHermes = join(process.env.USERPROFILE!, '.hermes')
+    const localHermes = join(tempDir, 'Local', 'hermes')
+    mkdirSync(userHermes, { recursive: true })
+    process.env.LOCALAPPDATA = join(tempDir, 'Local')
+
+    expect(detectHermesHome()).toBe(resolve(localHermes))
+  })
+
+  it('ignores ~/.hermes with unrelated entries or marker names of the wrong type', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    const userHermes = join(process.env.USERPROFILE!, '.hermes')
+    const localHermes = join(tempDir, 'Local', 'hermes')
+    mkdirSync(join(userHermes, 'config.yaml'), { recursive: true })
+    writeFileSync(join(userHermes, 'notes.txt'), 'not Hermes data\n')
+    process.env.LOCALAPPDATA = join(tempDir, 'Local')
+
+    expect(detectHermesHome()).toBe(resolve(localHermes))
+  })
+
+  it('falls back to Windows LOCALAPPDATA when ~/.hermes is missing', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
     const localHermes = join(tempDir, 'Local', 'hermes')
-    const roamingHermes = join(tempDir, 'Roaming', 'hermes')
-    mkdirSync(localHermes, { recursive: true })
-    mkdirSync(roamingHermes, { recursive: true })
     process.env.LOCALAPPDATA = join(tempDir, 'Local')
     process.env.APPDATA = join(tempDir, 'Roaming')
 
     expect(detectHermesHome()).toBe(resolve(localHermes))
   })
 
-  it('falls back to existing Windows APPDATA hermes when LOCALAPPDATA hermes is missing', () => {
+  it('falls back to Windows APPDATA when LOCALAPPDATA is unavailable', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
     const roamingHermes = join(tempDir, 'Roaming', 'hermes')
-    mkdirSync(roamingHermes, { recursive: true })
-    process.env.LOCALAPPDATA = join(tempDir, 'Local')
     process.env.APPDATA = join(tempDir, 'Roaming')
 
     expect(detectHermesHome()).toBe(resolve(roamingHermes))
+  })
+
+  it('uses ~/.hermes on Windows when AppData environment variables are unavailable', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    expect(detectHermesHome()).toBe(resolve(process.env.USERPROFILE!, '.hermes'))
   })
 })

--- a/tests/server/hermes-path.test.ts
+++ b/tests/server/hermes-path.test.ts
@@ -1,5 +1,5 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
-import { tmpdir } from 'os'
+import { mkdirSync, mkdtempSync, rmSync } from 'fs'
+import { homedir, tmpdir } from 'os'
 import { join, resolve } from 'path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { detectHermesHome } from '../../packages/server/src/modules/hermes/services/runtime/path'
@@ -12,7 +12,6 @@ describe('Hermes path detection', () => {
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'hermes-path-'))
     process.env = { ...originalEnv }
-    process.env.USERPROFILE = join(tempDir, 'User')
     delete process.env.HERMES_HOME
     delete process.env.LOCALAPPDATA
     delete process.env.APPDATA
@@ -31,67 +30,32 @@ describe('Hermes path detection', () => {
     expect(detectHermesHome()).toBe(resolve(tempDir, 'custom-home'))
   })
 
-  it('uses ~/.hermes with a Hermes config before LOCALAPPDATA and APPDATA', () => {
+  it('falls back to ~/.hermes on Windows when LOCALAPPDATA hermes is missing', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
-    const userHermes = join(process.env.USERPROFILE!, '.hermes')
-    mkdirSync(userHermes, { recursive: true })
-    writeFileSync(join(userHermes, 'config.yaml'), 'model: test\n')
-    process.env.LOCALAPPDATA = join(tempDir, 'Local')
-    process.env.APPDATA = join(tempDir, 'Roaming')
-
-    expect(detectHermesHome()).toBe(resolve(userHermes))
-  })
-
-  it('uses a legacy ~/.hermes with a known data directory', () => {
-    Object.defineProperty(process, 'platform', { value: 'win32' })
-    const userHermes = join(process.env.USERPROFILE!, '.hermes')
-    mkdirSync(join(userHermes, 'sessions'), { recursive: true })
     process.env.LOCALAPPDATA = join(tempDir, 'Local')
 
-    expect(detectHermesHome()).toBe(resolve(userHermes))
+    expect(detectHermesHome()).toBe(resolve(homedir(), '.hermes'))
   })
 
-  it('ignores an empty ~/.hermes directory', () => {
-    Object.defineProperty(process, 'platform', { value: 'win32' })
-    const userHermes = join(process.env.USERPROFILE!, '.hermes')
-    const localHermes = join(tempDir, 'Local', 'hermes')
-    mkdirSync(userHermes, { recursive: true })
-    process.env.LOCALAPPDATA = join(tempDir, 'Local')
-
-    expect(detectHermesHome()).toBe(resolve(localHermes))
-  })
-
-  it('ignores ~/.hermes with unrelated entries or marker names of the wrong type', () => {
-    Object.defineProperty(process, 'platform', { value: 'win32' })
-    const userHermes = join(process.env.USERPROFILE!, '.hermes')
-    const localHermes = join(tempDir, 'Local', 'hermes')
-    mkdirSync(join(userHermes, 'config.yaml'), { recursive: true })
-    writeFileSync(join(userHermes, 'notes.txt'), 'not Hermes data\n')
-    process.env.LOCALAPPDATA = join(tempDir, 'Local')
-
-    expect(detectHermesHome()).toBe(resolve(localHermes))
-  })
-
-  it('falls back to Windows LOCALAPPDATA when ~/.hermes is missing', () => {
+  it('uses existing Windows LOCALAPPDATA hermes before APPDATA', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
     const localHermes = join(tempDir, 'Local', 'hermes')
+    const roamingHermes = join(tempDir, 'Roaming', 'hermes')
+    mkdirSync(localHermes, { recursive: true })
+    mkdirSync(roamingHermes, { recursive: true })
     process.env.LOCALAPPDATA = join(tempDir, 'Local')
     process.env.APPDATA = join(tempDir, 'Roaming')
 
     expect(detectHermesHome()).toBe(resolve(localHermes))
   })
 
-  it('falls back to Windows APPDATA when LOCALAPPDATA is unavailable', () => {
+  it('falls back to existing Windows APPDATA hermes when LOCALAPPDATA hermes is missing', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
     const roamingHermes = join(tempDir, 'Roaming', 'hermes')
+    mkdirSync(roamingHermes, { recursive: true })
+    process.env.LOCALAPPDATA = join(tempDir, 'Local')
     process.env.APPDATA = join(tempDir, 'Roaming')
 
     expect(detectHermesHome()).toBe(resolve(roamingHermes))
-  })
-
-  it('uses ~/.hermes on Windows when AppData environment variables are unavailable', () => {
-    Object.defineProperty(process, 'platform', { value: 'win32' })
-
-    expect(detectHermesHome()).toBe(resolve(process.env.USERPROFILE!, '.hermes'))
   })
 })

--- a/tests/server/hermes-path.test.ts
+++ b/tests/server/hermes-path.test.ts
@@ -1,5 +1,5 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
-import { tmpdir } from 'os'
+import { mkdirSync, mkdtempSync, rmSync } from 'fs'
+import { homedir, tmpdir } from 'os'
 import { join, resolve } from 'path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { detectHermesHome } from '../../packages/server/src/modules/hermes/services/runtime/path'
@@ -31,67 +31,34 @@ describe('Hermes path detection', () => {
     expect(detectHermesHome()).toBe(resolve(tempDir, 'custom-home'))
   })
 
-  it('uses ~/.hermes with a Hermes config before LOCALAPPDATA and APPDATA', () => {
+  it('always uses USERPROFILE/.hermes on Windows even when AppData Hermes directories exist', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
     const userHermes = join(process.env.USERPROFILE!, '.hermes')
-    mkdirSync(userHermes, { recursive: true })
-    writeFileSync(join(userHermes, 'config.yaml'), 'model: test\n')
     process.env.LOCALAPPDATA = join(tempDir, 'Local')
     process.env.APPDATA = join(tempDir, 'Roaming')
+    mkdirSync(join(process.env.LOCALAPPDATA, 'hermes'), { recursive: true })
+    mkdirSync(join(process.env.APPDATA, 'hermes'), { recursive: true })
 
     expect(detectHermesHome()).toBe(resolve(userHermes))
   })
 
-  it('uses a legacy ~/.hermes with a known data directory', () => {
+  it('uses USERPROFILE/.hermes on Windows even when the directory does not exist', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
     const userHermes = join(process.env.USERPROFILE!, '.hermes')
-    mkdirSync(join(userHermes, 'sessions'), { recursive: true })
-    process.env.LOCALAPPDATA = join(tempDir, 'Local')
 
     expect(detectHermesHome()).toBe(resolve(userHermes))
   })
 
-  it('ignores an empty ~/.hermes directory', () => {
+  it('falls back to the OS home on Windows when USERPROFILE is blank', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
-    const userHermes = join(process.env.USERPROFILE!, '.hermes')
-    const localHermes = join(tempDir, 'Local', 'hermes')
-    mkdirSync(userHermes, { recursive: true })
-    process.env.LOCALAPPDATA = join(tempDir, 'Local')
+    process.env.USERPROFILE = '   '
 
-    expect(detectHermesHome()).toBe(resolve(localHermes))
+    expect(detectHermesHome()).toBe(resolve(homedir(), '.hermes'))
   })
 
-  it('ignores ~/.hermes with unrelated entries or marker names of the wrong type', () => {
-    Object.defineProperty(process, 'platform', { value: 'win32' })
-    const userHermes = join(process.env.USERPROFILE!, '.hermes')
-    const localHermes = join(tempDir, 'Local', 'hermes')
-    mkdirSync(join(userHermes, 'config.yaml'), { recursive: true })
-    writeFileSync(join(userHermes, 'notes.txt'), 'not Hermes data\n')
-    process.env.LOCALAPPDATA = join(tempDir, 'Local')
+  it('uses the OS home on non-Windows platforms', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' })
 
-    expect(detectHermesHome()).toBe(resolve(localHermes))
-  })
-
-  it('falls back to Windows LOCALAPPDATA when ~/.hermes is missing', () => {
-    Object.defineProperty(process, 'platform', { value: 'win32' })
-    const localHermes = join(tempDir, 'Local', 'hermes')
-    process.env.LOCALAPPDATA = join(tempDir, 'Local')
-    process.env.APPDATA = join(tempDir, 'Roaming')
-
-    expect(detectHermesHome()).toBe(resolve(localHermes))
-  })
-
-  it('falls back to Windows APPDATA when LOCALAPPDATA is unavailable', () => {
-    Object.defineProperty(process, 'platform', { value: 'win32' })
-    const roamingHermes = join(tempDir, 'Roaming', 'hermes')
-    process.env.APPDATA = join(tempDir, 'Roaming')
-
-    expect(detectHermesHome()).toBe(resolve(roamingHermes))
-  })
-
-  it('uses ~/.hermes on Windows when AppData environment variables are unavailable', () => {
-    Object.defineProperty(process, 'platform', { value: 'win32' })
-
-    expect(detectHermesHome()).toBe(resolve(process.env.USERPROFILE!, '.hermes'))
+    expect(detectHermesHome()).toBe(resolve(homedir(), '.hermes'))
   })
 })


### PR DESCRIPTION
## Summary
- use `%USERPROFILE%\.hermes` for both the user Hermes CLI and the Studio-managed Runtime on Windows
- remove `%LOCALAPPDATA%` / `%APPDATA%` probing and Hermes marker detection
- keep an explicit `HERMES_HOME` override as the highest priority
- align desktop/server resolution, documentation, and focused tests

## Validation
- `npm run test -- tests/server/hermes-path.test.ts`
- `npm run harness:check`
- `npm run build`