### PR TITLE
fix: recover Windows startup and invalid Ekko tool calls

### DIFF
--- a/packages/ekko-agent/src/directories.ts
+++ b/packages/ekko-agent/src/directories.ts
@@ -23,6 +23,7 @@ const BUILTIN_SKILL_MANIFEST_FILENAME = '.ekko-builtin-skills.json'
 const BUILTIN_SKILL_MANIFEST_OWNER = 'ekko-agent'
 const BUILTIN_SKILL_HASH_IGNORED_FILENAMES = new Set(['.DS_Store', 'Thumbs.db'])
 const LEGACY_HERMES_SKILL_CLEANUP_FILENAME = '.ekko-hermes-skill-cleanup-v2.json'
+const SKILL_RESET_QUARANTINE_PREFIX = '.ekko-skills-reset-'
 
 interface BuiltinSkillManifestEntry {
   owner?: string
@@ -82,6 +83,7 @@ export class EkkoDirectoryManager {
   initialize(options: EkkoDirectoryInitializationOptions = {}): EkkoDirectoryLayout {
     this.builtinSkills = EkkoBuiltinSkillSynchronizer.createDefault()
     this.initializeConfigDirectory()
+    this.cleanupSkillResetQuarantines()
     if (options.hermesRootDirectory) {
       this.resetLegacySkillsDirectory(options.hermesRootDirectory)
     } else {
@@ -189,12 +191,14 @@ export class EkkoDirectoryManager {
       throw new Error('Bundled Ekko Skills are unavailable; refusing to reset the existing Skill directory')
     }
     const profiles = new Set(['default', ...this.profileNames()])
-    rmSync(this.skillsDirectory, {
-      recursive: true,
-      force: true,
-      maxRetries: 5,
-      retryDelay: 200,
-    })
+    if (!this.quarantineSkillsDirectoryForReset()) {
+      // A Windows process can temporarily deny both deletion and rename. Keep
+      // Ekko available for this run and retry the full reset next startup; no
+      // migration marker is written until the old directory is detached.
+      for (const profile of profiles) this.profileSkillsDirectory(profile)
+      return
+    }
+
     mkdirSync(this.skillsDirectory, { recursive: true })
     for (const profile of profiles) this.profileSkillsDirectory(profile)
     const marker = `${JSON.stringify({
@@ -212,7 +216,68 @@ export class EkkoDirectoryManager {
       } catch {
         // Preserve the marker write failure that caused the cleanup attempt.
       }
-      throw error
+      // The marker is only an optimization that prevents repeating this safe,
+      // idempotent migration. Failure to persist it must not make Ekko
+      // unavailable when its config/database directories remain usable.
+      console.warn(
+        `[ekko-agent] failed to persist legacy Skill migration marker at ${cleanupPath}: ` +
+        `${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+  }
+
+  /**
+   * Atomically removes the complete active Skills tree before recreating it.
+   * Deleting the detached tree is best-effort because Windows scanners can
+   * keep individual files open even after the active path has been reset.
+   */
+  private quarantineSkillsDirectoryForReset(): boolean {
+    if (!existsSync(this.skillsDirectory)) return true
+    const quarantineDirectory = join(
+      this.rootDirectory,
+      `${SKILL_RESET_QUARANTINE_PREFIX}${randomUUID()}`,
+    )
+    try {
+      renameSync(this.skillsDirectory, quarantineDirectory)
+    } catch (error) {
+      if (!isTransientWindowsFilesystemError(error)) throw error
+      console.warn(
+        `[ekko-agent] Skill reset was deferred because Windows denied access to ${this.skillsDirectory}: ` +
+        `${error instanceof Error ? error.message : String(error)}`,
+      )
+      return false
+    }
+
+    this.removeSkillResetQuarantine(quarantineDirectory)
+    return true
+  }
+
+  private cleanupSkillResetQuarantines(): void {
+    let entries
+    try {
+      entries = readdirSync(this.rootDirectory, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() || !entry.name.startsWith(SKILL_RESET_QUARANTINE_PREFIX)) continue
+      this.removeSkillResetQuarantine(join(this.rootDirectory, entry.name))
+    }
+  }
+
+  private removeSkillResetQuarantine(directory: string): void {
+    try {
+      rmSync(directory, {
+        recursive: true,
+        force: true,
+        maxRetries: 5,
+        retryDelay: 200,
+      })
+    } catch (error) {
+      console.warn(
+        `[ekko-agent] detached legacy Skill directory will be cleaned on a later startup (${directory}): ` +
+        `${error instanceof Error ? error.message : String(error)}`,
+      )
     }
   }
 }
@@ -432,4 +497,9 @@ function isPlainDirectory(path: string): boolean {
 
 function isErrorWithCode(error: unknown, code: string): error is NodeJS.ErrnoException {
   return error instanceof Error && 'code' in error && error.code === code
+}
+
+function isTransientWindowsFilesystemError(error: unknown): boolean {
+  if (process.platform !== 'win32' || !(error instanceof Error) || !('code' in error)) return false
+  return ['EACCES', 'EBUSY', 'EPERM'].includes(String(error.code))
 }

--- a/packages/ekko-agent/src/model/providers/openai-compatible.ts
+++ b/packages/ekko-agent/src/model/providers/openai-compatible.ts
@@ -239,10 +239,17 @@ export class OpenAICompatibleModelClient implements ModelClient {
           }
 
           if (choice.finish_reason === 'tool_calls') {
+            let validToolCalls = 0
             for (const toolCall of toolCalls.values()) {
-              yield { type: 'tool-call', toolCall: normalizeToolCall(toolCall.id, toolCall.name, toolCall.argumentsText) }
+              const normalized = normalizeToolCall(toolCall.id, toolCall.name, toolCall.argumentsText)
+              if (!normalized) continue
+              validToolCalls += 1
+              yield { type: 'tool-call', toolCall: normalized }
             }
             toolCalls.clear()
+            if (validToolCalls === 0) {
+              throw invalidOpenAIToolCallError(this.provider)
+            }
           }
         }
       }
@@ -366,9 +373,10 @@ export function toOpenAIChatPayload(config: ModelProviderConfig, request: ModelR
   )
   const supportsToolChoice = supportsOpenAIChatToolChoice(model)
   const tools = request.tools?.length ? request.tools.map(toOpenAIToolDefinition) : undefined
+  const messages = sanitizeOpenAIChatToolHistory(request.messages)
   return {
     model,
-    messages: request.messages.flatMap(message =>
+    messages: messages.flatMap(message =>
       toOpenAIChatMessages(message, isQwenOAuth, reasoningReplayField, requiresAssistantContent, supportsVision)),
     temperature: request.temperature,
     max_tokens: request.maxTokens,
@@ -403,6 +411,10 @@ export function normalizeOpenAIChatResponse(provider: string, response: OpenAICh
   }
 
   const choice = response.choices?.[0]
+  const toolCalls = normalizeOpenAIToolCalls(choice?.message?.tool_calls)
+  if (choice?.finish_reason === 'tool_calls' && !toolCalls?.length) {
+    throw invalidOpenAIToolCallError(provider)
+  }
   return {
     id: response.id,
     model: response.model,
@@ -411,7 +423,7 @@ export function normalizeOpenAIChatResponse(provider: string, response: OpenAICh
       normalizeReasoning(choice?.message),
       openAIReasoningDetails(choice?.message?.reasoning_details),
     ),
-    toolCalls: choice?.message?.tool_calls?.map(toAgentToolCall),
+    toolCalls,
     usage: response.usage ? normalizeUsage(response.usage) : undefined,
     finishReason: choice?.finish_reason ?? undefined,
     raw: response,
@@ -608,16 +620,113 @@ function toOpenAIToolCall(toolCall: AgentToolCall): OpenAIToolCall {
   }
 }
 
-function toAgentToolCall(toolCall: OpenAIToolCall): AgentToolCall {
-  return normalizeToolCall(toolCall.id, toolCall.function.name, toolCall.function.arguments)
+function toAgentToolCall(toolCall: OpenAIToolCall): AgentToolCall | null {
+  return normalizeToolCall(
+    toolCall?.id,
+    toolCall?.function?.name,
+    toolCall?.function?.arguments,
+  )
 }
 
-function normalizeToolCall(id: string, name: string, argumentsText: string): AgentToolCall {
-  const parsedArguments = parseJson<unknown>(argumentsText)
+function normalizeToolCall(id: unknown, name: unknown, argumentsText: unknown): AgentToolCall | null {
+  const normalizedId = String(id || '').trim()
+  const normalizedName = String(name || '').trim()
+  if (!normalizedId || !normalizedName) return null
+  const normalizedArgumentsText = String(argumentsText || '').trim() || '{}'
+  const parsedArguments = parseJson<unknown>(normalizedArgumentsText)
   if (isPlainRecord(parsedArguments)) {
-    return { id, name, arguments: parsedArguments, rawArguments: argumentsText }
+    return {
+      id: normalizedId,
+      name: normalizedName,
+      arguments: parsedArguments,
+      rawArguments: normalizedArgumentsText,
+    }
   }
-  return { id, name, arguments: {}, rawArguments: argumentsText }
+  return {
+    id: normalizedId,
+    name: normalizedName,
+    arguments: {},
+    rawArguments: normalizedArgumentsText,
+  }
+}
+
+function normalizeOpenAIToolCalls(toolCalls: OpenAIToolCall[] | undefined): AgentToolCall[] | undefined {
+  const normalized = (toolCalls ?? [])
+    .map(toAgentToolCall)
+    .filter((toolCall): toolCall is AgentToolCall => !!toolCall)
+  return normalized.length ? normalized : undefined
+}
+
+function invalidOpenAIToolCallError(provider: string): ModelProviderError {
+  return new ModelProviderError(
+    'Model provider returned tool_calls without a complete id and function name.',
+    {
+      provider,
+      retryable: true,
+      details: { reason: 'invalid_tool_call' },
+    },
+  )
+}
+
+function sanitizeOpenAIChatToolHistory(messages: AgentMessage[]): AgentMessage[] {
+  const invalidToolCallIds = new Set<string>()
+  let invalidAnonymousToolCall = false
+  const sanitized: AgentMessage[] = []
+
+  for (const message of messages) {
+    if (message.role === 'assistant' && message.toolCalls?.length) {
+      const toolCalls: AgentToolCall[] = []
+      for (const toolCall of message.toolCalls) {
+        const normalized = normalizeAgentToolCall(toolCall)
+        if (normalized) {
+          toolCalls.push(normalized)
+          continue
+        }
+        const invalidId = String(toolCall?.id || '').trim()
+        if (invalidId) invalidToolCallIds.add(invalidId)
+        else invalidAnonymousToolCall = true
+      }
+      if (
+        toolCalls.length === 0 &&
+        !message.content.trim() &&
+        !agentReasoningText(message.reasoning).trim() &&
+        !message.reasoning?.native
+      ) continue
+      sanitized.push({
+        ...message,
+        toolCalls: toolCalls.length ? toolCalls : undefined,
+      })
+      continue
+    }
+
+    if (message.role === 'tool') {
+      const toolCallId = String(message.toolCallId || '').trim()
+      if (toolCallId && invalidToolCallIds.has(toolCallId)) continue
+      if (!toolCallId && invalidAnonymousToolCall) {
+        invalidAnonymousToolCall = false
+        continue
+      }
+      sanitized.push(toolCallId ? { ...message, toolCallId } : message)
+      continue
+    }
+
+    sanitized.push(message)
+  }
+
+  return sanitized
+}
+
+function normalizeAgentToolCall(toolCall: AgentToolCall): AgentToolCall | null {
+  const id = String(toolCall?.id || '').trim()
+  const name = String(toolCall?.name || '').trim()
+  if (!id || !name) return null
+  return {
+    ...toolCall,
+    id,
+    name,
+    arguments: isPlainRecord(toolCall.arguments) ? toolCall.arguments : {},
+    rawArguments: String(toolCall.rawArguments || '').trim() || '{}',
+  }
 }
 
 function normalizeContent(content: OpenAIMessageContent): string {

--- a/packages/server/src/modules/hermes/services/runtime/process.ts
+++ b/packages/server/src/modules/hermes/services/runtime/process.ts
@@ -2,6 +2,10 @@ import { execFile, spawn } from 'child_process'
 import type { ChildProcess, ExecFileOptions, SpawnOptions } from 'child_process'
 import { existsSync } from 'fs'
 import { basename, dirname, resolve } from 'path'
+import {
+  windowsCmdShimExecution,
+  windowsCommandNeedsShell,
+} from '../../../studio/public/windows-command'
 
 export interface HermesInvocation {
   command: string
@@ -47,11 +51,21 @@ export function execHermesWithBin(
   options?: ExecFileOptions,
 ): Promise<HermesExecResult> {
   const invocation = resolveHermesInvocation(hermesBin)
+  const invocationArgs = [...invocation.argsPrefix, ...args]
+  const execution = process.platform === 'win32' && windowsCommandNeedsShell(invocation.command)
+    ? windowsCmdShimExecution(invocation.command, invocationArgs)
+    : { command: invocation.command, args: invocationArgs }
   return new Promise((resolveExec, rejectExec) => {
     execFile(
-      invocation.command,
-      [...invocation.argsPrefix, ...args],
-      { ...withWindowsHide(options), encoding: 'utf8' },
+      execution.command,
+      execution.args,
+      {
+        ...withWindowsHide(options),
+        encoding: 'utf8',
+        ...('windowsVerbatimArguments' in execution
+          ? { windowsVerbatimArguments: execution.windowsVerbatimArguments }
+          : {}),
+      },
       (error, stdout, stderr) => {
         if (error) {
           rejectExec(Object.assign(error, { stdout, stderr }))
@@ -73,7 +87,16 @@ export function spawnHermesWithBin(
   options?: SpawnOptions,
 ): ChildProcess {
   const invocation = resolveHermesInvocation(hermesBin)
-  return spawn(invocation.command, [...invocation.argsPrefix, ...args], withWindowsHide(options))
+  const invocationArgs = [...invocation.argsPrefix, ...args]
+  const execution = process.platform === 'win32' && windowsCommandNeedsShell(invocation.command)
+    ? windowsCmdShimExecution(invocation.command, invocationArgs)
+    : { command: invocation.command, args: invocationArgs }
+  return spawn(execution.command, execution.args, {
+    ...withWindowsHide(options),
+    ...('windowsVerbatimArguments' in execution
+      ? { windowsVerbatimArguments: execution.windowsVerbatimArguments }
+      : {}),
+  })
 }
 
 export function spawnHermes(args: readonly string[], options?: SpawnOptions): ChildProcess {

--- a/tests/ekko-agent/model-request.test.ts
+++ b/tests/ekko-agent/model-request.test.ts
@@ -90,6 +90,90 @@ describe('ekko-agent model requests', () => {
     ]))
   })
 
+  it('retries a streamed response whose tool call has an empty function name', async () => {
+    const encoder = new TextEncoder()
+    let call = 0
+    const fetchMock = vi.fn(async () => {
+      call += 1
+      const frames = call === 1
+        ? [
+            'data: {"id":"chatcmpl_invalid","choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_invalid","type":"function","function":{"name":"","arguments":""}}]},"finish_reason":"tool_calls"}]}\n\n',
+            'data: [DONE]\n\n',
+          ]
+        : [
+            'data: {"id":"chatcmpl_recovered","choices":[{"delta":{"content":"Recovered"},"finish_reason":"stop"}]}\n\n',
+            'data: [DONE]\n\n',
+          ]
+      return new Response(new ReadableStream({
+        start(controller) {
+          for (const frame of frames) controller.enqueue(encoder.encode(frame))
+          controller.close()
+        },
+      }), { status: 200 })
+    })
+    const client = createModelClient(providerConfig, { fetch: fetchMock })
+    const runtime = new AgentRuntime({ modelClient: client })
+
+    const result = await runtime.run({ messages: ['Answer without an empty tool call.'] })
+
+    expect(result.output.content).toBe('Recovered')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(result.events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'model.retry',
+        error: expect.stringContaining('complete id and function name'),
+      }),
+    ]))
+  })
+
+  it('filters invalid Chat tool history and its orphaned tool result', () => {
+    const payload = toOpenAIChatPayload(providerConfig, {
+      messages: [
+        { role: 'user', content: 'Check the weather.' },
+        {
+          role: 'assistant',
+          content: '',
+          toolCalls: [{ id: 'call_invalid', name: '', arguments: {} }],
+        },
+        {
+          role: 'tool',
+          content: 'orphaned result',
+          toolCallId: 'call_invalid',
+          name: '',
+        },
+        { role: 'user', content: 'Try again.' },
+      ],
+      tools: [{ name: 'weather', parameters: { type: 'object' } }],
+    })
+
+    expect(payload.messages).toEqual([
+      expect.objectContaining({ role: 'user', content: 'Check the weather.' }),
+      expect.objectContaining({ role: 'user', content: 'Try again.' }),
+    ])
+  })
+
+  it('normalizes empty Chat tool arguments and drops incomplete parallel calls', () => {
+    const response = normalizeOpenAIChatResponse('deepseek', {
+      choices: [{
+        message: {
+          content: '',
+          tool_calls: [
+            { id: 'call_valid', type: 'function', function: { name: 'weather', arguments: '' } },
+            { id: 'call_invalid', type: 'function', function: { name: '', arguments: '{}' } },
+          ],
+        },
+        finish_reason: 'tool_calls',
+      }],
+    })
+
+    expect(response.toolCalls).toEqual([{
+      id: 'call_valid',
+      name: 'weather',
+      arguments: {},
+      rawArguments: '{}',
+    }])
+  })
+
   it('remembers image-rejecting Chat targets across client instances', async () => {
     const model = `text-only-memory-test-${Date.now()}-${Math.random()}`
     const config: ModelProviderConfig = {

--- a/tests/server/hermes-process.test.ts
+++ b/tests/server/hermes-process.test.ts
@@ -96,6 +96,34 @@ describe('Hermes process invocation', () => {
     }
   })
 
+  it('runs a standalone Windows hermes.cmd launcher through cmd.exe', async () => {
+    setPlatform('win32')
+    const root = mkdtempSync(join(tmpdir(), 'hermes-process-'))
+    try {
+      const scripts = join(root, 'Scripts')
+      mkdirSync(scripts)
+      const hermes = join(scripts, 'hermes.cmd')
+      writeFileSync(hermes, '@echo off\r\n')
+      const { execHermesWithBin } = await import('../../packages/server/src/modules/hermes/services/runtime/process')
+
+      await execHermesWithBin(hermes, ['profile', 'list'])
+
+      expect(execFileCalls[0]).toMatchObject({
+        command: process.env.comspec || 'cmd.exe',
+        args: expect.arrayContaining(['/d', '/s', '/c']),
+        options: expect.objectContaining({
+          windowsHide: true,
+          windowsVerbatimArguments: true,
+        }),
+      })
+      expect(execFileCalls[0].args.at(-1)).toContain('hermes.cmd')
+      expect(execFileCalls[0].args.at(-1)).toContain('profile')
+      expect(execFileCalls[0].args.at(-1)).toContain('list')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it('keeps normal Hermes command execution unchanged on non-Windows platforms', async () => {
     setPlatform('darwin')
     const { execHermesWithBin } = await import('../../packages/server/src/modules/hermes/services/runtime/process')
@@ -120,5 +148,32 @@ describe('Hermes process invocation', () => {
       args: ['-m', 'hermes_cli.main', 'gateway', 'run'],
       options: expect.objectContaining({ windowsHide: true }),
     })
+  })
+
+  it('spawns a standalone Windows hermes.cmd gateway through cmd.exe', async () => {
+    setPlatform('win32')
+    const root = mkdtempSync(join(tmpdir(), 'hermes-process-'))
+    try {
+      const scripts = join(root, 'Scripts')
+      mkdirSync(scripts)
+      const hermes = join(scripts, 'hermes.cmd')
+      writeFileSync(hermes, '@echo off\r\n')
+      const { spawnHermesWithBin } = await import('../../packages/server/src/modules/hermes/services/runtime/process')
+
+      spawnHermesWithBin(hermes, ['gateway', 'run'])
+
+      expect(spawnCalls[0]).toMatchObject({
+        command: process.env.comspec || 'cmd.exe',
+        args: expect.arrayContaining(['/d', '/s', '/c']),
+        options: expect.objectContaining({
+          windowsHide: true,
+          windowsVerbatimArguments: true,
+        }),
+      })
+      expect(spawnCalls[0].args.at(-1)).toContain('gateway')
+      expect(spawnCalls[0].args.at(-1)).toContain('run')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
## Summary

- atomically detach and rebuild the complete Ekko Skills tree so transient Windows EPERM failures do not disable Ekko or learning APIs
- execute standalone Windows hermes.cmd launchers through cmd.exe for profile discovery and gateway autostart
- reject incomplete OpenAI-compatible tool calls, normalize empty arguments to {}, retry all-invalid responses, and sanitize damaged replay history

## Verification

- npm run test:ekko-agent (275 passed)
- npx tsc --noEmit -p packages/server/tsconfig.json
- npm run harness:check
- targeted Hermes process and gateway tests passed