### PR TITLE
fix(group-chat): declare the conversation each reply belongs to

### DIFF
--- a/packages/server/src/modules/hermes/services/bridge/client.ts
+++ b/packages/server/src/modules/hermes/services/bridge/client.ts
@@ -56,6 +56,21 @@ export interface AgentBridgeChatOptions {
   /** Local patch (reasoning-effort): per-session reasoning effort override.
    * Empty/undefined = use config.yaml default. */
   reasoning_effort?: string
+  /** The conversation this reply belongs to, declared to Hermes.
+   *
+   * `session_id` names one runtime execution; a caller that issues a fresh
+   * one per reply (group chat does) leaves Hermes with no way to tell that
+   * two replies continue the same conversation, so every affinity hint it
+   * derives from that id — the OpenAI-wire `prompt_cache_key`, OpenRouter's
+   * and Nous' sticky `session_id`, xAI's `x-grok-conv-id` — is re-keyed on
+   * every single reply and never lands back on a warm prefix
+   * (NousResearch/hermes-agent#96811).
+   *
+   * Hermes deliberately will not infer the conversation from the id's shape,
+   * so it has to be declared. Pass a value that is stable for one
+   * conversation and distinct across conversations; omit it to keep the
+   * previous per-reply behaviour exactly. */
+  gateway_session_key?: string
 }
 
 export type AgentBridgeMessage =
@@ -526,6 +541,9 @@ export class AgentBridgeClient {
         : {}),
       // Local patch (reasoning-effort): per-session reasoning effort override.
       ...(options.reasoning_effort ? { reasoning_effort: options.reasoning_effort } : {}),
+      ...(options.gateway_session_key
+        ? { gateway_session_key: options.gateway_session_key }
+        : {}),
     })
   }
 

--- a/packages/server/src/modules/hermes/services/bridge/python/bridge_pool.py
+++ b/packages/server/src/modules/hermes/services/bridge/python/bridge_pool.py
@@ -384,6 +384,35 @@ class AgentPool:
             except Exception:
                 pass
 
+    @staticmethod
+    def _apply_declared_conversation(
+        session: AgentSession, gateway_session_key: str | None
+    ) -> None:
+        """Keep a cached session's declared conversation current.
+
+        The pool is keyed by ``session_id``, which names one runtime execution.
+        The declared conversation is a different identity and can rotate under a
+        reused id — group chat rotates it whenever the room's ``sessionSeed``
+        changes. Applied only while the session is idle, so a live turn's
+        affinity cannot move under it, and never cleared by a caller that simply
+        declares nothing.
+        """
+        key = str(gateway_session_key or "").strip()
+        if not key or session.running:
+            return
+        if str(session.config.get("gateway_session_key") or "") == key:
+            return
+        session.config["gateway_session_key"] = key
+        agent = getattr(session, "agent", None)
+        if agent is not None:
+            try:
+                agent._gateway_session_key = key
+            except Exception:
+                # A runtime that will not accept the attribute keeps the key it
+                # was built with; the declaration is an optimization, never a
+                # correctness requirement.
+                pass
+
     def get_or_create(
         self,
         session_id: str,
@@ -391,12 +420,14 @@ class AgentPool:
         model: str | None = None,
         provider: str | None = None,
         background_delegation_enabled: bool | None = None,
+        gateway_session_key: str | None = None,
     ) -> AgentSession:
         requested_model = str(model or "").strip()
         requested_provider = str(provider or "").strip()
         with self._lock:
             existing = self._sessions.get(session_id)
             if existing is not None:
+                self._apply_declared_conversation(existing, gateway_session_key)
                 # If profile changed, destroy old session and recreate
                 profile_changed = bool(profile and existing.config.get("profile") != profile)
                 runtime_changed = bool(
@@ -474,6 +505,15 @@ class AgentPool:
                     enabled_toolsets=_load_enabled_toolsets(),
                     platform=_bridge_platform(),
                     session_id=session_id,
+                    # The conversation this execution belongs to, when the
+                    # caller declares one. session_id is per-execution and group
+                    # chat mints a fresh one per reply, so without this every
+                    # conversation-affinity hint Hermes sends — prompt_cache_key
+                    # on both OpenAI-wire transports, the OpenRouter and Nous
+                    # sticky session_id, and xAI's x-grok-conv-id — is re-keyed
+                    # on every reply (NousResearch/hermes-agent#96811). None
+                    # keeps the previous per-execution behaviour exactly.
+                    gateway_session_key=str(gateway_session_key or "").strip() or None,
                     session_db=self._db.get_for_profile(profile),
                     ephemeral_system_prompt=prompt,
                     status_callback=self._status_callback(session_id),
@@ -515,6 +555,9 @@ class AgentPool:
                         # This is an Agent-session policy, not a per-turn flag.
                         # Callers select it when the cached AIAgent is created.
                         "background_delegation_enabled": background_delegation_enabled is not False,
+                        # The conversation this execution was declared to be
+                        # part of, so a later reuse can tell whether it moved.
+                        "gateway_session_key": str(gateway_session_key or "").strip(),
                     },
                 )
                 self._install_boundary_interrupt(session)
@@ -1649,6 +1692,7 @@ class AgentPool:
         source: str | None = None,
         reasoning_effort: str | None = None,
         background_delegation_enabled: bool | None = None,
+        gateway_session_key: str | None = None,
     ) -> RunRecord:
         session = self.get_or_create(
             session_id,
@@ -1656,6 +1700,7 @@ class AgentPool:
             model=model,
             provider=provider,
             background_delegation_enabled=background_delegation_enabled,
+            gateway_session_key=gateway_session_key,
         )
         # Install after agent construction so any runtime plugin initialization
         # has completed. Rechecking on every run also recovers from a forced

--- a/packages/server/src/modules/hermes/services/bridge/python/bridge_server.py
+++ b/packages/server/src/modules/hermes/services/bridge/python/bridge_server.py
@@ -77,6 +77,20 @@ class BridgeServer:
             )
             # Local patch (reasoning-effort): per-session reasoning effort override (Web UI brain button).
             reasoning_effort = req.get("reasoning_effort")
+            # The conversation this reply belongs to, when the caller declares
+            # one. session_id names a single runtime execution and group chat
+            # issues a fresh one per reply, so without this Hermes re-keys every
+            # conversation-affinity hint on every reply
+            # (NousResearch/hermes-agent#96811). Absent = unchanged behaviour.
+            gateway_session_key = req.get("gateway_session_key")
+            # Only forwarded when the caller actually declares a conversation,
+            # so a pool implementation that does not know the parameter keeps
+            # working unchanged.
+            declared_conversation_kwargs = (
+                {"gateway_session_key": gateway_session_key}
+                if gateway_session_key
+                else {}
+            )
             record = self.pool.start_chat(
                 session_id,
                 message,
@@ -91,6 +105,7 @@ class BridgeServer:
                 source,
                 reasoning_effort,
                 background_delegation_enabled,
+                **declared_conversation_kwargs,
             )
             if req.get("wait"):
                 timeout = float(req.get("timeout", 0) or 0)

--- a/packages/server/src/modules/studio/services/group-chat/agent-clients.ts
+++ b/packages/server/src/modules/studio/services/group-chat/agent-clients.ts
@@ -1325,6 +1325,43 @@ export class AgentClient implements GroupAgentExecutor {
         }
     }
 
