### PR TITLE
fix(ekko-agent): bound file reads and use native commands

### DIFF
--- a/packages/ekko-agent/docs/API.md
+++ b/packages/ekko-agent/docs/API.md
@@ -2535,12 +2535,12 @@ export interface SystemPromptInput {
   skillDiscoveryEnabled?: boolean
   skillManagementEnabled?: boolean
   skillNames?: string[]
-  context?: { provider?: string model?: string profile?: string cwd?: string workspaceRoot?: string }
+  context?: { provider?: string model?: string profile?: string cwd?: string workspaceRoot?: string platform?: NodeJS.Platform arch?: string }
 }
 
 export const EKKO_OUTPUT_FORMAT_GUIDELINES = `## Image and File Output When returning an image, video, or file to the user, use Markdown with an existing local absolute path. - Unix/macOS/WSL image: \`![description](/absolute/path/image.png)\` - Windows image: \`![description](<C:/absolute/path/image.png>)\` - Unix/macOS/WSL file: \`[filename](/absolute/path/file.pdf)\` - Windows file: \`[filename](<C:/absolute/path/file.pdf>)\` - Use forward slashes for Windows paths. - Wrap paths containing spaces, non-ASCII characters, or special characters in angle brackets. - Do not use relative paths or \`file://\` URLs. - Verify that the referenced file exists before returning it.`
 
-export const EKKO_TOOL_EXECUTION_GUIDELINES = `## Tool Execution Treat external commands, language packages, and other prerequisites named by a Skill as requirements, not proof that they are installed. - Before relying on an external dependency whose availability has not already been established, perform a lightweight availability check. - Do not run the primary dependency-based approach merely to discover whether its dependency exists. - Request independent tool calls together in one response. The runtime executes tools marked as parallel-safe concurrently while preserving serial barriers for stateful or dependent work. - When the user asks to execute or evaluate Node.js, JavaScript, or Python source code, use code_exec, including for one-line snippets. Do not probe Node or Python with terminal_exec first; code_exec resolves its runtime. - Use terminal_exec for CLI commands, project scripts, tests, builds, package managers, and other executables. - terminal_exec may use explicit absolute system paths and package-manager forms such as npx --dir. This capability is not limited to workspace files. - By default, keep downloads, clones, archives, extracted repositories, and generated intermediates inside the current workspace. Prefer the workspace's .ekko-tmp directory for disposable files so workspace-scoped file and image tools can inspect them. Use a system or external path only when the user or task explicitly requires it. - Dangerous tool calls may pause for runtime authorization. If authorization is denied, do not retry the operation through another tool or language runtime unless the user explicitly changes that decision. - After terminal_exec reports a [skill_validation] issue, do not claim the Skill installation is complete. Call skill_view for each writable local Skill and repair it with skill_manage until its frontmatter passes validation. Do not mutate read-only external Skill directories. - If a dependency is unavailable, prefer a compatible installed or built-in alternative. Install it only when installation is necessary and appropriate for the user's task. - Verify created artifacts before returning them.`
+export const EKKO_TOOL_EXECUTION_GUIDELINES = `## Tool Execution Treat external commands, language packages, and other prerequisites named by a Skill as requirements, not proof that they are installed. - Before relying on an external dependency whose availability has not already been established, perform a lightweight availability check. - Do not run the primary dependency-based approach merely to discover whether its dependency exists. - Request independent tool calls together in one response. The runtime executes tools marked as parallel-safe concurrently while preserving serial barriers for stateful or dependent work. - When the user asks to execute or evaluate Node.js, JavaScript, or Python source code, use code_exec, including for one-line snippets. Do not probe Node or Python with terminal_exec first; code_exec resolves its runtime. - Use terminal_exec for CLI commands, project scripts, tests, builds, package managers, and other executables. - terminal_exec may use explicit absolute system paths and platform-appropriate package-manager forms. Follow the Command Environment section below; this capability is not limited to workspace files. - By default, keep downloads, clones, archives, extracted repositories, and generated intermediates inside the current workspace. Prefer the workspace's .ekko-tmp directory for disposable files so workspace-scoped file and image tools can inspect them. Use a system or external path only when the user or task explicitly requires it. - Dangerous tool calls may pause for runtime authorization. If authorization is denied, do not retry the operation through another tool or language runtime unless the user explicitly changes that decision. - After terminal_exec reports a [skill_validation] issue, do not claim the Skill installation is complete. Call skill_view for each writable local Skill and repair it with skill_manage until its frontmatter passes validation. Do not mutate read-only external Skill directories. - If a dependency is unavailable, prefer a compatible installed or built-in alternative. Install it only when installation is necessary and appropriate for the user's task. - Verify created artifacts before returning them.`
 
 export const EKKO_CLARIFICATION_GUIDELINES = `## User Clarification When missing user input materially blocks or changes the task, call the clarify tool and wait for the response. - Do not present a blocking clarification question as an ordinary assistant response. - Ask one concise question that collects the necessary information; provide choices only for a short fixed set of answers. - Do not call clarify when a safe, reasonable assumption lets you continue without materially changing the outcome.`
 
