### PR TITLE
[codex] retry locked Windows Runtime filesystem operations

### DIFF
--- a/packages/server/src/modules/hermes/services/runtime/runtime-filesystem.ts
+++ b/packages/server/src/modules/hermes/services/runtime/runtime-filesystem.ts
@@ -1,0 +1,50 @@
+import { renameSync, rmSync } from 'fs'
+
+const WINDOWS_FS_MAX_RETRIES = 8
+const WINDOWS_FS_RETRY_DELAY_MS = 200
+
+export function removeRuntimePath(target: string): void {
+  // Runtime trees are large enough that Defender and indexers can briefly
+  // retain handles after extraction or shutdown. Node only retries rm when
+  // maxRetries is explicitly set, including for Windows permission_denied.
+  rmSync(target, {
+    recursive: true,
+    force: true,
+    maxRetries: process.platform === 'win32' ? WINDOWS_FS_MAX_RETRIES : 0,
+    retryDelay: process.platform === 'win32' ? WINDOWS_FS_RETRY_DELAY_MS : 100,
+  })
+}
+
+export function cleanupRuntimePath(target: string): void {
+  try {
+    removeRuntimePath(target)
+  } catch (err) {
+    // Cleanup must not replace the extraction or installation error that led
+    // us here; a later run uses a unique temporary path and can proceed.
+    console.warn(`[runtime] failed to clean up ${target}: ${err instanceof Error ? err.message : String(err)}`)
+  }
+}
+
+function isRetryableWindowsFilesystemError(err: unknown): boolean {
+  if (process.platform !== 'win32' || !err || typeof err !== 'object') return false
+  const code = String((err as NodeJS.ErrnoException).code || '')
+  return code === 'EACCES' || code === 'EBUSY' || code === 'ENOTEMPTY' || code === 'EPERM'
+}
+
+function waitForFilesystemRetry(attempt: number): Promise<void> {
+  return new Promise(resolvePromise => {
+    setTimeout(resolvePromise, attempt * WINDOWS_FS_RETRY_DELAY_MS)
+  })
+}
+
+export async function renameRuntimePath(source: string, destination: string): Promise<void> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      renameSync(source, destination)
+      return
+    } catch (err) {
+      if (attempt >= WINDOWS_FS_MAX_RETRIES || !isRetryableWindowsFilesystemError(err)) throw err
+      await waitForFilesystemRetry(attempt + 1)
+    }
+  }
+}

--- a/packages/server/src/modules/hermes/services/runtime/version-manager.ts
+++ b/packages/server/src/modules/hermes/services/runtime/version-manager.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto'
-import { accessSync, constants, createReadStream, createWriteStream, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, statSync, writeFileSync, type Dirent } from 'fs'
+import { accessSync, constants, createReadStream, createWriteStream, existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync, type Dirent } from 'fs'
 import { get as httpGet } from 'http'
 import { get as httpsGet } from 'https'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'path'
@@ -8,6 +8,7 @@ import { config } from '../../../studio/public/config'
 import { getHermesAgentVersion, getHermesWebUiVersion } from '../../../studio/public/system-info'
 import { updateAgentStatus } from '../../../studio/public/agent-status-registry'
 import { discoverHermesCliInstallations, type HermesCliInstallation } from './discovery'
+import { cleanupRuntimePath, removeRuntimePath, renameRuntimePath } from './runtime-filesystem'
 
 const ACTIVE_VERSION_FILE = 'active-version.json'
 const DEFAULT_REMOTE_MANIFEST_URL = 'https://api.hermes-studio.ai/api/studio/versions'