+    /**
+     * The conversation this room member is currently in, declared to Hermes.
+     *
+     * `groupRuntimeSessionId` is per-reply by design — a server-issued
+     * continuation identity, never accepted from an Agent socket — so Hermes
+     * sees a brand-new conversation on every reply and re-keys every affinity
+     * hint it derives from that id: `prompt_cache_key` on both OpenAI-wire
+     * transports, OpenRouter's and Nous' sticky `session_id`, and xAI's
+     * `x-grok-conv-id` (NousResearch/hermes-agent#96811). Hermes deliberately
+     * will not recover the conversation from the id's shape, so the host has
+     * to declare it.
+     *
+     * `groupBridgeSessionId` is the value that is already stable for exactly
+     * one conversation: it carries the room, profile, agent name and runtime
+     * identity, plus the room-owned `sessionSeed` — which is what rotates when
+     * the room starts a new conversation, so a reset lands on a cold bucket
+     * without Hermes needing to observe one. The arguments match the room
+     * socket's own calls byte for byte, so both sides name the same
+     * conversation.
+     */
+    private groupDeclaredConversationKey(roomId: string): string | undefined {
+        try {
+            const seed = String(this.storage?.getRoom?.(roomId)?.sessionSeed || '0')
+            return groupBridgeSessionId(roomId, this.profile, this.name, seed, {
+                agent: this.agent,
+                provider: this.provider,
+                model: this.model,
+                apiMode: this.apiMode,
+                reasoningEffort: this.reasoningEffort,
+            })
+        } catch {
+            // Declaring the conversation is an optimization; a room we cannot
+            // read simply keeps the previous per-reply behaviour.
+            return undefined
+        }
+    }
+
     async replyToMention(
         roomId: string,
         msg: MentionMessage,
@@ -1432,6 +1469,10 @@ export class AgentClient implements GroupAgentExecutor {
             const flushedAssistantParts = new Set<string>()
             let lastChunk: GroupPrimaryAgentBridgeOutput | null = null
             const roomWorkspace = String(this.storage?.getRoom?.(roomId)?.workspace || '').trim()
+            // sessionId above names this reply; this names the conversation the
+            // reply belongs to, so Hermes keeps one affinity bucket across all
+            // of them (see groupDeclaredConversationKey).
+            const declaredConversationKey = this.groupDeclaredConversationKey(roomId)
             const started = await bridge.chat(
                 sessionId,
                 bridgeInput,
@@ -1444,6 +1485,9 @@ export class AgentClient implements GroupAgentExecutor {
                     ...(this.reasoningEffort ? { reasoning_effort: this.reasoningEffort } : {}),
                     source: 'api_server',
                     ...(roomWorkspace ? { workspace: roomWorkspace } : {}),
+                    ...(declaredConversationKey
+                        ? { gateway_session_key: declaredConversationKey }
+                        : {}),
                     // Used only if this operation creates the cached AgentSession.
                     background_delegation_enabled: this.backgroundDelegationEnabled,
                 },

--- a/tests/server/group-chat-declared-conversation.test.ts
+++ b/tests/server/group-chat-declared-conversation.test.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Group chat declares the conversation each reply belongs to.
+ *
+ * `groupRuntimeSessionId` is per-reply on purpose, so Hermes used to see a
+ * brand-new conversation on every reply and re-key every affinity hint it
+ * derives from that id (NousResearch/hermes-agent#96811). These tests pin the
+ * declaration: what is sent, that it holds across replies, that it rotates on
+ * the room's own conversation boundary, and that a room we cannot read simply
+ * declares nothing.
+ */
+
+const mockSocket = vi.hoisted(() => ({
+  id: 'agent-socket-1',
+  connected: true,
+  io: { on: vi.fn() },
+  on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+    if (event === 'connect') queueMicrotask(() => handler())
+    return mockSocket
+  }),
+  emit: vi.fn((event: string, data?: any, ack?: Function) => {
+    if (event === 'message' && ack) ack({ id: data?.id || 'msg-id' })
+    return mockSocket
+  }),
+  disconnect: vi.fn(),
+}))
+
+const bridgeMock = vi.hoisted(() => ({
+  chat: vi.fn(async (sessionId: string) => ({
+    ok: true,
+    run_id: 'bridge-run-id',
+    session_id: sessionId,
+    status: 'running',
+  })),
+  streamOutput: vi.fn(async function* (runId: string) {
+    yield {
+      ok: true,
+      run_id: runId,
+      session_id: 'session-1',
+      status: 'complete',
+      delta: 'done',
+      cursor: 1,
+      output: 'done',
+      done: true,
+      events: [],
+      event_cursor: 0,
+    }
+  }),
+  contextEstimate: vi.fn(async () => ({ ok: true })),
+  interrupt: vi.fn(async () => undefined),
+  destroy: vi.fn(async () => undefined),
+}))
+
+vi.mock('socket.io-client', () => ({ io: vi.fn(() => mockSocket) }))
+vi.mock('../../packages/server/src/modules/studio/services/auth/token-auth', () => ({
+  getToken: vi.fn(async () => 'test-token'),
+}))
+vi.mock('../../packages/server/src/modules/studio/public/profile-config', () => ({
+  readConfigYamlForProfile: vi.fn(async () => ({ model: { default: 'model-a', provider: 'provider-a' } })),
+}))
+vi.mock('../../packages/server/src/modules/studio/repositories/usage-store', () => ({ updateUsage: vi.fn() }))
+vi.mock('../../packages/server/src/modules/studio/public/group-chat-agent-runtime', () => ({
+  createGroupPrimaryAgentBridge: vi.fn(() => bridgeMock),
+  cancelGroupEkkoClarification: vi.fn(() => ({ resolved: false })),
+}))
+vi.mock('../../packages/server/src/modules/studio/services/chat-run/workspace-diff-tracker', () => ({
+  startWorkspaceRunCheckpoint: vi.fn(),
+  completeWorkspaceRunCheckpointDraft: vi.fn(() => null),
+  discardWorkspaceRunCheckpoint: vi.fn(),
+}))
+
+const MENTION = {
+  messageId: 'message-1',
+  content: '@Worker take a look',
+  senderName: 'Human',
+  senderId: 'human-1',
+  timestamp: 1,
+  role: 'user' as const,
+}
+
+async function createClient(seed: string | null = 'seed-1') {
+  const { AgentClients } = await import('../../packages/server/src/modules/studio/services/group-chat/agent-clients')
+  const clients = new AgentClients()
+  const client = await clients.createAgent({
+    agentId: 'agent-1',
+    profile: 'default',
+    provider: 'provider-a',
+    model: 'model-a',
+    name: 'Worker',
+    description: '',
+    invited: 0,
+    backgroundDelegationEnabled: false,
+  } as any)
+  const storage = {
+    getRoom: vi.fn(() => (seed === null ? undefined : { sessionSeed: seed, workspace: '' })),
+    saveWorkspaceDiffMessageForRun: vi.fn(),
+    updateRoomTotalTokens: vi.fn(),
+    getMessagesForContext: vi.fn(() => []),
+    getContextSnapshot: vi.fn(() => null),
+  }
+  client.setStorage(storage as any)
+  ;(clients as any).rooms.set('room-1', new Map([[client.agentId, client]]))
+  return client as any
+}
+
+function chatCallOptions(index = 0) {
+  return bridgeMock.chat.mock.calls[index]?.[5] as Record<string, unknown> | undefined
+}
+
+function chatCallSessionId(index = 0) {
+  return bridgeMock.chat.mock.calls[index]?.[0] as string
+}
+
+describe('group chat declares the conversation to Hermes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSocket.emit.mockImplementation((event: string, data?: any, ack?: Function) => {
+      if (event === 'message' && ack) ack({ id: data?.id || 'msg-id' })
+      return mockSocket
+    })
+    bridgeMock.chat.mockImplementation(async (sessionId: string) => ({
+      ok: true,
+      run_id: 'bridge-run-id',
+      session_id: sessionId,
+      status: 'running',
+    }))
+  })
+
+  it('sends the room member conversation key alongside the per-reply session id', async () => {
+    const { groupBridgeSessionId } = await import('../../packages/server/src/modules/studio/services/group-chat/agent-clients')
+    const client = await createClient('seed-1')
+
+    await client.replyToMention('room-1', MENTION)
+
+    const expected = groupBridgeSessionId('room-1', 'default', 'Worker', 'seed-1', {
+      agent: 'hermes',
+      provider: 'provider-a',
+      model: 'model-a',
+      apiMode: '',
+      reasoningEffort: '',
+    })
+    expect(chatCallOptions()).toMatchObject({ gateway_session_key: expected })
+    // The declaration names the conversation; the first argument still names
+    // this one reply, and the two must not be the same value.
+    expect(chatCallSessionId()).not.toBe(expected)
+    expect(chatCallSessionId()).toMatch(/^gc_run_/)
+  })
+
+  it('holds one conversation across replies with distinct session ids', async () => {
+    const client = await createClient('seed-1')
+
+    await client.replyToMention('room-1', MENTION)
+    await client.replyToMention('room-1', { ...MENTION, messageId: 'message-2' })
+
+    expect(bridgeMock.chat).toHaveBeenCalledTimes(2)
+    expect(chatCallSessionId(0)).not.toBe(chatCallSessionId(1))
+    expect(chatCallOptions(0)?.gateway_session_key)
+      .toBe(chatCallOptions(1)?.gateway_session_key)
+  })
+
+  it('rotates the declaration when the room starts a new conversation', async () => {
+    const first = await createClient('seed-1')
+    await first.replyToMention('room-1', MENTION)
+    const before = chatCallOptions(0)?.gateway_session_key
+
+    vi.clearAllMocks()
+    const second = await createClient('seed-2')
+    await second.replyToMention('room-1', MENTION)
+    const after = chatCallOptions(0)?.gateway_session_key
+
+    expect(before).toBeTruthy()
+    expect(after).toBeTruthy()
+    expect(after).not.toBe(before)
+  })
+
+  it('falls back to the default seed for a room that never reset', async () => {
+    const { groupBridgeSessionId } = await import('../../packages/server/src/modules/studio/services/group-chat/agent-clients')
+    const client = await createClient('')
+
+    await client.replyToMention('room-1', MENTION)
+
+    // A room row carries sessionSeed TEXT NOT NULL DEFAULT '0'; an empty value
+    // is the same conversation as '0', not a missing declaration.
+    expect(chatCallOptions()).toMatchObject({
+      gateway_session_key: groupBridgeSessionId('room-1', 'default', 'Worker', '0', {
+        agent: 'hermes',
+        provider: 'provider-a',
+        model: 'model-a',
+        apiMode: '',
+        reasoningEffort: '',
+      }),
+    })
+  })
+})
+
+describe('AgentBridgeClient carries the declared conversation', () => {
+  it('forwards the key when one is declared', async () => {
+    const { AgentBridgeClient } = await import('../../packages/server/src/modules/hermes/services/bridge/client')
+    const client = new AgentBridgeClient({ endpoint: 'tcp://127.0.0.1:1', connectRetryMs: 0, timeoutMs: 1 })
+    const request = vi.spyOn(client, 'request').mockResolvedValue({ ok: true, run_id: 'r1' } as any)
+
+    await client.chat('run-1', 'hello', undefined, undefined, 'default', {
+      gateway_session_key: 'gc_room_default_Worker_0_h_deadbeefdeadbeef',
+    })
+
+    expect(request).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'chat',
+      session_id: 'run-1',
+      gateway_session_key: 'gc_room_default_Worker_0_h_deadbeefdeadbeef',
+    }))
+  })
+
+  it('omits the field entirely when nothing is declared', async () => {
+    const { AgentBridgeClient } = await import('../../packages/server/src/modules/hermes/services/bridge/client')
+    const client = new AgentBridgeClient({ endpoint: 'tcp://127.0.0.1:1', connectRetryMs: 0, timeoutMs: 1 })
+    const request = vi.spyOn(client, 'request').mockResolvedValue({ ok: true, run_id: 'r1' } as any)
+
+    await client.chat('run-1', 'hello')
+
+    expect(request.mock.calls[0][0]).not.toHaveProperty('gateway_session_key')
+  })
+})