@@ -2983,9 +2983,13 @@ export function createDelegationTools(): AgentTool[]
 ### `src/tools/files.ts`
 
 ```ts
+export const DEFAULT_READ_FILE_MAX_BYTES = 50_000
+
 export interface ReadFileInput extends Record<string, unknown> {
   path: string
   encoding?: BufferEncoding
+  offset?: number
+  limit?: number
 }
 
 export interface WriteFileInput extends Record<string, unknown> {
@@ -2997,7 +3001,7 @@ export interface WriteFileInput extends Record<string, unknown> {
 
 export class ReadFileTool implements AgentTool<ReadFileInput> {
   readonly concurrency = 'parallel' as const
-  readonly definition = { name: 'read_file', description: 'Read a UTF-8 text file from the workspace.', parameters: { type: 'object', properties: { path: { type: 'string', description: 'File path relative to the current workspace.' }, encoding: { type: 'string', description: 'Text encoding. Defaults to utf8.' }, }, required: ['path'], additionalProperties: false, }, }
+  readonly definition = { name: 'read_file', description: `Read a text file from the workspace, reading at most ${DEFAULT_READ_FILE_MAX_BYTES} file bytes per call. Use offset to continue a truncated read.`, parameters: { type: 'object', properties: { path: { type: 'string', description: 'File path relative to the current workspace.' }, encoding: { type: 'string', description: 'Text encoding. Defaults to utf8.' }, offset: { type: 'number', description: 'Zero-based byte offset. Defaults to 0; use nextOffset from a truncated result to continue.' }, limit: { type: 'number', description: `Maximum file bytes to read (minimum 4). Defaults to and cannot exceed ${DEFAULT_READ_FILE_MAX_BYTES}.` }, }, required: ['path'], additionalProperties: false, }, }
   async execute(input: ReadFileInput, context: AgentToolContext = {}): Promise<AgentToolResult>
 }
 
@@ -3194,10 +3198,11 @@ export interface TerminalExecInput extends Record<string, unknown> {
 
 export interface TerminalExecToolOptions {
   timeoutMs?: number
+  platform?: NodeJS.Platform
 }
 
 export class TerminalExecTool implements AgentTool<TerminalExecInput> {
-  readonly definition = { name: 'terminal_exec', description: [ 'Run a CLI command, project script, test, build, package manager, or system executable.', 'Prefer command as the executable and args as the argument array; shell string execution is not used.', 'Commands are not confined to the workspace: explicit absolute paths and package-manager forms such as npx --dir are supported.', 'Keep downloads, clones, extracted files, and generated intermediates under the current workspace (prefer .ekko-tmp) when workspace tools need to inspect them.', 'When the user asks to execute or evaluate Node.js, JavaScript, or Python source code, use code_exec instead, even for a one-line snippet.', 'Destructive, privileged, remote-shell, publishing, and other dangerous commands require runtime authorization before execution.', ].join(' '), parameters: { type: 'object', properties: { command: { type: 'string', description: 'Executable command to run. Prefer a bare executable such as "node", "ls", or "/bin/sh".' }, args: { type: 'array', items: { type: 'string' }, description: 'Command arguments.' }, cwd: { type: 'string', description: 'Working directory. Relative paths resolve from the current workspace; explicit absolute system paths are supported.' }, timeoutMs: { type: 'number', description: 'Timeout in milliseconds.' }, }, required: ['command'], additionalProperties: false, }, }
+  readonly definition: AgentTool['definition']
   constructor(options: TerminalExecToolOptions = {})
   async execute(input: TerminalExecInput, context: AgentToolContext = {}): Promise<AgentToolResult>
 }

--- a/packages/ekko-agent/src/runtime/system-prompt.ts
+++ b/packages/ekko-agent/src/runtime/system-prompt.ts
@@ -13,6 +13,8 @@ export interface SystemPromptInput {
     profile?: string
     cwd?: string
     workspaceRoot?: string
+    platform?: NodeJS.Platform
+    arch?: string
   }
 }
 
@@ -38,7 +40,7 @@ Treat external commands, language packages, and other prerequisites named by a S
 - Request independent tool calls together in one response. The runtime executes tools marked as parallel-safe concurrently while preserving serial barriers for stateful or dependent work.
 - When the user asks to execute or evaluate Node.js, JavaScript, or Python source code, use code_exec, including for one-line snippets. Do not probe Node or Python with terminal_exec first; code_exec resolves its runtime.
 - Use terminal_exec for CLI commands, project scripts, tests, builds, package managers, and other executables.
-- terminal_exec may use explicit absolute system paths and package-manager forms such as npx --dir. This capability is not limited to workspace files.
+- terminal_exec may use explicit absolute system paths and platform-appropriate package-manager forms. Follow the Command Environment section below; this capability is not limited to workspace files.
 - By default, keep downloads, clones, archives, extracted repositories, and generated intermediates inside the current workspace. Prefer the workspace's .ekko-tmp directory for disposable files so workspace-scoped file and image tools can inspect them. Use a system or external path only when the user or task explicitly requires it.
 - Dangerous tool calls may pause for runtime authorization. If authorization is denied, do not retry the operation through another tool or language runtime unless the user explicitly changes that decision.
 - After terminal_exec reports a [skill_validation] issue, do not claim the Skill installation is complete. Call skill_view for each writable local Skill and repair it with skill_manage until its frontmatter passes validation. Do not mutate read-only external Skill directories.
@@ -57,6 +59,10 @@ export function buildSystemPrompt(input: SystemPromptInput = {}): string {
   sections.push(input.basePrompt?.trim() || DEFAULT_BASE_PROMPT)
   sections.push(EKKO_OUTPUT_FORMAT_GUIDELINES)
   sections.push(EKKO_TOOL_EXECUTION_GUIDELINES)
+  sections.push(commandEnvironmentGuidelines(
+    input.context?.platform ?? process.platform,
+    input.context?.arch ?? process.arch,
+  ))
   if (input.clarificationEnabled) sections.push(EKKO_CLARIFICATION_GUIDELINES)
 
   if (input.runtimeInstructions?.length) {
@@ -109,6 +115,42 @@ export function buildSystemPrompt(input: SystemPromptInput = {}): string {
   }
 
   return sections.filter(Boolean).join('\n\n')
+}
+
+function commandEnvironmentGuidelines(platform: NodeJS.Platform, arch: string): string {
+  if (platform === 'win32') {
+    return `## Command Environment
+Host platform: Windows (${arch}). Generate Windows-native commands.
+
+- terminal_exec launches the provided executable directly and does not add an implicit shell.
+- Do not use Unix-only commands or paths such as sh, bash, ls, cat, grep, sed, awk, head, tail, which, /bin/sh, or /tmp unless this run has already established that a Unix compatibility layer provides them.
+- Prefer the workspace file tools for file access instead of shell-specific cat or type commands.
+- Run ordinary executables directly with separate command and args values.
+- For cmd built-ins, pipelines, redirection, or compound command lines, explicitly use command=cmd.exe with args=["/d", "/s", "/c", "..."] only when necessary.
+- Windows .cmd and .bat launchers, including many package-manager shims, are command scripts; invoke them through cmd.exe rather than treating them as native executables.
+- For PowerShell syntax, explicitly use powershell.exe or pwsh.exe with -NoProfile and -Command. Do not send PowerShell syntax to cmd.exe.
+- Use where.exe to locate an executable, or Get-Command inside PowerShell. Do not use which.
+- Use Windows paths and quote path arguments with spaces. Do not invent drive letters or assume WSL is installed.`
+  }
+
+  if (platform === 'darwin') {
+    return `## Command Environment
+Host platform: macOS (${arch}). Generate macOS-native commands.
+
+- terminal_exec launches the provided executable directly and does not add an implicit shell.
+- Run ordinary executables directly with separate command and args values. Invoke sh or zsh explicitly only when pipelines, redirection, globbing, or compound shell syntax is necessary.
+- Do not use Windows-only commands, PowerShell syntax, drive-letter paths, or cmd.exe.
+- macOS command-line utilities are BSD variants; do not assume GNU-only flags are available.
+- Prefer the workspace file tools for file access instead of cat-based shell pipelines.`
+  }
+
+  return `## Command Environment
+Host platform: ${platform === 'linux' ? 'Linux' : platform} (${arch}). Generate commands native to this platform.
+
+- terminal_exec launches the provided executable directly and does not add an implicit shell.
+- Run ordinary executables directly with separate command and args values. Invoke sh or bash explicitly only when pipelines, redirection, globbing, or compound shell syntax is necessary.
+- Do not use Windows-only commands, PowerShell syntax, drive-letter paths, or cmd.exe unless this run has already established that they are available.
+- Prefer the workspace file tools for file access instead of cat-based shell pipelines.`
 }
 
 function section(title: string, content: string): string {

--- a/packages/ekko-agent/src/tools/files.ts
+++ b/packages/ekko-agent/src/tools/files.ts
@@ -1,11 +1,15 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { mkdir, open, writeFile } from 'node:fs/promises'
 import path from 'node:path'
-import type { AgentTool, AgentToolContext, AgentToolResult } from './types'
+import { AgentToolError, type AgentTool, type AgentToolContext, type AgentToolResult } from './types'
 import { resolveToolPath } from './path-safety'
+
+export const DEFAULT_READ_FILE_MAX_BYTES = 50_000
 
 export interface ReadFileInput extends Record<string, unknown> {
   path: string
   encoding?: BufferEncoding
+  offset?: number
+  limit?: number
 }
 
 export interface WriteFileInput extends Record<string, unknown> {
@@ -20,12 +24,14 @@ export class ReadFileTool implements AgentTool<ReadFileInput> {
 
   readonly definition = {
     name: 'read_file',
-    description: 'Read a UTF-8 text file from the workspace.',
+    description: `Read a text file from the workspace, reading at most ${DEFAULT_READ_FILE_MAX_BYTES} file bytes per call. Use offset to continue a truncated read.`,
     parameters: {
       type: 'object',
       properties: {
         path: { type: 'string', description: 'File path relative to the current workspace.' },
         encoding: { type: 'string', description: 'Text encoding. Defaults to utf8.' },
+        offset: { type: 'number', description: 'Zero-based byte offset. Defaults to 0; use nextOffset from a truncated result to continue.' },
+        limit: { type: 'number', description: `Maximum file bytes to read (minimum 4). Defaults to and cannot exceed ${DEFAULT_READ_FILE_MAX_BYTES}.` },
       },
       required: ['path'],
       additionalProperties: false,
@@ -34,14 +40,48 @@ export class ReadFileTool implements AgentTool<ReadFileInput> {
 
   async execute(input: ReadFileInput, context: AgentToolContext = {}): Promise<AgentToolResult> {
     const filePath = resolveToolPath(input.path, context)
-    const content = await readFile(filePath, input.encoding || 'utf8')
-    return {
-      ok: true,
-      content,
-      data: {
-        path: filePath,
-        bytes: Buffer.byteLength(content, input.encoding || 'utf8'),
-      },
+    const encoding = normalizeReadEncoding(input.encoding)
+    const offset = nonNegativeInteger(input.offset, 'offset', 0)
+    const requestedLimit = positiveInteger(input.limit, 'limit', DEFAULT_READ_FILE_MAX_BYTES, 4)
+    const limit = Math.min(requestedLimit, DEFAULT_READ_FILE_MAX_BYTES)
+    const file = await open(filePath, 'r')
+
+    try {
+      const fileInfo = await file.stat()
+      const availableBytes = Math.max(0, fileInfo.size - offset)
+      const readCapacity = Math.min(availableBytes, limit)
+      const buffer = Buffer.alloc(readCapacity)
+      const bytesRead = readCapacity > 0
+        ? (await file.read(buffer, 0, readCapacity, offset)).bytesRead
+        : 0
+      const returnedBytes = decodedByteBoundary(
+        buffer.subarray(0, bytesRead),
+        encoding,
+        offset,
+        availableBytes > bytesRead,
+      )
+      const nextOffset = offset + returnedBytes
+      const truncated = nextOffset < fileInfo.size
+      const chunk = buffer.subarray(0, returnedBytes).toString(encoding)
+      const content = truncated
+        ? `${chunk}${chunk && !chunk.endsWith('\n') ? '\n' : ''}\n[read_file truncated: returned bytes ${offset}-${nextOffset - 1} of ${fileInfo.size}; call again with offset=${nextOffset}]`
+        : chunk
+
+      return {
+        ok: true,
+        content,
+        data: {
+          path: filePath,
+          bytes: returnedBytes,
+          totalBytes: fileInfo.size,
+          offset,
+          nextOffset,
+          truncated,
+          limit,
+        },
+      }
+    } finally {
+      await file.close()
     }
   }
 }
@@ -85,4 +125,57 @@ export function createFileTools(): AgentTool[] {
     new ReadFileTool(),
     new WriteFileTool(),
   ]
+}
+
+function normalizeReadEncoding(value: BufferEncoding | undefined): BufferEncoding {
+  const encoding = value || 'utf8'
+  if (!Buffer.isEncoding(encoding)) {
+    throw new AgentToolError(`Unsupported text encoding: ${encoding}`, 'INVALID_TOOL_INPUT')
+  }
+  return encoding
+}
+
+function nonNegativeInteger(value: number | undefined, name: string, fallback: number): number {
+  if (value === undefined) return fallback
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new AgentToolError(`${name} must be a non-negative integer.`, 'INVALID_TOOL_INPUT')
+  }
+  return value
+}
+
+function positiveInteger(value: number | undefined, name: string, fallback: number, minimum = 1): number {
+  if (value === undefined) return fallback
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    throw new AgentToolError(`${name} must be an integer greater than or equal to ${minimum}.`, 'INVALID_TOOL_INPUT')
+  }
+  return value
+}
+
+function decodedByteBoundary(buffer: Buffer, encoding: BufferEncoding, offset: number, hasMore: boolean): number {
+  let end = buffer.length
+  if (!hasMore || end === 0) return end
+  const normalized = encoding.toLowerCase()
+  if (normalized === 'utf8' || normalized === 'utf-8') {
+    let lead = end - 1
+    while (lead >= 0 && (buffer[lead] & 0xc0) === 0x80) lead -= 1
+    if (lead < 0) return end
+    const expectedBytes = utf8SequenceBytes(buffer[lead])
+    if (expectedBytes > end - lead) end = lead
+    return end
+  }
+  if (
+    (normalized === 'utf16le' || normalized === 'utf-16le' || normalized === 'ucs2' || normalized === 'ucs-2')
+    && (offset + end) % 2 !== 0
+  ) {
+    return end - 1
+  }
+  return end
+}
+
+function utf8SequenceBytes(leadByte: number): number {
+  if ((leadByte & 0x80) === 0) return 1
+  if ((leadByte & 0xe0) === 0xc0) return 2
+  if ((leadByte & 0xf0) === 0xe0) return 3
+  if ((leadByte & 0xf8) === 0xf0) return 4
+  return 1
 }

--- a/packages/ekko-agent/src/tools/terminal.ts
+++ b/packages/ekko-agent/src/tools/terminal.ts
@@ -12,36 +12,17 @@ export interface TerminalExecInput extends Record<string, unknown> {
 
 export interface TerminalExecToolOptions {
   timeoutMs?: number
+  platform?: NodeJS.Platform
 }
 
 export class TerminalExecTool implements AgentTool<TerminalExecInput> {
-  readonly definition = {
-    name: 'terminal_exec',
-    description: [
-      'Run a CLI command, project script, test, build, package manager, or system executable.',
-      'Prefer command as the executable and args as the argument array; shell string execution is not used.',
-      'Commands are not confined to the workspace: explicit absolute paths and package-manager forms such as npx --dir are supported.',
-      'Keep downloads, clones, extracted files, and generated intermediates under the current workspace (prefer .ekko-tmp) when workspace tools need to inspect them.',
-      'When the user asks to execute or evaluate Node.js, JavaScript, or Python source code, use code_exec instead, even for a one-line snippet.',
-      'Destructive, privileged, remote-shell, publishing, and other dangerous commands require runtime authorization before execution.',
-    ].join(' '),
-    parameters: {
-      type: 'object',
-      properties: {
-        command: { type: 'string', description: 'Executable command to run. Prefer a bare executable such as "node", "ls", or "/bin/sh".' },
-        args: { type: 'array', items: { type: 'string' }, description: 'Command arguments.' },
-        cwd: { type: 'string', description: 'Working directory. Relative paths resolve from the current workspace; explicit absolute system paths are supported.' },
-        timeoutMs: { type: 'number', description: 'Timeout in milliseconds.' },
-      },
-      required: ['command'],
-      additionalProperties: false,
-    },
-  }
+  readonly definition: AgentTool['definition']
 
   private readonly timeoutMs: number
 
   constructor(options: TerminalExecToolOptions = {}) {
     this.timeoutMs = positiveInteger(options.timeoutMs, 30_000)
+    this.definition = terminalExecDefinition(options.platform ?? process.platform)
   }
 
   async execute(input: TerminalExecInput, context: AgentToolContext = {}): Promise<AgentToolResult> {
@@ -122,6 +103,56 @@ export class TerminalExecTool implements AgentTool<TerminalExecInput> {
         })
       })
     })
+  }
+}
+
+function terminalExecDefinition(platform: NodeJS.Platform): AgentTool['definition'] {
+  const windows = platform === 'win32'
+  const platformGuidance = windows
+    ? [
+        'This runtime is Windows: generate Windows-native commands.',
+        'Do not use Unix-only commands such as sh, bash, ls, cat, grep, sed, awk, head, tail, which, or /bin/sh unless their availability was already established.',
+        'Run native executables directly. For cmd built-ins, compound syntax, and .cmd or .bat launchers, explicitly invoke cmd.exe; for PowerShell syntax, explicitly invoke powershell.exe or pwsh.exe.',
+      ]
+    : platform === 'darwin'
+      ? [
+          'This runtime is macOS: generate macOS-native commands and remember that system utilities use BSD rather than GNU semantics.',
+          'Run normal executables directly. Invoke sh or zsh explicitly only for shell syntax.',
+        ]
+      : [
+          `This runtime is ${platform === 'linux' ? 'Linux' : platform}: generate native commands for this platform.`,
+          'Run normal executables directly. Invoke sh or bash explicitly only for shell syntax.',
+        ]
+
+  return {
+    name: 'terminal_exec',
+    description: [
+      'Run a CLI command, project script, test, build, package manager, or system executable.',
+      'Prefer command as the executable and args as the argument array; shell string execution is not used.',
+      ...platformGuidance,
+      windows
+        ? 'Commands are not confined to the workspace: explicit absolute Windows paths are supported.'
+        : 'Commands are not confined to the workspace: explicit absolute paths and package-manager forms such as npx --dir are supported.',
+      'Keep downloads, clones, extracted files, and generated intermediates under the current workspace (prefer .ekko-tmp) when workspace tools need to inspect them.',
+      'When the user asks to execute or evaluate Node.js, JavaScript, or Python source code, use code_exec instead, even for a one-line snippet.',
+      'Destructive, privileged, remote-shell, publishing, and other dangerous commands require runtime authorization before execution.',
+    ].join(' '),
+    parameters: {
+      type: 'object',
+      properties: {
+        command: {
+          type: 'string',
+          description: windows
+            ? 'Executable command to run, such as git.exe, cmd.exe, or powershell.exe. Do not place a whole shell command line here.'
+            : 'Executable command to run. Prefer a bare executable such as git, ls, or /bin/sh.',
+        },
+        args: { type: 'array', items: { type: 'string' }, description: 'Command arguments.' },
+        cwd: { type: 'string', description: 'Working directory. Relative paths resolve from the current workspace; explicit absolute system paths are supported.' },
+        timeoutMs: { type: 'number', description: 'Timeout in milliseconds.' },
+      },
+      required: ['command'],
+      additionalProperties: false,
+    },
   }
 }
 

--- a/tests/ekko-agent/runtime.test.ts
+++ b/tests/ekko-agent/runtime.test.ts
@@ -2166,10 +2166,43 @@ describe('ekko-agent runtime', () => {
     expect(prompt).toContain('use code_exec, including for one-line snippets')
     expect(prompt).toContain('Do not probe Node or Python with terminal_exec first')
     expect(prompt).toContain('Use terminal_exec for CLI commands')
-    expect(prompt).toContain('npx --dir')
+    expect(prompt).toContain('platform-appropriate package-manager forms')
     expect(prompt).toContain("workspace's .ekko-tmp directory")
     expect(prompt).toContain('After terminal_exec reports a [skill_validation] issue')
     expect(prompt).toContain('do not retry the operation through another tool or language runtime')
     expect(prompt).toContain('prefer a compatible installed or built-in alternative')
+  })
+
+  it('buildSystemPrompt injects Windows-native command rules on Windows', () => {
+    const prompt = buildSystemPrompt({
+      basePrompt: 'Base',
+      context: { platform: 'win32', arch: 'x64' },
+    })
+
+    expect(prompt).toContain('## Command Environment')
+    expect(prompt).toContain('Host platform: Windows (x64)')
+    expect(prompt).toContain('Do not use Unix-only commands or paths')
+    expect(prompt).toContain('command=cmd.exe')
+    expect(prompt).toContain('Windows .cmd and .bat launchers')
+    expect(prompt).toContain('Use where.exe')
+    expect(prompt).toContain('Do not use which')
+    expect(prompt).toContain('Do not invent drive letters or assume WSL is installed')
+  })
+
+  it('buildSystemPrompt injects macOS and Linux command rules independently', () => {
+    const macPrompt = buildSystemPrompt({
+      basePrompt: 'Base',
+      context: { platform: 'darwin', arch: 'arm64' },
+    })
+    const linuxPrompt = buildSystemPrompt({
+      basePrompt: 'Base',
+      context: { platform: 'linux', arch: 'x64' },
+    })
+
+    expect(macPrompt).toContain('Host platform: macOS (arm64)')
+    expect(macPrompt).toContain('BSD variants')
+    expect(macPrompt).toContain('Invoke sh or zsh explicitly')
+    expect(linuxPrompt).toContain('Host platform: Linux (x64)')
+    expect(linuxPrompt).toContain('Invoke sh or bash explicitly')
   })
 })

--- a/tests/ekko-agent/tools.test.ts
+++ b/tests/ekko-agent/tools.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   AgentToolError,
+  DEFAULT_READ_FILE_MAX_BYTES,
   DelegateTaskTool,
   ReadFileTool,
   TerminalExecTool,
@@ -68,6 +69,71 @@ describe('ekko-agent tools', () => {
       ok: true,
       content: 'ship tools',
     })
+  })
+
+  it('bounds large file reads and supports continuing from the next byte offset', async () => {
+    const reader = new ReadFileTool()
+    const content = 'x'.repeat(DEFAULT_READ_FILE_MAX_BYTES + 25)
+    await writeFile(path.join(workspaceRoot, 'large.txt'), content)
+
+    const first = await reader.execute({
+      path: 'large.txt',
+      limit: DEFAULT_READ_FILE_MAX_BYTES * 2,
+    }, { workspaceRoot })
+
+    expect(first.content.startsWith('x'.repeat(DEFAULT_READ_FILE_MAX_BYTES))).toBe(true)
+    expect(first.content).toContain(`[read_file truncated: returned bytes 0-${DEFAULT_READ_FILE_MAX_BYTES - 1} of ${content.length}; call again with offset=${DEFAULT_READ_FILE_MAX_BYTES}]`)
+    expect(first.data).toMatchObject({
+      bytes: DEFAULT_READ_FILE_MAX_BYTES,
+      totalBytes: content.length,
+      offset: 0,
+      nextOffset: DEFAULT_READ_FILE_MAX_BYTES,
+      truncated: true,
+      limit: DEFAULT_READ_FILE_MAX_BYTES,
+    })
+
+    const second = await reader.execute({
+      path: 'large.txt',
+      offset: DEFAULT_READ_FILE_MAX_BYTES,
+    }, { workspaceRoot })
+    expect(second).toMatchObject({
+      ok: true,
+      content: 'x'.repeat(25),
+      data: {
+        bytes: 25,
+        totalBytes: content.length,
+        offset: DEFAULT_READ_FILE_MAX_BYTES,
+        nextOffset: content.length,
+        truncated: false,
+      },
+    })
+  })
+
+  it('does not split a UTF-8 code point at a read boundary', async () => {
+    const reader = new ReadFileTool()
+    await writeFile(path.join(workspaceRoot, 'unicode.txt'), 'aaaa😀z')
+
+    const first = await reader.execute({ path: 'unicode.txt', limit: 5 }, { workspaceRoot })
+    expect(first.content).toMatch(/^aaaa\n\n\[read_file truncated:/)
+    expect(first.content).not.toContain('�')
+    expect(first.data).toMatchObject({ bytes: 4, nextOffset: 4, truncated: true })
+
+    await expect(reader.execute({ path: 'unicode.txt', offset: 4 }, { workspaceRoot })).resolves.toMatchObject({
+      content: '😀z',
+      data: { bytes: 5, nextOffset: 9, truncated: false },
+    })
+  })
+
+  it('rejects invalid read ranges', async () => {
+    const reader = new ReadFileTool()
+    await writeFile(path.join(workspaceRoot, 'note.txt'), 'hello')
+
+    await expect(reader.execute({ path: 'note.txt', offset: -1 }, { workspaceRoot }))
+      .rejects.toMatchObject({ code: 'INVALID_TOOL_INPUT' })
+    await expect(reader.execute({ path: 'note.txt', limit: 0 }, { workspaceRoot }))
+      .rejects.toMatchObject({ code: 'INVALID_TOOL_INPUT' })
+    await expect(reader.execute({ path: 'note.txt', limit: 3 }, { workspaceRoot }))
+      .rejects.toMatchObject({ code: 'INVALID_TOOL_INPUT' })
   })
 
   it('blocks file paths outside workspaceRoot', async () => {
@@ -287,6 +353,27 @@ describe('ekko-agent tools', () => {
       ok: true,
       content: 'ok',
     })
+  })
+
+  it('describes Windows-native terminal commands without Unix defaults', () => {
+    const definition = new TerminalExecTool({ platform: 'win32' }).definition
+
+    expect(definition.description).toContain('This runtime is Windows')
+    expect(definition.description).toContain('Do not use Unix-only commands')
+    expect(definition.description).toContain('cmd.exe')
+    expect(definition.description).toContain('.cmd or .bat launchers')
+    expect(definition.description).toContain('powershell.exe')
+    expect(definition.description).not.toContain('npx --dir')
+    expect(definition.parameters.properties?.command?.description).toContain('git.exe')
+  })
+
+  it('describes macOS terminal semantics separately from Windows', () => {
+    const definition = new TerminalExecTool({ platform: 'darwin' }).definition
+
+    expect(definition.description).toContain('This runtime is macOS')
+    expect(definition.description).toContain('BSD rather than GNU')
+    expect(definition.description).toContain('sh or zsh')
+    expect(definition.description).not.toContain('generate Windows-native commands')
   })
 
   it('delegates foreground and background tasks through the runtime callback', async () => {


### PR DESCRIPTION
## Summary
- cap Ekko read_file responses at 50,000 bytes and support offset/limit paging
- preserve UTF-8 and UTF-16 chunk boundaries and return continuation metadata
- inject host-platform command guidance into the system prompt and terminal_exec schema
- keep Windows command generation native to cmd.exe and PowerShell instead of assuming Unix tools

## Validation
- Ekko test suite: 291 passed
- npm run harness:check
- npm run api:docs:check
- npm run build