@@ -570,7 +571,7 @@ export async function downloadRuntimeVersion(version: string, source: VersionDow
   const tempRoot = join(storageRoot, `.runtime-download-${process.pid}-${Date.now()}`)
 
   mkdirSync(storageRoot, { recursive: true })
-  rmSync(tempRoot, { recursive: true, force: true })
+  removeRuntimePath(tempRoot)
   mkdirSync(tempRoot, { recursive: true })
 
   try {
@@ -584,12 +585,12 @@ export async function downloadRuntimeVersion(version: string, source: VersionDow
     await extractTarGzip(archive, tempRoot)
     validateRuntimeDirectory(tempRoot, platform)
     onProgress?.({ stage: 'install', message: 'runtimeVersions.jobStage.installRuntime' })
-    rmSync(targetRoot, { recursive: true, force: true })
+    removeRuntimePath(targetRoot)
     mkdirSync(dirname(targetRoot), { recursive: true })
-    renameSync(tempRoot, targetRoot)
+    await renameRuntimePath(tempRoot, targetRoot)
   } finally {
-    rmSync(archive, { force: true })
-    rmSync(tempRoot, { recursive: true, force: true })
+    cleanupRuntimePath(archive)
+    cleanupRuntimePath(tempRoot)
   }
 
   return {
@@ -618,7 +619,7 @@ export async function downloadWebUiVersion(version: string, source: VersionDownl
   const assetUrl = downloadAssetUrl(assetName, releaseTag, source)
 
   mkdirSync(storageRoot, { recursive: true })
-  rmSync(tempRoot, { recursive: true, force: true })
+  removeRuntimePath(tempRoot)
   mkdirSync(tempRoot, { recursive: true })
 
   try {
@@ -635,12 +636,12 @@ export async function downloadWebUiVersion(version: string, source: VersionDownl
       if (!existsSync(join(extractedRoot, required))) throw new Error(`Web UI archive is missing required file: ${required}`)
     }
     onProgress?.({ stage: 'install', message: 'runtimeVersions.jobStage.installWebUi' })
-    rmSync(targetRoot, { recursive: true, force: true })
+    removeRuntimePath(targetRoot)
     mkdirSync(dirname(targetRoot), { recursive: true })
-    renameSync(extractedRoot, targetRoot)
+    await renameRuntimePath(extractedRoot, targetRoot)
   } finally {
-    rmSync(archive, { force: true })
-    rmSync(tempRoot, { recursive: true, force: true })
+    cleanupRuntimePath(archive)
+    cleanupRuntimePath(tempRoot)
   }
 
   return { version: cleanVersion, directory: targetRoot, active: false }
@@ -730,11 +731,11 @@ export function deleteInstalledRuntimeVersion(version: string): InstalledRuntime
   if (!target) throw new Error(`Installed runtime version not found for this platform: ${cleanVersion}`)
   if (target.active) throw new Error('Active runtime version cannot be deleted')
 
-  rmSync(target.directory, { recursive: true, force: true })
+  removeRuntimePath(target.directory)
   try {
     const versionRoot = dirname(target.directory)
     if (existsSync(versionRoot) && readdirSync(versionRoot).length === 0) {
-      rmSync(versionRoot, { recursive: true, force: true })
+      removeRuntimePath(versionRoot)
     }
   } catch {
     /* ignore empty parent cleanup failures */
@@ -783,7 +784,7 @@ export function deleteDownloadedWebUiVersion(version: string): InstalledWebUiVer
     throw new Error('Only downloaded Web UI versions can be deleted')
   }
 
-  rmSync(targetDir, { recursive: true, force: true })
+  removeRuntimePath(targetDir)
   return target
 }
 

--- a/tests/server/runtime-filesystem.test.ts
+++ b/tests/server/runtime-filesystem.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fsMocks = vi.hoisted(() => ({
+  renameSync: vi.fn(),
+  rmSync: vi.fn(),
+}))
+
+vi.mock('fs', async importOriginal => ({
+  ...await importOriginal<typeof import('fs')>(),
+  renameSync: fsMocks.renameSync,
+  rmSync: fsMocks.rmSync,
+}))
+
+import {
+  cleanupRuntimePath,
+  removeRuntimePath,
+  renameRuntimePath,
+} from '../../packages/server/src/modules/hermes/services/runtime/runtime-filesystem'
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+function windowsFilesystemError(code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(`${code}: Runtime directory is temporarily locked`), { code })
+}
+
+describe('runtime filesystem operations', () => {
+  beforeEach(() => {
+    fsMocks.renameSync.mockReset()
+    fsMocks.rmSync.mockReset()
+    fsMocks.renameSync.mockReturnValue(undefined)
+    fsMocks.rmSync.mockReturnValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform)
+  })
+
+  it('retries recursive Runtime removal on Windows filesystem locks', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    removeRuntimePath('D:\\Runtime 存储\\hermes\\0.20.0')
+
+    expect(fsMocks.rmSync).toHaveBeenCalledWith('D:\\Runtime 存储\\hermes\\0.20.0', {
+      recursive: true,
+      force: true,
+      maxRetries: 8,
+      retryDelay: 200,
+    })
+  })
+
+  it('does not let temporary cleanup failures replace the install error', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    fsMocks.rmSync.mockImplementation(() => {
+      throw windowsFilesystemError('EPERM')
+    })
+
+    expect(() => cleanupRuntimePath('D:\\新建文件夹\\.runtime-download-123')).not.toThrow()
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('EPERM'))
+  })
+
+  it('retries a Windows Runtime directory rename while a scanner holds it', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    vi.useFakeTimers()
+    fsMocks.renameSync
+      .mockImplementationOnce(() => { throw windowsFilesystemError('EPERM') })
+      .mockImplementationOnce(() => { throw windowsFilesystemError('EBUSY') })
+      .mockReturnValue(undefined)
+
+    const renamed = renameRuntimePath(
+      'D:\\新建文件夹\\.runtime-download-123',
+      'D:\\新建文件夹\\hermes\\0.20.0\\win-x64',
+    )
+    await vi.runAllTimersAsync()
+
+    await expect(renamed).resolves.toBeUndefined()
+    expect(fsMocks.renameSync).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not retry non-locking rename errors', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    const error = windowsFilesystemError('EXDEV')
+    fsMocks.renameSync.mockImplementation(() => { throw error })
+
+    await expect(renameRuntimePath('source', 'destination')).rejects.toBe(error)
+    expect(fsMocks.renameSync).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary
- retry Windows Runtime removals and directory replacements when Defender or indexers temporarily retain file handles
- keep best-effort download cleanup from masking the original installation failure
- apply the same guarded removal behavior to Runtime and downloaded Web UI deletion
- cover Unicode Windows paths, cleanup failures, retryable locks, and non-retryable rename errors

## Validation
- npm run test -- tests/server/runtime-filesystem.test.ts tests/server/runtime-version-manager.test.ts
- npx tsc --noEmit -p packages/server/tsconfig.json
- npm run harness:check
- npm run build