### PR DESCRIPTION
`Refs NousResearch/hermes-agent#96811` — this is the host half of that issue.

Group chat re-keys **every** conversation-affinity hint Hermes sends, on **every single reply**, so a room member never lands back on the prefix it just warmed.

## The defect

`groupRuntimeSessionId(roomId, profile, name)` mints a fresh UUID-backed id per reply. That is correct and deliberate — it is a server-issued continuation identity, never accepted from an Agent socket. The problem is that this id is the *only* conversation signal the bridge hands Hermes, and Hermes derives all four affinity surfaces from it.

| Surface | Where it goes |
| --- | --- |
| `prompt_cache_key` | both OpenAI-wire transports |
| `body.session_id` | OpenRouter sticky routing |
| `body.session_id` | Nous Portal sticky key |
| `x-grok-conv-id` | xAI header |

Hermes deliberately refuses to recover a conversation from an id's *shape* — client-supplied ids collide, and truncated room-member ids collide with each other — so the conversation has to be **declared**.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[🩸 Room Member Replies] --> B[groupRuntimeSessionId<br/>fresh UUID every reply]
    B --> C{Conversation Declared?}

    C -->|before: no| D[🔥 Hermes Sees A New<br/>Conversation Each Reply]
    D --> E1[prompt_cache_key rotates]
    D --> E2[OpenRouter sticky id rotates]
    D --> E3[Nous Portal key rotates]
    D --> E4[x-grok-conv-id rotates]
    E1 --> F[⚔️ Cold Prefix Forever]
    E2 --> F
    E3 --> F
    E4 --> F

    C -->|after: yes| G[groupBridgeSessionId<br/>room + profile + name<br/>+ runtime + sessionSeed]
    G --> H[🔒 One Affinity Identity<br/>gwk_ hash]
    H --> I[Warm Prefix Across Replies]
    G --> J[New sessionSeed<br/>= new conversation]
    J --> K[Cold Bucket On Reset]
```

## The fix

The stable value already exists. `groupBridgeSessionId(roomId, profile, name, sessionSeed, runtimeConfig)` is stable for exactly one conversation: it carries the room, profile, agent name and runtime identity, plus the room-owned `sessionSeed` — which is what `UPDATE gc_rooms SET sessionSeed = ?` rotates when a room starts a new conversation. So a real room reset lands on a cold bucket without Hermes having to observe a reset of its own. The arguments match the room socket's own calls (`sockets/group-chat.ts:3704`, `:4167`) byte for byte, so both sides name one conversation.

It travels as `gateway_session_key`, an optional field the Hermes `AIAgent` constructor already accepts, threaded through the one path the reproduction uses.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph LR
    A[replyToMention<br/>agent-clients.ts] -->|gateway_session_key| B[bridge.chat<br/>client.ts]
    B -->|JSON payload| C[bridge_server.py<br/>forwarded only when declared]
    C --> D[AgentPool.start_chat]
    D --> E[get_or_create]
    E --> F[🔥 AIAgent gateway_session_key]
    G[Non-Hermes Agents] -.->|early return| H[replyToMentionWithChatRun<br/>untouched]
```

| File | What |
| --- | --- |
| `studio/services/group-chat/agent-clients.ts` | `groupDeclaredConversationKey()`, sent on the reply |
| `hermes/services/bridge/client.ts` | optional `gateway_session_key` in the chat options and payload |
| `hermes/services/bridge/python/bridge_server.py` | reads it, forwards it only when declared |
| `hermes/services/bridge/python/bridge_pool.py` | threads it to `AIAgent`, refreshes an idle cached session |
| `tests/server/group-chat-declared-conversation.test.ts` | new |

## Blast radius

- **Only the Hermes primary-agent reply path changes.** `replyToMention` returns early into `replyToMentionWithChatRun` for every non-hermes agent, so codex, claude, ekko and pi are untouched.
- **The field is optional everywhere.** `handle-bridge-run.ts` does not send it and is unchanged. `bridge_server` forwards the keyword *only* when a conversation is actually declared, so a pool implementation that does not know the parameter keeps working — this is what keeps `agent-bridge-python-concurrency`'s `FakePool` green without editing it. `get_or_create` and `start_chat` take the parameter last, so the existing positional call still binds.
- **A cached session reused under a rotated declaration** has its key refreshed only while idle, never mid-run.
- **A room that cannot be read** declares nothing and keeps today's behaviour exactly.

## Proof, on real values

Not fixtures. The real `groupRuntimeSessionId` and `groupBridgeSessionId` produced the ids; a real Hermes `AIAgent` on a real SQLite `state.db`, with rows written exactly the way `_prepersist_user_message` writes them, produced the wire values through the real transports and provider plugins.

**Before** — three replies, three identities, and the raw runtime id leaving the process verbatim:

```
reply gc_run_room-7c1f_default_Reviewer_e1239667…   prompt_cache_key pck_999e9dc4fb9911eb9d50cbec
                                                    openrouter/nous/x-grok-conv-id = the raw gc_run_ id
reply gc_run_room-7c1f_default_Reviewer_96786905…   prompt_cache_key pck_6e10ca6401777f7521da7016
reply gc_run_room-7c1f_default_Reviewer_5803014f…   prompt_cache_key pck_abc158d968c43fd850bc8a9d
-> 3 distinct affinity identities across 3 replies
```

**After** — the same three replies, one identity on all four surfaces:

```
reply gc_run_room-7c1f_default_Reviewer_e1239667…   prompt_cache_key      pck_daf290a8a983032b4b865bf4
                                                    openrouter_session_id gwk_39165ec23d41e21816aba30b
                                                    nous_session_id       gwk_39165ec23d41e21816aba30b
                                                    x_grok_conv_id        gwk_39165ec23d41e21816aba30b
reply gc_run_room-7c1f_default_Reviewer_96786905…   identical
reply gc_run_room-7c1f_default_Reviewer_5803014f…   identical
-> 1 distinct affinity identity across 3 replies
```

And the three properties that keep it honest: a new `sessionSeed` rotates the identity, another room member never shares it, and the raw declared key never reaches the wire — it is hashed to `gwk_<sha256[:24]>` first, because it embeds room, profile and member names and this value goes out as a provider routing key.

## Test plan

- [x] `tests/server/group-chat-declared-conversation.test.ts` — **6 passed**, new. Removing the declaration turns **3 of them red**; no existing test was modified to make them pass.
- [x] `group-chat-agent-workspace` + `group-chat-agent-routing-baseline` + `group-chat-agent-model-config` + `group-chat-agent-disconnect` + `group-chat-approval` — **86 passed**.
- [x] `agent-bridge-python-concurrency` — **43 passed**, including `forwards Agent creation policy from chat and context-estimate requests`, which drives the real `bridge_server.handle` against a pool that does not know the new parameter.
- [x] `agent-bridge-client-*` and `agent-bridge-reasoning-effort` — green.
- [x] `tsc --noEmit -p packages/server/tsconfig.json` — clean.
- [x] `agent-bridge-manager` has 3 failures on this machine; they are **pre-existing** and reproduce identically on a clean `main` checkout (verified with `git stash`).

 
