### PR TITLE
[codex] harden Runtime fallback validation

### DIFF
--- a/packages/client/src/api/hermes/runtime-versions.ts
+++ b/packages/client/src/api/hermes/runtime-versions.ts
@@ -9,6 +9,13 @@ export interface ActiveVersionManifest {
   pendingRuntimeRootDirectory?: string
   runtimeMigrationError?: string
   runtimeActivationError?: string
+  runtimeValidationFailures?: Array<{
+    version: string
+    platform: string
+    directory: string
+    reason: string
+    failedAt: string
+  }>
   webUiDirectory?: string
   platform?: string
   updatedAt?: string

--- a/packages/client/src/components/layout/VersionManagementModal.vue
+++ b/packages/client/src/components/layout/VersionManagementModal.vue
@@ -55,6 +55,9 @@ const currentPlatformRuntime = computed(() =>
 const runtimeVersions = computed(() => uniqueVersions([
   ...(status.value?.hermes.remoteVersions || []),
   ...currentPlatformRuntime.value.map(item => item.version),
+  ...(status.value?.active?.runtimeValidationFailures || [])
+    .filter(failure => failure.platform === status.value?.platform)
+    .map(failure => failure.version),
 ]))
 
 const runtimeJobs = computed(() => jobs.value.filter(job => job.kind === 'runtime'))

--- a/packages/desktop/src/main/hermes-environment-selection.ts
+++ b/packages/desktop/src/main/hermes-environment-selection.ts
@@ -29,6 +29,13 @@ export interface DesktopHermesSelection {
   agentRoot?: string
   environmentRoot?: string
   managedRuntimeVersion?: string
+  managedRuntimeFailures?: DesktopManagedHermesRuntimeFailure[]
+}
+
+export interface DesktopManagedHermesRuntimeFailure {
+  directory: string
+  version: string
+  reason: string
 }
 
 export interface DesktopManagedHermesRuntime {
@@ -38,6 +45,8 @@ export interface DesktopManagedHermesRuntime {
   agentRoot: string
   environmentRoot: string
   managedRuntimeVersion?: string
+  probePath?: string
+  validationError?: string
 }
 
 export interface DesktopHermesSelectionOptions {
@@ -45,6 +54,7 @@ export interface DesktopHermesSelectionOptions {
   searchPath: string
   hermesHome: string
   managedRuntime?: DesktopManagedHermesRuntime
+  managedRuntimes?: DesktopManagedHermesRuntime[]
   probeTimeoutMs?: number
 }
 
@@ -270,19 +280,45 @@ function normalizeVersion(raw: string): string {
     .trim() || ''
 }
 
+type HermesVersionProbeResult =
+  | { ok: true; version: string }
+  | { ok: false; error: string }
+
+function probeFailureMessage(error: unknown, timeout: number): string {
+  const detail = error as NodeJS.ErrnoException & {
+    killed?: boolean
+    signal?: NodeJS.Signals
+    stderr?: string | Buffer
+  }
+  const stderr = typeof detail?.stderr === 'string'
+    ? detail.stderr.trim()
+    : Buffer.isBuffer(detail?.stderr)
+      ? detail.stderr.toString('utf8').trim()
+      : ''
+  if (detail?.killed || detail?.code === 'ETIMEDOUT') {
+    return `hermes --version timed out after ${timeout}ms${stderr ? `: ${stderr}` : ''}`
+  }
+  const code = detail?.code !== undefined ? ` (${String(detail.code)})` : ''
+  const message = error instanceof Error ? error.message.replace(/^Error:\s*/, '').trim() : String(error)
+  return `hermes --version failed${code}: ${stderr || message || 'unknown error'}`
+}
+
 async function probeHermesVersion(
   selection: Omit<DesktopHermesSelection, 'version' | 'source'>,
   env: NodeJS.ProcessEnv,
   timeout: number,
-): Promise<string> {
-  if (!selection.pythonPath || !selection.agentRoot || !selection.environmentRoot) return ''
+  source: Exclude<DesktopHermesSelectionSource, 'none'>,
+): Promise<HermesVersionProbeResult> {
+  if (!selection.pythonPath) return { ok: false, error: 'Python path is not configured' }
+  if (!selection.agentRoot) return { ok: false, error: 'Agent Root is not configured' }
+  if (!selection.environmentRoot) return { ok: false, error: 'Python environment root is not configured' }
   const command = process.platform === 'win32' ? selection.pythonPath : selection.path
   const args = process.platform === 'win32'
     ? ['-m', 'hermes_cli.main', '--version']
     : ['--version']
   const probeEnv = withDesktopHermesSelection(env, {
     ...selection,
-    source: 'user-cli',
+    source,
     version: '',
   })
   try {
@@ -292,10 +328,26 @@ async function probeHermesVersion(
       windowsHide: true,
       env: probeEnv,
     })
-    return normalizeVersion(String(stdout || ''))
-  } catch {
-    return ''
+    const version = normalizeVersion(String(stdout || ''))
+    return version
+      ? { ok: true, version }
+      : { ok: false, error: 'hermes --version returned an empty version' }
+  } catch (error) {
+    return { ok: false, error: probeFailureMessage(error, timeout) }
   }
+}
+
+function managedRuntimePreflightError(runtime: DesktopManagedHermesRuntime): string {
+  if (runtime.validationError) return runtime.validationError
+  if (!existsSync(runtime.path)) return `Hermes executable is missing: ${runtime.path}`
+  if (!existsSync(runtime.pythonPath)) return `Python executable is missing: ${runtime.pythonPath}`
+  return ''
+}
+
+function missingManagedRuntimeAgentFiles(runtime: DesktopManagedHermesRuntime): string[] {
+  return ['run_agent.py', 'cli.py']
+    .map(name => join(runtime.agentRoot, name))
+    .filter(file => !existsSync(file))
 }
 
 function completeUserCliSelection(
@@ -321,46 +373,77 @@ export async function resolveDesktopHermesSelection(
     || (process.platform === 'win32' ? 'Path' : 'PATH')
   baseEnv[pathKey] = options.searchPath
   const explicitCommand = baseEnv.HERMES_BIN?.trim()
-  const managedRoot = options.managedRuntime?.directory || ''
+  const managedRuntimes = options.managedRuntimes?.length
+    ? options.managedRuntimes
+    : options.managedRuntime ? [options.managedRuntime] : []
+  const managedRoots = managedRuntimes.map(runtime => runtime.directory).filter(Boolean)
   const commands = [
     ...(explicitCommand && existsSync(explicitCommand) ? [explicitCommand] : []),
     ...findHermesCommands(options.searchPath, baseEnv),
   ]
   const userCommands = [...new Map(commands
-    .filter(command => !managedRoot || !isPathWithin(command, managedRoot))
+    .filter(command => !managedRoots.some(root => isPathWithin(command, root)))
     .map(command => [comparablePath(command), command])).values()]
   const timeout = options.probeTimeoutMs || DEFAULT_PROBE_TIMEOUT_MS
   const userCandidates = userCommands
     .map(command => completeUserCliSelection(command, options.hermesHome, baseEnv))
     .filter((candidate): candidate is NonNullable<typeof candidate> => Boolean(candidate))
-  const versions = await Promise.all(userCandidates.map(candidate =>
-    probeHermesVersion(candidate, baseEnv, timeout),
-  ))
-  const usableIndex = versions.findIndex(Boolean)
-  if (usableIndex >= 0) {
-    return {
-      ...userCandidates[usableIndex],
-      source: 'user-cli',
-      version: versions[usableIndex],
-    }
-  }
-
-  const managed = options.managedRuntime
-  if (managed
-    && existsSync(managed.path)
-    && existsSync(managed.pythonPath)
-    && existsSync(join(managed.agentRoot, 'run_agent.py'))) {
-    const version = await probeHermesVersion(managed, baseEnv, timeout)
-    if (version) {
+  for (const candidate of userCandidates) {
+    const probe = await probeHermesVersion(candidate, baseEnv, timeout, 'user-cli')
+    if (probe.ok) {
       return {
-        ...managed,
-        source: 'managed-runtime',
-        version,
+        ...candidate,
+        source: 'user-cli',
+        version: probe.version,
       }
     }
   }
 
-  return { source: 'none', path: '', version: '' }
+  const managedRuntimeFailures: DesktopManagedHermesRuntimeFailure[] = []
+  for (const managed of managedRuntimes) {
+    const preflightError = managedRuntimePreflightError(managed)
+    if (preflightError) {
+      managedRuntimeFailures.push({
+        directory: managed.directory,
+        version: managed.managedRuntimeVersion || '',
+        reason: preflightError,
+      })
+      continue
+    }
+
+    const managedEnv = { ...baseEnv }
+    if (managed.probePath) managedEnv[pathKey] = managed.probePath
+    const probe = await probeHermesVersion(managed, managedEnv, timeout, 'managed-runtime')
+    if (probe.ok) {
+      const missingAgentFiles = missingManagedRuntimeAgentFiles(managed)
+      if (missingAgentFiles.length > 0) {
+        managedRuntimeFailures.push({
+          directory: managed.directory,
+          version: managed.managedRuntimeVersion || '',
+          reason: `Runtime Agent files are missing: ${missingAgentFiles.join(', ')}`,
+        })
+        continue
+      }
+      return {
+        ...managed,
+        source: 'managed-runtime',
+        version: probe.version,
+        ...(managedRuntimeFailures.length > 0 ? { managedRuntimeFailures } : {}),
+      }
+    }
+    managedRuntimeFailures.push({
+      directory: managed.directory,
+      version: managed.managedRuntimeVersion || '',
+      reason: probe.error,
+    })
+  }
+
+  return {
+    source: 'none',
+    path: '',
+    version: '',
+    ...(managedRuntimeFailures.length > 0 ? { managedRuntimeFailures } : {}),
+  }
 }
 
 export function withDesktopHermesSelection(

--- a/packages/desktop/src/main/paths.ts
+++ b/packages/desktop/src/main/paths.ts
@@ -1,6 +1,6 @@
 import { app } from 'electron'
-import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
-import { join, relative, resolve } from 'node:path'
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { basename, dirname, join, relative, resolve } from 'node:path'
 import { homedir, platform } from 'node:os'
 import {
   resolveRuntimeResourceDir,
@@ -32,6 +32,7 @@ type RuntimeReleaseMetadata = {
 }
 
 type ActiveRuntimeVersion = {
+  schema?: unknown
   desktopAppVersion?: unknown
   platform?: unknown
   webUiVersion?: unknown
@@ -40,8 +41,17 @@ type ActiveRuntimeVersion = {
   pendingRuntimeRootDirectory?: unknown
   runtimeMigrationError?: unknown
   runtimeActivationError?: unknown
+  runtimeValidationFailures?: RuntimeValidationFailure[]
   webUiDirectory?: unknown
   updatedAt?: unknown
+}
+
+type RuntimeValidationFailure = {
+  version: string
+  platform: string
+  directory: string
+  reason: string
+  failedAt: string
 }
 
 function runtimeRequiredFileGroups(root: string): string[][] {
@@ -55,7 +65,11 @@ function runtimeRequiredFileGroups(root: string): string[][] {
       ]
     : [join(environmentRoot, 'bin', 'hermes')]
   const node = isWin ? join(root, 'node', 'node.exe') : join(root, 'node', 'bin', 'node')
-  const groups = [[python], hermes, [node]]
+  const groups = [
+    [python],
+    hermes,
+    [node],
+  ]
   if (isWin) groups.push([join(root, 'git', 'cmd', 'git.exe')])
   return groups
 }
@@ -91,12 +105,17 @@ function installedRuntimeDirectories(): Array<{ directory: string; version: stri
   const root = join(runtimeStorageRoot(), 'hermes')
   const currentPlatform = runtimePlatformKey()
   if (!existsSync(root)) return []
+  const failedDirectories = new Set(
+    (readActiveRuntimeVersion()?.runtimeValidationFailures || [])
+      .map(failure => resolve(failure.directory)),
+  )
 
   const runtimes: Array<{ directory: string; version: string }> = []
   try {
     for (const versionEntry of readdirSync(root, { withFileTypes: true })) {
       if (!versionEntry.isDirectory()) continue
       const platformDir = join(root, versionEntry.name, currentPlatform)
+      if (failedDirectories.has(resolve(platformDir))) continue
       if (!runtimeDirectoryReady(platformDir)) continue
       runtimes.push({
         directory: platformDir,
@@ -124,7 +143,9 @@ function readActiveRuntimeVersion(): ActiveRuntimeVersion | null {
   }
 }
 
-function recordRuntimeActivationError(active: ActiveRuntimeVersion, error: string): void {
+export function recordRuntimeActivationError(error: string): void {
+  const active = readActiveRuntimeVersion()
+  if (!active) return
   const file = activeRuntimeVersionFile()
   if (active.runtimeActivationError === error) return
   try {
@@ -136,6 +157,60 @@ function recordRuntimeActivationError(active: ActiveRuntimeVersion, error: strin
   } catch (err) {
     console.warn(
       `[runtime] failed to persist Runtime activation error: `
+      + `${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+}
+
+export function recordRuntimeSelectionResult(
+  failures: Array<{ directory: string; reason: string; version?: string }>,
+  selected?: { directory: string; version: string },
+): void {
+  if (failures.length === 0) return
+  const active = readActiveRuntimeVersion() || { schema: 1 }
+  const detail = failures
+    .map(failure => `Runtime "${failure.directory}" failed: ${failure.reason}`)
+    .join(' ')
+  const failedAt = new Date().toISOString()
+  const failedDirectories = new Set(failures.map(failure => resolve(failure.directory)))
+  const selectedDirectory = selected ? resolve(selected.directory) : ''
+  const runtimeValidationFailures: RuntimeValidationFailure[] = [
+    ...(active.runtimeValidationFailures || []).filter(failure => {
+      const directory = resolve(failure.directory)
+      return directory !== selectedDirectory && !failedDirectories.has(directory)
+    }),
+    ...failures.map(failure => ({
+      version: failure.version || basename(dirname(failure.directory)),
+      platform: runtimePlatformKey(),
+      directory: failure.directory,
+      reason: failure.reason,
+      failedAt,
+    })),
+  ]
+  const next: Record<string, unknown> = {
+    ...active,
+    schema: 1,
+    runtimeActivationError: selected
+      ? `${detail} Using fallback Runtime "${selected.directory}".`
+      : `${detail} No usable installed Runtime was found.`,
+    runtimeValidationFailures,
+    updatedAt: failedAt,
+  }
+  if (selected) {
+    next.runtimeDirectory = selected.directory
+    next.hermesRuntimeVersion = selected.version
+    next.platform = runtimePlatformKey()
+  } else {
+    delete next.runtimeDirectory
+    delete next.hermesRuntimeVersion
+  }
+  const file = activeRuntimeVersionFile()
+  try {
+    mkdirSync(dirname(file), { recursive: true })
+    writeFileSync(file, JSON.stringify(next, null, 2) + '\n')
+  } catch (err) {
+    console.warn(
+      `[runtime] failed to persist Runtime selection result: `
       + `${err instanceof Error ? err.message : String(err)}`,
     )
   }
@@ -292,7 +367,7 @@ export function desktopRuntimeDir(): string {
       ? `${activationError} Falling back to "${fallback}".`
       : `${activationError} No usable installed Runtime was found.`
     console.warn(`[runtime] ${detail}`)
-    recordRuntimeActivationError(active, detail)
+    recordRuntimeActivationError(detail)
   }
   if (fallback) return resolve(fallback)
 

--- a/packages/desktop/src/main/runtime-manager.ts
+++ b/packages/desktop/src/main/runtime-manager.ts
@@ -92,6 +92,13 @@ type ActiveRuntimeVersion = {
   pendingRuntimeRootDirectory?: string
   runtimeMigrationError?: string
   runtimeActivationError?: string
+  runtimeValidationFailures?: Array<{
+    version: string
+    platform: string
+    directory: string
+    reason: string
+    failedAt: string
+  }>
   webUiDirectory?: string
   platform?: string
   updatedAt?: string
@@ -124,7 +131,14 @@ function requiredRuntimeFiles(root: string): string[] {
   const nodeBin = process.platform === 'win32'
     ? join(root, 'node', 'node.exe')
     : join(root, 'node', 'bin', 'node')
-  const files = [pythonBin, hermesBin, nodeBin, join(root, RUNTIME_MANIFEST_NAME)]
+  const files = [
+    pythonBin,
+    hermesBin,
+    join(root, 'python', 'run_agent.py'),
+    join(root, 'python', 'cli.py'),
+    nodeBin,
+    join(root, RUNTIME_MANIFEST_NAME),
+  ]
   if (process.platform === 'win32') files.push(join(root, 'git', 'cmd', 'git.exe'))
   return files
 }
@@ -636,6 +650,8 @@ export function writeActiveRuntimeVersion(
     platform: runtimePlatformKey(),
     updatedAt: new Date().toISOString(),
   }
+  next.runtimeValidationFailures = (active?.runtimeValidationFailures || [])
+    .filter(failure => resolve(failure.directory) !== resolve(runtimeRoot))
   if (desktopAppVersionChanged) {
     delete next.webUiVersion
     if (activeWebUiVersion) {

--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -2,7 +2,7 @@ import { ChildProcess, execFile, execFileSync, spawn } from 'node:child_process'
 import { mkdirSync, readFileSync, writeFileSync, chmodSync, existsSync, readdirSync } from 'node:fs'
 import { createServer } from 'node:net'
 import { homedir } from 'node:os'
-import { dirname, delimiter, join, resolve } from 'node:path'
+import { basename, dirname, delimiter, join, resolve } from 'node:path'
 import { randomBytes } from 'node:crypto'
 import { promisify } from 'node:util'
 import { app } from 'electron'
@@ -24,10 +24,14 @@ import {
   tokenFile,
   pythonDir,
   pythonEnvironmentDir,
+  recordRuntimeSelectionResult,
+  runtimePlatformKey,
+  runtimeStorageRoot,
 } from './paths'
 import {
   resolveDesktopHermesSelection,
   withDesktopHermesSelection,
+  type DesktopManagedHermesRuntime,
 } from './hermes-environment-selection'
 
 const DEFAULT_PORT = 8748
@@ -258,6 +262,201 @@ function mergePathEntries(...paths: Array<string | undefined | null>): string {
   return entries.join(delimiter)
 }
 
+type ManagedRuntimeCandidate = DesktopManagedHermesRuntime & {
+  agentBrowserBin: string
+  agentBrowserHome: string
+  nodeBin: string
+  nodePath: string
+  gitBin?: string
+  gitPath: string
+  playwrightBrowsers: string
+}
+
+type RuntimeManifestSummary = {
+  schema?: number
+  platform?: string
+  hermesAgentVersion?: string
+  hermesSource?: {
+    repository?: string
+    ref?: string
+    commit?: string
+    installMethod?: string
+  }
+  asset?: { name?: string }
+}
+
+function readRuntimeManifestSummary(directory: string): RuntimeManifestSummary | null {
+  try {
+    return JSON.parse(readFileSync(join(directory, 'runtime-manifest.json'), 'utf8')) as RuntimeManifestSummary
+  } catch {
+    return null
+  }
+}
+
+function runtimeVersionFromManifest(directory: string, fallback = ''): string {
+  const manifest = readRuntimeManifestSummary(directory)
+  if (manifest?.hermesAgentVersion?.trim()) return manifest.hermesAgentVersion.trim()
+  const assetName = manifest?.asset?.name || ''
+  return assetName.match(/hermes-agent-([^-]+)-/)?.[1] || fallback
+}
+
+function validateManagedRuntimeCandidate(
+  candidate: ManagedRuntimeCandidate,
+  requireManifest: boolean,
+): string {
+  const requiredGroups: Array<{ label: string; paths: string[] }> = [
+    { label: 'Python executable', paths: [candidate.pythonPath] },
+    { label: 'Hermes executable', paths: [candidate.path] },
+    { label: 'Node executable', paths: [candidate.nodePath] },
+  ]
+  if (process.platform === 'win32') {
+    requiredGroups.push({ label: 'Git executable', paths: [candidate.gitBin || join(candidate.directory, 'git', 'cmd', 'git.exe')] })
+  }
+  const missing = requiredGroups.filter(group => !group.paths.some(existsSync))
+  if (missing.length > 0) {
+    return missing.map(group => `${group.label} is missing: ${group.paths.join(' or ')}`).join('; ')
+  }
+  if (!requireManifest) return ''
+
+  const manifest = readRuntimeManifestSummary(candidate.directory)
+  if (!manifest) return `Runtime manifest is missing or invalid: ${join(candidate.directory, 'runtime-manifest.json')}`
+  const expectedPlatform = runtimePlatformKey()
+  if (manifest.platform && manifest.platform !== expectedPlatform) {
+    return `Runtime platform mismatch: expected ${expectedPlatform}, received ${manifest.platform}`
+  }
+  if ((manifest.schema || 0) >= 2) {
+    const sourceFiles = [
+      join(candidate.agentRoot, '.git', 'HEAD'),
+      join(candidate.agentRoot, 'pyproject.toml'),
+    ]
+    const missingSourceFiles = sourceFiles.filter(file => !existsSync(file))
+    if (missingSourceFiles.length > 0) {
+      return `Runtime updateable source files are missing: ${missingSourceFiles.join(', ')}`
+    }
+    if (manifest.hermesSource?.installMethod !== 'git'
+      || !manifest.hermesSource.repository
+      || !manifest.hermesSource.ref
+      || !/^[0-9a-f]{40}$/i.test(manifest.hermesSource.commit || '')) {
+      return 'Runtime Hermes Git source metadata is invalid'
+    }
+  }
+  return ''
+}
+
+function directManagedRuntimeCandidate(
+  directory: string,
+  version: string,
+  userSearchPath: string,
+): ManagedRuntimeCandidate {
+  const agentRoot = join(directory, 'python')
+  const venvRoot = join(agentRoot, 'venv')
+  const environmentRoot = process.platform === 'win32'
+    ? [join(venvRoot, 'Scripts', 'python.exe'), join(venvRoot, 'python.exe')].some(existsSync) ? venvRoot : agentRoot
+    : existsSync(join(venvRoot, 'bin', 'python3')) ? venvRoot : agentRoot
+  const pythonPath = process.platform === 'win32'
+    ? existsSync(join(environmentRoot, 'Scripts', 'python.exe'))
+      ? join(environmentRoot, 'Scripts', 'python.exe')
+      : join(environmentRoot, 'python.exe')
+    : join(environmentRoot, 'bin', 'python3')
+  const commandWrapper = join(environmentRoot, 'Scripts', 'hermes.cmd')
+  const executable = join(environmentRoot, 'Scripts', 'hermes.exe')
+  const path = process.platform === 'win32'
+    ? existsSync(commandWrapper) || !existsSync(executable) ? commandWrapper : executable
+    : join(environmentRoot, 'bin', 'hermes')
+  const nodeBin = process.platform === 'win32' ? join(directory, 'node') : join(directory, 'node', 'bin')
+  const nodePath = process.platform === 'win32' ? join(nodeBin, 'node.exe') : join(nodeBin, 'node')
+  const gitBin = process.platform === 'win32' ? join(directory, 'git', 'cmd', 'git.exe') : undefined
+  const gitPath = process.platform === 'win32'
+    ? [join(directory, 'git', 'cmd'), join(directory, 'git', 'mingw64', 'bin')].filter(existsSync).join(delimiter)
+    : ''
+  const agentBrowserHome = join(agentRoot, 'agent-browser')
+  const agentBrowserBin = process.platform === 'win32'
+    ? join(agentRoot, 'node')
+    : join(agentRoot, 'node', 'bin')
+  const candidate: ManagedRuntimeCandidate = {
+    directory,
+    path,
+    pythonPath,
+    agentRoot,
+    environmentRoot,
+    managedRuntimeVersion: runtimeVersionFromManifest(directory, version),
+    agentBrowserBin,
+    agentBrowserHome,
+    nodeBin,
+    nodePath,
+    gitBin,
+    gitPath,
+    playwrightBrowsers: join(agentRoot, 'ms-playwright'),
+    probePath: mergePathEntries(dirname(path), dirname(pythonPath), agentBrowserBin, nodeBin, gitPath, userSearchPath),
+  }
+  candidate.validationError = validateManagedRuntimeCandidate(candidate, true)
+  return candidate
+}
+
+function managedRuntimeCandidates(
+  primary: ManagedRuntimeCandidate,
+  userSearchPath: string,
+): ManagedRuntimeCandidate[] {
+  if (process.env.HERMES_DESKTOP_RUNTIME_DIR?.trim()) return [primary]
+
+  const currentPlatform = runtimePlatformKey()
+  const root = join(runtimeStorageRoot(), 'hermes')
+  let versionDirectories: Array<{ version: string; directory: string }> = []
+  try {
+    versionDirectories = readdirSync(root, { withFileTypes: true })
+      .filter(entry => entry.isDirectory())
+      .map(entry => ({ version: entry.name, directory: join(root, entry.name, currentPlatform) }))
+      .filter(item => existsSync(item.directory))
+      .sort((left, right) => right.version.localeCompare(left.version, undefined, { numeric: true }))
+  } catch {
+    // Missing Runtime storage is a normal first-launch state.
+  }
+
+  const candidates: ManagedRuntimeCandidate[] = []
+  const seen = new Set<string>()
+  const validationFailures = new Map<string, string>()
+  try {
+    const active = JSON.parse(readFileSync(join(webUiHome(), 'desktop-runtime', 'active-version.json'), 'utf8')) as {
+      runtimeDirectory?: string
+      hermesRuntimeVersion?: string
+      platform?: string
+      runtimeValidationFailures?: Array<{ directory?: string; reason?: string }>
+    }
+    for (const failure of active.runtimeValidationFailures || []) {
+      if (failure.directory?.trim()) {
+        validationFailures.set(resolve(failure.directory), failure.reason || 'Runtime validation failed')
+      }
+    }
+    const activeDirectory = active.runtimeDirectory?.trim()
+    if (activeDirectory) {
+      const activeCandidate = directManagedRuntimeCandidate(
+        activeDirectory,
+        active.hermesRuntimeVersion || basename(dirname(activeDirectory)),
+        userSearchPath,
+      )
+      activeCandidate.validationError ||= validationFailures.get(resolve(activeDirectory))
+      candidates.push(activeCandidate)
+      seen.add(resolve(activeCandidate.directory))
+    }
+  } catch {
+    // A missing active selection is a normal first-launch state.
+  }
+  if (!seen.has(resolve(primary.directory))) {
+    primary.validationError ||= validationFailures.get(resolve(primary.directory))
+    candidates.push(primary)
+    seen.add(resolve(primary.directory))
+  }
+  for (const item of versionDirectories) {
+    const key = resolve(item.directory)
+    if (seen.has(key)) continue
+    seen.add(key)
+    const candidate = directManagedRuntimeCandidate(item.directory, item.version, userSearchPath)
+    candidate.validationError ||= validationFailures.get(key)
+    candidates.push(candidate)
+  }
+  return candidates
+}
+
 function extractMarkedPath(output: string): string | null {
   const start = output.lastIndexOf(PATH_MARKER_START)
   const end = output.lastIndexOf(PATH_MARKER_END)
@@ -376,13 +575,6 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
   mkdirSync(agentHome, { recursive: true })
 
   const isWin = process.platform === 'win32'
-  const bundledPythonPath = bundledPython()
-  const bundledPythonEnvironment = pythonEnvironmentDir()
-  const bundledAgentBrowserBin = isWin
-    ? join(pythonDir(), 'node')
-    : join(pythonDir(), 'node', 'bin')
-  const bundledNodeBin = nodeBinDir()
-  const bundledGitPath = gitPathDirs().join(delimiter)
   const bridgePort = await getFreeTcpPort()
   const workerPortBase = await getFreeTcpPortInRange(20000, 59000)
   const loginShellPath = await getLoginShellPath()
@@ -394,31 +586,83 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
     process.env.Path,
     COMMON_USER_BIN_DIRS.join(delimiter),
   )
+  const primaryRuntimeDirectory = desktopRuntimeDir()
+  const primaryPythonRoot = pythonDir()
+  const primaryPythonEnvironment = pythonEnvironmentDir()
+  const primaryPythonPath = bundledPython()
+  const primaryHermesPath = hermesBin()
+  const bundledNodeBin = nodeBinDir()
+  const primaryNodePath = bundledNode()
+  const primaryGitBin = bundledGit()
+  const primaryGitPath = gitPathDirs().join(delimiter)
+  const primaryAgentBrowserHome = bundledAgentBrowserHome()
+  const primaryAgentBrowserBin = isWin
+    ? join(primaryPythonRoot, 'node')
+    : join(primaryPythonRoot, 'node', 'bin')
+  const primaryRuntime: ManagedRuntimeCandidate = {
+    directory: primaryRuntimeDirectory,
+    path: primaryHermesPath,
+    pythonPath: primaryPythonPath,
+    agentRoot: primaryPythonRoot,
+    environmentRoot: primaryPythonEnvironment,
+    managedRuntimeVersion: runtimeVersionFromManifest(
+      primaryRuntimeDirectory,
+      basename(dirname(primaryRuntimeDirectory)),
+    ),
+    agentBrowserBin: primaryAgentBrowserBin,
+    agentBrowserHome: primaryAgentBrowserHome,
+    nodeBin: bundledNodeBin,
+    nodePath: primaryNodePath,
+    gitBin: primaryGitBin,
+    gitPath: primaryGitPath,
+    playwrightBrowsers: join(primaryPythonRoot, 'ms-playwright'),
+    probePath: mergePathEntries(
+      dirname(primaryHermesPath),
+      dirname(primaryPythonPath),
+      primaryAgentBrowserBin,
+      bundledNodeBin,
+      primaryGitPath,
+      userSearchPath,
+    ),
+  }
+  primaryRuntime.validationError = validateManagedRuntimeCandidate(
+    primaryRuntime,
+    app.isPackaged || Boolean(process.env.HERMES_DESKTOP_RUNTIME_DIR?.trim()),
+  )
+  const runtimeCandidates = managedRuntimeCandidates(primaryRuntime, userSearchPath)
   const hermesSelection = await resolveDesktopHermesSelection({
     env: process.env,
     searchPath: userSearchPath,
     hermesHome: agentHome,
-    managedRuntime: {
-      directory: desktopRuntimeDir(),
-      path: hermesBin(),
-      pythonPath: bundledPythonPath,
-      agentRoot: pythonDir(),
-      environmentRoot: bundledPythonEnvironment,
-    },
+    managedRuntimes: runtimeCandidates,
   })
+  const selectedManagedRuntime = hermesSelection.source === 'managed-runtime'
+    ? runtimeCandidates.find(candidate => resolve(candidate.path) === resolve(hermesSelection.path))
+    : undefined
+  const runtimeSupport = hermesSelection.source === 'none'
+    ? undefined
+    : selectedManagedRuntime || runtimeCandidates.find(candidate => !candidate.validationError)
+  const runtimeFailures = hermesSelection.managedRuntimeFailures || []
+  if (runtimeFailures.length > 0) {
+    for (const failure of runtimeFailures) {
+      console.warn(`[runtime] rejected Runtime "${failure.directory}": ${failure.reason}`)
+    }
+    recordRuntimeSelectionResult(runtimeFailures, selectedManagedRuntime
+      ? {
+          directory: selectedManagedRuntime.directory,
+          version: selectedManagedRuntime.managedRuntimeVersion || hermesSelection.version,
+        }
+      : undefined)
+  }
   const runtimePath = mergePathEntries(
     hermesSelection.path ? dirname(hermesSelection.path) : '',
     hermesSelection.pythonPath ? dirname(hermesSelection.pythonPath) : '',
-    bundledAgentBrowserBin,
-    bundledNodeBin,
-    bundledGitPath,
+    runtimeSupport?.agentBrowserBin,
+    runtimeSupport?.nodeBin,
+    runtimeSupport?.gitPath,
     userSearchPath,
   )
   const browserExecutableOverride = process.env.AGENT_BROWSER_EXECUTABLE_PATH?.trim()
-  const gitBin = bundledGit()
-  const bundledNodePath = bundledNode()
-  const bundledBrowserHome = bundledAgentBrowserHome()
-  const bundledPlaywrightBrowsers = join(pythonDir(), 'ms-playwright')
   console.log(
     `[desktop] Hermes source=${hermesSelection.source} `
     + `version=${hermesSelection.version || '-'} path=${hermesSelection.path || '-'}`,
@@ -430,18 +674,22 @@ export async function startWebUiServer(port = DEFAULT_PORT): Promise<string> {
     ELECTRON_RUN_AS_NODE: '1',
     NODE_ENV: 'production',
     HERMES_DESKTOP: 'true',
-    ...(existsSync(bundledNodePath) ? {
-      HERMES_AGENT_NODE: bundledNodePath,
-      HERMES_AGENT_NODE_ROOT: isWin ? bundledNodeBin : dirname(bundledNodeBin),
+    ...(runtimeSupport && existsSync(runtimeSupport.nodePath) ? {
+      HERMES_AGENT_NODE: runtimeSupport.nodePath,
+      HERMES_AGENT_NODE_ROOT: isWin ? runtimeSupport.nodeBin : dirname(runtimeSupport.nodeBin),
     } : {}),
     ...(process.env.AGENT_BROWSER_HOME?.trim()
       ? { AGENT_BROWSER_HOME: process.env.AGENT_BROWSER_HOME.trim() }
-      : existsSync(bundledBrowserHome) ? { AGENT_BROWSER_HOME: bundledBrowserHome } : {}),
+      : runtimeSupport && existsSync(runtimeSupport.agentBrowserHome)
+        ? { AGENT_BROWSER_HOME: runtimeSupport.agentBrowserHome }
+        : {}),
     ...(browserExecutableOverride ? { AGENT_BROWSER_EXECUTABLE_PATH: browserExecutableOverride } : {}),
     ...(process.env.PLAYWRIGHT_BROWSERS_PATH
       ? { PLAYWRIGHT_BROWSERS_PATH: process.env.PLAYWRIGHT_BROWSERS_PATH }
-      : existsSync(bundledPlaywrightBrowsers) ? { PLAYWRIGHT_BROWSERS_PATH: bundledPlaywrightBrowsers } : {}),
-    ...(gitBin ? { HERMES_AGENT_GIT: gitBin } : {}),
+      : runtimeSupport && existsSync(runtimeSupport.playwrightBrowsers)
+        ? { PLAYWRIGHT_BROWSERS_PATH: runtimeSupport.playwrightBrowsers }
+        : {}),
+    ...(runtimeSupport?.gitBin && existsSync(runtimeSupport.gitBin) ? { HERMES_AGENT_GIT: runtimeSupport.gitBin } : {}),
     // Force TCP loopback for the agent bridge. The default `ipc:///tmp/...`
     // unix socket is rejected on macOS in some EDR/sandbox setups (silent
     // SIGKILL of the bridge child within ~150ms). TCP on 127.0.0.1 works

--- a/packages/server/src/bootstrap/http.ts
+++ b/packages/server/src/bootstrap/http.ts
@@ -69,7 +69,11 @@ import {
   readLockedDesktopHermesSelection,
   type HermesRuntimeSelection,
 } from '../modules/hermes/services/runtime/selection'
-import { configureRuntimeInstallCompletedHandler, getRuntimeVersionStatus } from '../modules/hermes/services/runtime/version-manager'
+import {
+  configureRuntimeInstallCompletedHandler,
+  getRuntimeVersionStatus,
+  readActiveVersionManifest,
+} from '../modules/hermes/services/runtime/version-manager'
 import { isHermesAgentAvailable, updateAgentStatus } from '../modules/studio/public/agent-status-registry'
 import { scheduleWebUiRestart } from '../modules/studio/public/web-ui-restart'
 
@@ -326,6 +330,7 @@ function startLanDiscovery(): void {
 
 function recordLockedHermesSelection(selection: HermesRuntimeSelection): void {
   if (selection.source === 'none' || !selection.path) {
+    const activationError = readActiveVersionManifest()?.runtimeActivationError || ''
     updateAgentStatus('hermes', {
       name: 'Hermes',
       provider: 'Nous Research',
@@ -334,7 +339,7 @@ function recordLockedHermesSelection(selection: HermesRuntimeSelection): void {
       version: '',
       source: 'not-installed',
       path: '',
-      error: '',
+      error: activationError,
       installations: [],
     })
     return

--- a/packages/server/src/modules/hermes/services/runtime/discovery.ts
+++ b/packages/server/src/modules/hermes/services/runtime/discovery.ts
@@ -23,6 +23,11 @@ export interface HermesCliInstallation {
   source: 'managed-runtime' | 'user-cli'
   selected: boolean
   managedRuntimeVersion?: string
+  error?: string
+}
+
+export interface HermesCliDiscoveryOptions {
+  source?: 'all' | HermesCliInstallation['source']
 }
 
 function canonicalPath(path: string): string {
@@ -69,7 +74,21 @@ function normalizeVersion(raw: string): string {
     .trim() || ''
 }
 
-async function readHermesCliVersion(path: string, env: NodeJS.ProcessEnv): Promise<string> {
+function versionProbeError(error: unknown): string {
+  const detail = error as NodeJS.ErrnoException & { killed?: boolean; stderr?: string | Buffer }
+  const stderr = typeof detail?.stderr === 'string'
+    ? detail.stderr.trim()
+    : Buffer.isBuffer(detail?.stderr) ? detail.stderr.toString('utf8').trim() : ''
+  if (detail?.killed || detail?.code === 'ETIMEDOUT') return 'hermes --version timed out after 5000ms'
+  const code = detail?.code !== undefined ? ` (${String(detail.code)})` : ''
+  const message = error instanceof Error ? error.message.replace(/^Error:\s*/, '').trim() : String(error)
+  return `hermes --version failed${code}: ${stderr || message || 'unknown error'}`
+}
+
+export async function probeHermesCliVersion(
+  path: string,
+  env: NodeJS.ProcessEnv,
+): Promise<{ version: string; error: string }> {
   try {
     const result = await execHermesWithBin(path, ['--version'], {
       encoding: 'utf8',
@@ -77,9 +96,14 @@ async function readHermesCliVersion(path: string, env: NodeJS.ProcessEnv): Promi
       windowsHide: true,
       env,
     })
-    return normalizeVersion(result.stdout)
-  } catch {
-    if (process.platform !== 'win32' || !windowsCommandNeedsShell(path)) return ''
+    const version = normalizeVersion(result.stdout)
+    return version
+      ? { version, error: '' }
+      : { version: '', error: 'hermes --version returned an empty version' }
+  } catch (firstError) {
+    if (process.platform !== 'win32' || !windowsCommandNeedsShell(path)) {
+      return { version: '', error: versionProbeError(firstError) }
+    }
     try {
       const execution = windowsCmdShimExecution(path, ['--version'])
       const { stdout } = await execFileAsync(execution.command, execution.args, {
@@ -89,9 +113,12 @@ async function readHermesCliVersion(path: string, env: NodeJS.ProcessEnv): Promi
         windowsVerbatimArguments: execution.windowsVerbatimArguments,
         env,
       })
-      return normalizeVersion(String(stdout || ''))
-    } catch {
-      return ''
+      const version = normalizeVersion(String(stdout || ''))
+      return version
+        ? { version, error: '' }
+        : { version: '', error: 'hermes --version returned an empty version' }
+    } catch (fallbackError) {
+      return { version: '', error: versionProbeError(fallbackError) }
     }
   }
 }
@@ -105,6 +132,7 @@ async function readHermesCliVersion(path: string, env: NodeJS.ProcessEnv): Promi
 export async function discoverHermesCliInstallations(
   managedRuntimes: HermesManagedRuntimeLocation[],
   env: NodeJS.ProcessEnv = process.env,
+  options: HermesCliDiscoveryOptions = {},
 ): Promise<HermesCliInstallation[]> {
   const configuredBin = resolveHermesBin(env.HERMES_BIN)
   const commandPaths = await findHermesCommandPaths(env)
@@ -123,18 +151,24 @@ export async function discoverHermesCliInstallations(
     ? configuredPath
     : uniqueCandidates[0] ? comparablePath(uniqueCandidates[0]) : ''
 
-  return Promise.all(uniqueCandidates.map(async path => {
+  const installations: HermesCliInstallation[] = []
+  for (const path of uniqueCandidates) {
     const canonical = canonicalPath(path)
     const managedRuntime = managedRuntimes.find(runtime => {
       const runtimeDirectory = canonicalPath(runtime.directory)
       return isPathWithin(canonical, runtimeDirectory)
     })
-    return {
+    const source = managedRuntime ? 'managed-runtime' : 'user-cli'
+    if (options.source && options.source !== 'all' && options.source !== source) continue
+    const probe = await probeHermesCliVersion(path, env)
+    installations.push({
       path,
-      version: await readHermesCliVersion(path, env),
-      source: managedRuntime ? 'managed-runtime' : 'user-cli',
+      version: probe.version,
+      source,
       selected: comparablePath(path) === selectedPath,
       ...(managedRuntime ? { managedRuntimeVersion: managedRuntime.version } : {}),
-    }
-  }))
+      ...(probe.error ? { error: probe.error } : {}),
+    })
+  }
+  return installations
 }

--- a/packages/server/src/modules/hermes/services/runtime/selection.ts
+++ b/packages/server/src/modules/hermes/services/runtime/selection.ts
@@ -1,9 +1,19 @@
 import { existsSync } from 'fs'
 import { homedir } from 'os'
 import { delimiter, dirname, join } from 'path'
-import { discoverHermesCliInstallations, type HermesCliInstallation } from './discovery'
+import {
+  discoverHermesCliInstallations,
+  probeHermesCliVersion,
+  type HermesCliInstallation,
+} from './discovery'
 import { resolveHermesInstallationEnvironment } from './installation'
-import { listInstalledRuntimeVersions, readActiveVersionManifest, type InstalledRuntimeVersion } from './version-manager'
+import { isPathWithin } from './path'
+import {
+  listRuntimeVersionCandidates,
+  readActiveVersionManifest,
+  recordRuntimeSelectionResult,
+  type InstalledRuntimeVersion,
+} from './version-manager'
 
 export interface HermesRuntimeSelection {
   source: 'user-cli' | 'managed-runtime' | 'none'
@@ -65,9 +75,16 @@ function prependPath(env: NodeJS.ProcessEnv, entries: string[]): void {
 
 function clearManagedRuntimeEnvironment(env: NodeJS.ProcessEnv): void {
   for (const name of [
+    'HERMES_BIN',
     'HERMES_AGENT_BRIDGE_PYTHON',
     'HERMES_AGENT_CLI_PYTHON',
     'HERMES_AGENT_ROOT',
+    'HERMES_AGENT_NODE',
+    'HERMES_AGENT_NODE_ROOT',
+    'HERMES_AGENT_GIT',
+    'HERMES_RUNTIME_SOURCE',
+    'HERMES_RUNTIME_VERSION',
+    'HERMES_MANAGED_RUNTIME_VERSION',
     'VIRTUAL_ENV',
     'UV_PROJECT_ENVIRONMENT',
     'UV_PYTHON',
@@ -75,6 +92,31 @@ function clearManagedRuntimeEnvironment(env: NodeJS.ProcessEnv): void {
   ]) {
     delete env[name]
   }
+}
+
+function removeManagedRuntimePathEntries(
+  env: NodeJS.ProcessEnv,
+  runtimes: InstalledRuntimeVersion[],
+): void {
+  const pathKey = Object.keys(env).find(key => key.toLowerCase() === 'path')
+    || (process.platform === 'win32' ? 'Path' : 'PATH')
+  env[pathKey] = (env[pathKey] || '')
+    .split(delimiter)
+    .filter(entry => entry && !runtimes.some(runtime => isPathWithin(entry, runtime.directory)))
+    .join(delimiter)
+
+  for (const name of ['AGENT_BROWSER_HOME', 'PLAYWRIGHT_BROWSERS_PATH'] as const) {
+    const value = env[name]?.trim()
+    if (value && runtimes.some(runtime => isPathWithin(value, runtime.directory))) delete env[name]
+  }
+}
+
+function prepareRuntimeSelectionEnvironment(
+  env: NodeJS.ProcessEnv,
+  runtimes: InstalledRuntimeVersion[],
+): void {
+  clearManagedRuntimeEnvironment(env)
+  removeManagedRuntimePathEntries(env, runtimes)
 }
 
 function hermesHomeForEnvironment(env: NodeJS.ProcessEnv): string {
@@ -131,6 +173,8 @@ function applyUserCli(env: NodeJS.ProcessEnv, installation: HermesCliInstallatio
   )
   clearManagedRuntimeEnvironment(env)
   env.HERMES_BIN = installation.path
+  env.HERMES_RUNTIME_SOURCE = 'user-cli'
+  env.HERMES_RUNTIME_VERSION = installation.version
   if (paths.python) {
     env.HERMES_AGENT_BRIDGE_PYTHON = paths.python
     env.HERMES_AGENT_CLI_PYTHON = paths.python
@@ -154,7 +198,11 @@ function applyUserCli(env: NodeJS.ProcessEnv, installation: HermesCliInstallatio
 
 function applyManagedRuntime(env: NodeJS.ProcessEnv, runtime: InstalledRuntimeVersion): HermesRuntimeSelection {
   const paths = managedRuntimePaths(runtime)
+  clearManagedRuntimeEnvironment(env)
   env.HERMES_BIN = paths.hermes
+  env.HERMES_RUNTIME_SOURCE = 'managed-runtime'
+  env.HERMES_RUNTIME_VERSION = runtime.manifestHermesRuntimeVersion || runtime.version
+  env.HERMES_MANAGED_RUNTIME_VERSION = runtime.version
   env.HERMES_AGENT_BRIDGE_PYTHON = paths.python
   env.HERMES_AGENT_CLI_PYTHON = paths.python
   env.HERMES_AGENT_ROOT = paths.pythonRoot
@@ -193,20 +241,83 @@ export async function configurePreferredHermesRuntime(
 
   addUserHermesBinDirectory(env)
   const active = readActiveVersionManifest()
-  const installed = listInstalledRuntimeVersions(active)
-  const installations = await discoverHermesCliInstallations(installed, env)
+  const runtimeCandidates = listRuntimeVersionCandidates(active)
+  const installations = await discoverHermesCliInstallations(runtimeCandidates, env, { source: 'user-cli' })
   const userCli = installations.find(item =>
     item.source === 'user-cli'
     && Boolean(item.path)
     && Boolean(item.version.trim()),
   )
-  if (userCli) return applyUserCli(env, userCli)
+  if (userCli) {
+    prepareRuntimeSelectionEnvironment(env, runtimeCandidates)
+    return applyUserCli(env, userCli)
+  }
 
-  const activeRuntime = installed.find(item => item.active)
-    || installed.find(item => item.platform === `${process.platform === 'win32' ? 'win' : process.platform === 'darwin' ? 'mac' : process.platform}-${process.arch}`)
-  if (activeRuntime) return applyManagedRuntime(env, activeRuntime)
+  const currentPlatform = `${process.platform === 'win32' ? 'win' : process.platform === 'darwin' ? 'mac' : process.platform}-${process.arch}`
+  const managedFailures: Array<{
+    directory: string
+    reason: string
+    version: string
+    platform: string
+  }> = []
+  const cleanEnvironment = { ...env }
+  prepareRuntimeSelectionEnvironment(cleanEnvironment, runtimeCandidates)
+  for (const runtime of runtimeCandidates) {
+    if (runtime.platform !== currentPlatform) {
+      managedFailures.push({
+        directory: runtime.directory,
+        reason: `Runtime platform mismatch: expected ${currentPlatform}, received ${runtime.platform}`,
+        version: runtime.version,
+        platform: runtime.platform,
+      })
+      continue
+    }
+    if (runtime.validationError) {
+      managedFailures.push({
+        directory: runtime.directory,
+        reason: runtime.validationError,
+        version: runtime.version,
+        platform: runtime.platform,
+      })
+      continue
+    }
 
-  if (env.HERMES_BIN && !existsSync(env.HERMES_BIN)) delete env.HERMES_BIN
-  clearManagedRuntimeEnvironment(env)
+    const candidateEnv = { ...cleanEnvironment }
+    const candidateSelection = applyManagedRuntime(candidateEnv, runtime)
+    const probe = await probeHermesCliVersion(candidateSelection.path, candidateEnv)
+    if (!probe.version) {
+      managedFailures.push({
+        directory: runtime.directory,
+        reason: probe.error || 'hermes --version failed',
+        version: runtime.version,
+        platform: runtime.platform,
+      })
+      continue
+    }
+    const missingAgentFiles = ['run_agent.py', 'cli.py']
+      .map(name => join(runtime.directory, 'python', name))
+      .filter(file => !existsSync(file))
+    if (missingAgentFiles.length > 0) {
+      managedFailures.push({
+        directory: runtime.directory,
+        reason: `Runtime Agent files are missing: ${missingAgentFiles.join(', ')}`,
+        version: runtime.version,
+        platform: runtime.platform,
+      })
+      continue
+    }
+
+    prepareRuntimeSelectionEnvironment(env, runtimeCandidates)
+    const selected = applyManagedRuntime(env, runtime)
+    selected.version = probe.version
+    env.HERMES_RUNTIME_VERSION = probe.version
+    recordRuntimeSelectionResult(managedFailures, runtime)
+    return selected
+  }
+
+  recordRuntimeSelectionResult(managedFailures)
+  prepareRuntimeSelectionEnvironment(env, runtimeCandidates)
+  env.HERMES_RUNTIME_SOURCE = 'none'
+  env.HERMES_RUNTIME_VERSION = ''
   return { source: 'none', path: '', version: '' }
 }

--- a/packages/server/src/modules/hermes/services/runtime/version-manager.ts
+++ b/packages/server/src/modules/hermes/services/runtime/version-manager.ts
@@ -27,9 +27,18 @@ export interface ActiveVersionManifest {
   pendingRuntimeRootDirectory?: string
   runtimeMigrationError?: string
   runtimeActivationError?: string
+  runtimeValidationFailures?: RuntimeValidationFailure[]
   webUiDirectory?: string
   platform?: string
   updatedAt?: string
+}
+
+export interface RuntimeValidationFailure {
+  version: string
+  platform: string
+  directory: string
+  reason: string
+  failedAt: string
 }
 
 export interface InstalledRuntimeVersion {
@@ -38,6 +47,7 @@ export interface InstalledRuntimeVersion {
   directory: string
   active: boolean
   manifestHermesRuntimeVersion?: string
+  validationError?: string
 }
 
 export interface InstalledWebUiVersion {
@@ -203,6 +213,52 @@ export function readActiveVersionManifest(): ActiveVersionManifest | null {
   return readJsonFile<ActiveVersionManifest>(activeVersionPath())
 }
 
+export function recordRuntimeSelectionResult(
+  failures: Array<{ directory: string; reason: string; version?: string; platform?: string }>,
+  selected?: InstalledRuntimeVersion,
+): void {
+  if (failures.length === 0) return
+  const active = readActiveVersionManifest() || { schema: 1 }
+  const detail = failures
+    .map(failure => `Runtime "${failure.directory}" failed: ${failure.reason}`)
+    .join(' ')
+  const failedAt = new Date().toISOString()
+  const failedDirectories = new Set(failures.map(failure => resolve(failure.directory)))
+  const selectedDirectory = selected ? resolve(selected.directory) : ''
+  const previousFailures = active.runtimeValidationFailures || []
+  const runtimeValidationFailures: RuntimeValidationFailure[] = [
+    ...previousFailures.filter(failure => {
+      const directory = resolve(failure.directory)
+      return directory !== selectedDirectory && !failedDirectories.has(directory)
+    }),
+    ...failures.map(failure => ({
+      version: failure.version || basename(dirname(failure.directory)),
+      platform: failure.platform || basename(failure.directory),
+      directory: failure.directory,
+      reason: failure.reason,
+      failedAt,
+    })),
+  ]
+  const next: ActiveVersionManifest = {
+    ...active,
+    runtimeActivationError: selected
+      ? `${detail} Using fallback Runtime "${selected.directory}".`
+      : `${detail} No usable installed Runtime was found.`,
+    runtimeValidationFailures,
+    updatedAt: failedAt,
+  }
+  if (selected) {
+    next.hermesRuntimeVersion = selected.manifestHermesRuntimeVersion || selected.version
+    next.runtimeDirectory = selected.directory
+    next.platform = selected.platform
+  } else {
+    delete next.hermesRuntimeVersion
+    delete next.runtimeDirectory
+  }
+  mkdirSync(dirname(activeVersionPath()), { recursive: true })
+  writeFileSync(activeVersionPath(), JSON.stringify(next, null, 2) + '\n', 'utf8')
+}
+
 function normalizeStringList(value: unknown): string[] {
   return Array.isArray(value)
     ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
@@ -239,9 +295,23 @@ function requiredRuntimeFileGroups(root: string): string[][] {
   const nodeBin = process.platform === 'win32'
     ? join(root, 'node', 'node.exe')
     : join(root, 'node', 'bin', 'node')
-  const groups = [[pythonBin], hermesBins, [nodeBin], [join(root, 'runtime-manifest.json')]]
+  const groups = [
+    [pythonBin],
+    hermesBins,
+    [nodeBin],
+    [join(root, 'runtime-manifest.json')],
+  ]
   if (process.platform === 'win32') groups.push([join(root, 'git', 'cmd', 'git.exe')])
   return groups
+}
+
+function validateRuntimeAgentFiles(root: string): void {
+  const missing = ['run_agent.py', 'cli.py']
+    .map(name => join(root, 'python', name))
+    .filter(file => !existsSync(file))
+  if (missing.length > 0) {
+    throw new Error(`Runtime Agent files are missing: ${missing.map(file => relative(root, file)).join(', ')}`)
+  }
 }
 
 function missingRuntimeFiles(root: string): string[] {
@@ -322,24 +392,39 @@ function scanInstalledRuntimeVersions(active = readActiveVersionManifest()): Ins
   return installed
 }
 
-export function listInstalledRuntimeVersions(active = readActiveVersionManifest()): InstalledRuntimeVersion[] {
+function sortRuntimeVersions(installed: InstalledRuntimeVersion[]): InstalledRuntimeVersion[] {
   const currentPlatform = runtimePlatformKey()
-  const installed = scanInstalledRuntimeVersions(active)
-    .filter(item => {
-      try {
-        validateRuntimeDirectory(item.directory, item.platform)
-        return true
-      } catch {
-        return false
-      }
-    })
-
   return installed.sort((left, right) => {
     if (left.active !== right.active) return left.active ? -1 : 1
     if (left.platform === currentPlatform && right.platform !== currentPlatform) return -1
     if (right.platform === currentPlatform && left.platform !== currentPlatform) return 1
     return right.version.localeCompare(left.version, undefined, { numeric: true })
   })
+}
+
+export function listRuntimeVersionCandidates(active = readActiveVersionManifest()): InstalledRuntimeVersion[] {
+  const validationFailures = new Map(
+    (active?.runtimeValidationFailures || []).map(failure => [resolve(failure.directory), failure.reason]),
+  )
+  const candidates = scanInstalledRuntimeVersions(active)
+    .map(item => {
+      const recordedFailure = validationFailures.get(resolve(item.directory))
+      if (recordedFailure) return { ...item, validationError: recordedFailure }
+      try {
+        validateRuntimeDirectory(item.directory, item.platform)
+        return item
+      } catch (error) {
+        return {
+          ...item,
+          validationError: error instanceof Error ? error.message : String(error),
+        }
+      }
+    })
+  return sortRuntimeVersions(candidates)
+}
+
+export function listInstalledRuntimeVersions(active = readActiveVersionManifest()): InstalledRuntimeVersion[] {
+  return listRuntimeVersionCandidates(active).filter(item => !item.validationError)
 }
 
 export function listInstalledWebUiVersions(active = readActiveVersionManifest()): InstalledWebUiVersion[] {
@@ -480,7 +565,8 @@ function recordHermesAgentStatus(status: RuntimeVersionStatus): void {
   const selected = status.hermes.cliInstallations.find(item => item.selected)
     || status.hermes.cliInstallations[0]
   const activeRuntime = status.hermes.installed.find(item => item.active)
-  const installed = Boolean(status.hermes.agentVersion || selected?.path || activeRuntime)
+  const installed = status.hermes.source !== 'none'
+    && Boolean(status.hermes.agentVersion || selected?.path || activeRuntime)
   updateAgentStatus('hermes', {
     name: 'Hermes',
     provider: 'Nous Research',
@@ -493,7 +579,7 @@ function recordHermesAgentStatus(status: RuntimeVersionStatus): void {
       || '',
     source: installed ? selected?.source || (activeRuntime ? 'managed-runtime' : 'user-cli') : 'not-installed',
     path: selected?.path || '',
-    error: '',
+    error: status.hermes.source === 'none' ? status.hermes.activationError : '',
     installations: status.hermes.cliInstallations,
   })
 }
@@ -600,6 +686,7 @@ export async function downloadRuntimeVersion(version: string, source: VersionDow
     onProgress?.({ stage: 'extract', message: 'runtimeVersions.jobStage.extractRuntime' })
     await extractTarGzip(archive, tempRoot)
     validateRuntimeDirectory(tempRoot, platform)
+    validateRuntimeAgentFiles(tempRoot)
     onProgress?.({ stage: 'install', message: 'runtimeVersions.jobStage.installRuntime' })
     removeRuntimePath(targetRoot)
     mkdirSync(dirname(targetRoot), { recursive: true })
@@ -673,6 +760,7 @@ export function activateInstalledRuntimeVersion(version: string): ActiveVersionM
   if (!target) throw new Error(`Installed runtime version not found for this platform: ${cleanVersion}`)
   try {
     validateRuntimeDirectory(target.directory, target.platform)
+    validateRuntimeAgentFiles(target.directory)
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err)
     throw new Error(`Runtime ${cleanVersion} cannot be activated: ${detail}`)
@@ -688,6 +776,8 @@ export function activateInstalledRuntimeVersion(version: string): ActiveVersionM
     pendingRuntimeRootDirectory: active?.pendingRuntimeRootDirectory || '',
     runtimeMigrationError: active?.runtimeMigrationError || '',
     runtimeActivationError: '',
+    runtimeValidationFailures: (active?.runtimeValidationFailures || [])
+      .filter(failure => resolve(failure.directory) !== resolve(target.directory)),
     platform: target.platform,
     updatedAt: new Date().toISOString(),
   }
@@ -775,6 +865,7 @@ export function activateDownloadedWebUiVersion(version: string): ActiveVersionMa
     pendingRuntimeRootDirectory: active?.pendingRuntimeRootDirectory || '',
     runtimeMigrationError: active?.runtimeMigrationError || '',
     runtimeActivationError: active?.runtimeActivationError || '',
+    runtimeValidationFailures: active?.runtimeValidationFailures || [],
     platform: active?.platform || runtimePlatformKey(),
     updatedAt: new Date().toISOString(),
   }

--- a/packages/server/src/modules/studio/sockets/chat-run.ts
+++ b/packages/server/src/modules/studio/sockets/chat-run.ts
@@ -54,6 +54,7 @@ import { authenticateUserToken, isAuthEnabled, type AuthenticatedUser } from '..
 import { userCanAccessProfile } from '../repositories/users-store'
 import { observeRunChatPetEvent } from '../public/pet-events'
 import { observeChatRunWebhookEvent, type ChatRunWebhookAgent } from '../services/webhooks'
+import { getAgentStatusSnapshot } from '../public/agent-status-registry'
 
 type AgentBridgeBackgroundNotification = any
 type AgentBridgeBackgroundSession = any
@@ -161,9 +162,29 @@ function isBridgeRunSource(source?: string): boolean {
   return source === 'cli' || source === 'global_agent' || source === 'workflow' || source === 'group_chat'
 }
 
-export async function ensureBridgeReadyForChatRun(): Promise<{ ok: true } | { ok: false; error: string }> {
+type ChatRunBridgeReadiness =
+  | { ok: true }
+  | { ok: false; error: string; runtimeUnavailable?: true }
+
+function runtimeUnavailableForChatRun(): ChatRunBridgeReadiness | null {
+  if (process.env.HERMES_RUNTIME_SOURCE?.trim() !== 'none') return null
+  const status = getAgentStatusSnapshot().agents.find(agent => agent.id === 'hermes')
+  return {
+    ok: false,
+    error: status?.error.trim()
+      || 'Hermes Runtime is not installed or is incomplete. Open Runtime Manager to repair or download a Runtime.',
+    runtimeUnavailable: true,
+  }
+}
+
+export async function ensureBridgeReadyForChatRun(): Promise<ChatRunBridgeReadiness> {
+  const runtimeUnavailable = runtimeUnavailableForChatRun()
+  if (runtimeUnavailable) return runtimeUnavailable
+
   try {
-    const readiness = await getAgentBridgeManager().ensureReady({ timeoutMs: 1000, connectRetryMs: 0, recover: false })
+    const manager = getAgentBridgeManager()
+    await manager.start()
+    const readiness = await manager.ensureReady({ timeoutMs: 1000, connectRetryMs: 0, recover: false })
     if (readiness.reachable) {
       return { ok: true }
     }
@@ -893,7 +914,9 @@ export class ChatRunSocket {
           event: 'run.failed',
           session_id: data.session_id,
           queue_id: data.queue_id,
-          error: `Agent Bridge is not reachable: ${bridgeReady.error}`,
+          error: bridgeReady.runtimeUnavailable
+            ? `Hermes Runtime is unavailable: ${bridgeReady.error}`
+            : `Agent Bridge is not reachable: ${bridgeReady.error}`,
         }
         if (data.session_id) {
           observeChatRunWebhookEvent({

--- a/tests/client/version-management-modal.test.ts
+++ b/tests/client/version-management-modal.test.ts
@@ -136,6 +136,33 @@ describe('VersionManagementModal Runtime storage selector', () => {
     expect(wrapper.text()).toContain('0.20.0')
   })
 
+  it('shows a failed Runtime as downloadable even when remote version lookup is unavailable', async () => {
+    const status = {
+      ...runtimeStatus(),
+      active: {
+        schema: 1,
+        runtimeValidationFailures: [{
+          version: '0.20.0',
+          platform: 'mac-arm64',
+          directory: '/state/desktop-runtime/hermes/0.20.0/mac-arm64',
+          reason: 'hermes --version timed out after 5000ms',
+          failedAt: new Date(0).toISOString(),
+        }],
+      },
+    }
+    api.fetchRuntimeVersionStatus.mockResolvedValue(status)
+    const wrapper = mount(VersionManagementModal, { props: { show: false } })
+
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('0.20.0')
+    expect(wrapper.text()).toContain('runtimeVersions.downloadGithub')
+    expect(wrapper.text()).toContain('runtimeVersions.downloadCf')
+    expect(wrapper.text()).not.toContain('runtimeVersions.installed')
+    expect(wrapper.text()).not.toContain('runtimeVersions.useVersion')
+  })
+
   it('shows selected user CLI paths in a read-only details drawer', async () => {
     const status = runtimeStatus()
     delete (status.hermes as { source?: string }).source

--- a/tests/desktop/hermes-environment-selection.test.ts
+++ b/tests/desktop/hermes-environment-selection.test.ts
@@ -1,6 +1,6 @@
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { delimiter, join } from 'node:path'
+import { delimiter, dirname, join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   resolveDesktopHermesSelection,
@@ -28,6 +28,7 @@ function userCli(root: string, version: string, succeeds = true) {
   const agentCommand = join(agentRoot, 'hermes')
   mkdirSync(agentRoot, { recursive: true })
   writeFileSync(join(agentRoot, 'run_agent.py'), '')
+  writeFileSync(join(agentRoot, 'cli.py'), '')
   writeFileSync(agentCommand, '')
   const command = executable(
     join(root, '.local', 'bin', 'hermes'),
@@ -38,17 +39,30 @@ function userCli(root: string, version: string, succeeds = true) {
   return { command, python, agentRoot, environmentRoot, hermesHome }
 }
 
-function managedRuntime(root: string, version: string): DesktopManagedHermesRuntime {
-  const directory = join(root, 'managed-runtime')
+function managedRuntime(
+  root: string,
+  version: string,
+  options: { name?: string; command?: string; probePath?: string } = {},
+): DesktopManagedHermesRuntime {
+  const directory = join(root, options.name || 'managed-runtime')
   const agentRoot = join(directory, 'python')
   const environmentRoot = join(agentRoot, 'venv')
   const pythonPath = executable(join(environmentRoot, 'bin', 'python3'), '#!/bin/sh\nexit 0\n')
   const path = executable(
     join(environmentRoot, 'bin', 'hermes'),
-    `#!/bin/sh\nprintf 'Hermes Agent ${version}\\n'\n`,
+    options.command || `#!/bin/sh\nprintf 'Hermes Agent ${version}\\n'\n`,
   )
   writeFileSync(join(agentRoot, 'run_agent.py'), '')
-  return { directory, path, pythonPath, agentRoot, environmentRoot, managedRuntimeVersion: version }
+  writeFileSync(join(agentRoot, 'cli.py'), '')
+  return {
+    directory,
+    path,
+    pythonPath,
+    agentRoot,
+    environmentRoot,
+    managedRuntimeVersion: version,
+    ...(options.probePath ? { probePath: options.probePath } : {}),
+  }
 }
 
 afterEach(() => {
@@ -146,5 +160,74 @@ describe.skipIf(process.platform === 'win32')('desktop Hermes environment select
       HERMES_RUNTIME_VERSION: '',
     })
     expect(withDesktopHermesSelection({ HERMES_BIN: '/stale/hermes' }, selected).HERMES_BIN).toBeUndefined()
+  })
+
+  it('probes managed Runtimes sequentially with isolated PATH values and records the first failure', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'desktop-hermes-selection-'))
+    temporaryDirectories.push(root)
+    const attempts = join(root, 'attempts.log')
+    const first = managedRuntime(root, '0.21.0', {
+      name: 'first-runtime',
+      command: `#!/bin/sh\nprintf 'first\\n' >> "${attempts}"\nexit 23\n`,
+    })
+    first.probePath = [dirname(first.path), '/usr/bin', '/bin'].join(delimiter)
+    const fallback = managedRuntime(root, '0.20.6', {
+      name: 'fallback-runtime',
+      command: `#!/bin/sh\nprintf 'fallback\\n' >> "${attempts}"\ncase "$PATH" in *first-runtime*) exit 41;; esac\nprintf 'Hermes Agent 0.20.6\\n'\n`,
+    })
+    fallback.probePath = [dirname(fallback.path), '/usr/bin', '/bin'].join(delimiter)
+
+    const selected = await resolveDesktopHermesSelection({
+      env: { PATH: [first.path, fallback.path].map(dirname).join(delimiter) },
+      searchPath: '/usr/bin:/bin',
+      hermesHome: join(root, '.hermes'),
+      managedRuntimes: [first, fallback],
+    })
+
+    expect(selected).toMatchObject({
+      source: 'managed-runtime',
+      path: fallback.path,
+      version: '0.20.6',
+      managedRuntimeFailures: [{
+        directory: first.directory,
+        version: '0.21.0',
+        reason: expect.stringContaining('(23)'),
+      }],
+    })
+    expect(readFileSync(attempts, 'utf8').trim().split('\n')).toEqual(['first', 'fallback'])
+  })
+
+  it('checks cli.py after hermes --version succeeds before falling back', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'desktop-hermes-selection-'))
+    temporaryDirectories.push(root)
+    const attempts = join(root, 'agent-files-attempts.log')
+    const incomplete = managedRuntime(root, '0.21.0', {
+      name: 'missing-cli-runtime',
+      command: `#!/bin/sh\nprintf 'version-ok\\n' >> "${attempts}"\nprintf 'Hermes Agent 0.21.0\\n'\n`,
+    })
+    rmSync(join(incomplete.agentRoot, 'cli.py'))
+    incomplete.probePath = [dirname(incomplete.path), '/usr/bin', '/bin'].join(delimiter)
+    const fallback = managedRuntime(root, '0.20.6', {
+      name: 'complete-runtime',
+      command: `#!/bin/sh\nprintf 'fallback\\n' >> "${attempts}"\nprintf 'Hermes Agent 0.20.6\\n'\n`,
+    })
+    fallback.probePath = [dirname(fallback.path), '/usr/bin', '/bin'].join(delimiter)
+
+    const selected = await resolveDesktopHermesSelection({
+      env: { PATH: '/usr/bin:/bin' },
+      searchPath: '/usr/bin:/bin',
+      hermesHome: join(root, '.hermes'),
+      managedRuntimes: [incomplete, fallback],
+    })
+
+    expect(selected).toMatchObject({
+      source: 'managed-runtime',
+      path: fallback.path,
+      managedRuntimeFailures: [{
+        directory: incomplete.directory,
+        reason: expect.stringContaining('cli.py'),
+      }],
+    })
+    expect(readFileSync(attempts, 'utf8').trim().split('\n')).toEqual(['version-ok', 'fallback'])
   })
 })

--- a/tests/desktop/runtime-manager.test.ts
+++ b/tests/desktop/runtime-manager.test.ts
@@ -38,6 +38,9 @@ function tempDir(prefix: string): string {
 }
 
 function createRuntimeFiles(root: string, options: { standardWindowsVenv?: boolean } = {}) {
+  mkdirSync(join(root, 'python'), { recursive: true })
+  writeFileSync(join(root, 'python', 'run_agent.py'), '')
+  writeFileSync(join(root, 'python', 'cli.py'), '')
   if (process.platform === 'win32') {
     const pythonRoot = options.standardWindowsVenv
       ? join(root, 'python', 'venv')

--- a/tests/server/chat-run-bridge-readiness.test.ts
+++ b/tests/server/chat-run-bridge-readiness.test.ts
@@ -4,6 +4,7 @@ const handleBridgeRunMock = vi.hoisted(() => vi.fn(async () => {}))
 const resumeBridgeRunMock = vi.hoisted(() => vi.fn(async () => {}))
 const handleCodingAgentRunMock = vi.hoisted(() => vi.fn(async () => {}))
 const loadSessionStateFromDbMock = vi.hoisted(() => vi.fn())
+const startBridgeMock = vi.hoisted(() => vi.fn())
 const ensureReadyMock = vi.hoisted(() => vi.fn())
 const getRuntimeStateMock = vi.hoisted(() => vi.fn())
 const userCanAccessProfileMock = vi.hoisted(() => vi.fn((_user: unknown, _profile: string) => true))
@@ -53,6 +54,7 @@ vi.mock('../../packages/server/src/modules/hermes/services/bridge/manager', () =
 vi.mock('../../packages/server/src/modules/studio/public/chat-agent-runtime', () => ({
   createPrimaryAgentBridge: vi.fn(() => bridgeMock),
   getPrimaryAgentBridgeManager: vi.fn(() => ({
+    start: startBridgeMock,
     ensureReady: ensureReadyMock,
     getRuntimeState: getRuntimeStateMock,
   })),
@@ -281,6 +283,8 @@ describe('ChatRunSocket global pending interactions', () => {
 describe('ensureBridgeReadyForChatRun', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    startBridgeMock.mockReset()
+    startBridgeMock.mockResolvedValue(undefined)
     ensureReadyMock.mockReset()
     getRuntimeStateMock.mockReset()
     bridgeMock.status.mockReset()
@@ -309,6 +313,7 @@ describe('ensureBridgeReadyForChatRun', () => {
     const { ensureBridgeReadyForChatRun } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
 
     await expect(ensureBridgeReadyForChatRun()).resolves.toEqual({ ok: true })
+    expect(startBridgeMock).toHaveBeenCalledTimes(1)
     expect(ensureReadyMock).toHaveBeenCalledWith({ timeoutMs: 1000, connectRetryMs: 0, recover: false })
   })
 
@@ -351,11 +356,38 @@ describe('ensureBridgeReadyForChatRun', () => {
       error: 'bridge startup timed out',
     })
   })
+
+  it('returns the recorded Runtime failure without starting the bridge when Runtime is unavailable', async () => {
+    const previousSource = process.env.HERMES_RUNTIME_SOURCE
+    process.env.HERMES_RUNTIME_SOURCE = 'none'
+    const registry = await import('../../packages/server/src/modules/studio/public/agent-status-registry')
+    registry.updateAgentStatus('hermes', {
+      installed: false,
+      source: 'not-installed',
+      error: 'Runtime 0.21.0 is missing python/run_agent.py',
+    })
+    try {
+      const { ensureBridgeReadyForChatRun } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
+      await expect(ensureBridgeReadyForChatRun()).resolves.toEqual({
+        ok: false,
+        error: 'Runtime 0.21.0 is missing python/run_agent.py',
+        runtimeUnavailable: true,
+      })
+      expect(startBridgeMock).not.toHaveBeenCalled()
+      expect(ensureReadyMock).not.toHaveBeenCalled()
+    } finally {
+      if (previousSource === undefined) delete process.env.HERMES_RUNTIME_SOURCE
+      else process.env.HERMES_RUNTIME_SOURCE = previousSource
+      registry.resetAgentStatusRegistryForTests()
+    }
+  })
 })
 
 describe('ChatRunSocket bridge readiness gating', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    startBridgeMock.mockReset()
+    startBridgeMock.mockResolvedValue(undefined)
     ensureReadyMock.mockReset()
     getRuntimeStateMock.mockReset()
     bridgeMock.status.mockReset()

--- a/tests/server/hermes-runtime-selection.test.ts
+++ b/tests/server/hermes-runtime-selection.test.ts
@@ -1,6 +1,6 @@
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
-import { delimiter, join } from 'path'
+import { delimiter, dirname, join } from 'path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const state = vi.hoisted(() => ({ appHome: '' }))
@@ -50,6 +50,7 @@ function createUserCli(home: string, version: string): {
   mkdirSync(join(agentRoot, 'venv', 'bin'), { recursive: true })
   mkdirSync(join(home, '.local', 'bin'), { recursive: true })
   writeFileSync(join(agentRoot, 'run_agent.py'), '')
+  writeFileSync(join(agentRoot, 'cli.py'), '')
   writeFileSync(agentCommand, '')
   writeFileSync(python, `#!/bin/sh\nprintf 'Hermes Agent ${version}\\n'\n`)
   writeFileSync(command, `#!/bin/sh\nexec "${python}" "${agentCommand}" "$@"\n`)
@@ -58,12 +59,22 @@ function createUserCli(home: string, version: string): {
   return { command, python, agentRoot, hermesHome }
 }
 
-function createManagedRuntime(root: string, version: string): string {
+function createManagedRuntime(
+  root: string,
+  version: string,
+  options: { activate?: boolean; command?: string } = {},
+): string {
   const runtime = join(root, 'desktop-runtime', 'hermes', version, platformKey())
   const environmentBin = join(runtime, 'python', 'venv', 'bin')
   const managedCli = cli(environmentBin, version)
+  if (options.command) {
+    writeFileSync(managedCli, options.command)
+    chmodSync(managedCli, 0o755)
+  }
   writeFileSync(join(environmentBin, 'python3'), '#!/bin/sh\nexit 0\n')
   chmodSync(join(environmentBin, 'python3'), 0o755)
+  writeFileSync(join(runtime, 'python', 'run_agent.py'), '')
+  writeFileSync(join(runtime, 'python', 'cli.py'), '')
   mkdirSync(join(runtime, 'node', 'bin'), { recursive: true })
   writeFileSync(join(runtime, 'node', 'bin', 'node'), '')
   writeFileSync(join(runtime, 'runtime-manifest.json'), JSON.stringify({
@@ -71,12 +82,14 @@ function createManagedRuntime(root: string, version: string): string {
     platform: platformKey(),
     hermesAgentVersion: version,
   }))
-  writeFileSync(join(root, 'desktop-runtime', 'active-version.json'), JSON.stringify({
-    schema: 1,
-    hermesRuntimeVersion: version,
-    runtimeDirectory: runtime,
-    platform: platformKey(),
-  }))
+  if (options.activate !== false) {
+    writeFileSync(join(root, 'desktop-runtime', 'active-version.json'), JSON.stringify({
+      schema: 1,
+      hermesRuntimeVersion: version,
+      runtimeDirectory: runtime,
+      platform: platformKey(),
+    }))
+  }
   return managedCli
 }
 
@@ -96,6 +109,8 @@ describe.skipIf(process.platform === 'win32')('Hermes Runtime selection', () => 
     const userCli = createUserCli(userHome, '0.20.4')
     const env: NodeJS.ProcessEnv = {
       ...process.env,
+      HERMES_DESKTOP: undefined,
+      HERMES_RUNTIME_SELECTION_LOCKED: undefined,
       HOME: userHome,
       HERMES_HOME: userCli.hermesHome,
       HERMES_BIN: managedCli,
@@ -131,6 +146,8 @@ describe.skipIf(process.platform === 'win32')('Hermes Runtime selection', () => 
     mkdirSync(userHome)
     const env: NodeJS.ProcessEnv = {
       ...process.env,
+      HERMES_DESKTOP: undefined,
+      HERMES_RUNTIME_SELECTION_LOCKED: undefined,
       HOME: userHome,
       HERMES_HOME: join(userHome, '.hermes'),
       HERMES_BIN: managedCli,
@@ -153,6 +170,8 @@ describe.skipIf(process.platform === 'win32')('Hermes Runtime selection', () => 
     mkdirSync(userHome)
     const env: NodeJS.ProcessEnv = {
       ...process.env,
+      HERMES_DESKTOP: undefined,
+      HERMES_RUNTIME_SELECTION_LOCKED: undefined,
       HOME: userHome,
       HERMES_HOME: join(userHome, '.hermes'),
       HERMES_BIN: managedCli,
@@ -197,5 +216,99 @@ describe.skipIf(process.platform === 'win32')('Hermes Runtime selection', () => 
       pythonPath: env.HERMES_AGENT_CLI_PYTHON,
       agentRoot: env.HERMES_AGENT_ROOT,
     })
+  })
+
+  it('falls back one Runtime at a time, isolates its environment, and preserves Web UI activation', async () => {
+    state.appHome = mkdtempSync(join(tmpdir(), 'hermes-selection-'))
+    temporaryDirectories.push(state.appHome)
+    const attempts = join(state.appHome, 'attempts.log')
+    const fallbackCli = createManagedRuntime(state.appHome, '0.20.6', {
+      activate: false,
+      command: `#!/bin/sh\nprintf 'fallback\\n' >> "${attempts}"\ncase "$PATH" in *0.21.0*) exit 41;; esac\nprintf 'Hermes Agent 0.20.6\\n'\n`,
+    })
+    const failingCli = createManagedRuntime(state.appHome, '0.21.0', {
+      command: `#!/bin/sh\nprintf 'failing\\n' >> "${attempts}"\nexit 23\n`,
+    })
+    const activeVersionPath = join(state.appHome, 'desktop-runtime', 'active-version.json')
+    const active = JSON.parse(readFileSync(activeVersionPath, 'utf8'))
+    writeFileSync(activeVersionPath, JSON.stringify({
+      ...active,
+      webUiVersion: '0.7.12',
+      webUiDirectory: '/preserved/webui',
+    }))
+    const invalidRuntime = join(state.appHome, 'desktop-runtime', 'hermes', '0.21.0', platformKey())
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      HOME: join(state.appHome, 'empty-home'),
+      HERMES_HOME: join(state.appHome, 'empty-home', '.hermes'),
+      HERMES_DESKTOP: undefined,
+      HERMES_RUNTIME_SELECTION_LOCKED: undefined,
+      HERMES_BIN: failingCli,
+      AGENT_BROWSER_HOME: join(invalidRuntime, 'python', 'agent-browser'),
+      PATH: [dirname(failingCli), '/usr/bin', '/bin'].join(delimiter),
+    }
+    mkdirSync(env.HOME!)
+
+    const { configurePreferredHermesRuntime } = await import('../../packages/server/src/modules/hermes/services/runtime/selection')
+    const selected = await configurePreferredHermesRuntime(env)
+    const persisted = JSON.parse(readFileSync(activeVersionPath, 'utf8'))
+
+    expect(selected).toMatchObject({ source: 'managed-runtime', path: fallbackCli, version: '0.20.6' })
+    expect(readFileSync(attempts, 'utf8').trim().split('\n')).toEqual(['failing', 'fallback'])
+    expect(env.PATH).not.toContain('0.21.0')
+    expect(env.AGENT_BROWSER_HOME).toContain('0.20.6')
+    expect(persisted).toMatchObject({
+      runtimeDirectory: join(state.appHome, 'desktop-runtime', 'hermes', '0.20.6', platformKey()),
+      hermesRuntimeVersion: '0.20.6',
+      webUiVersion: '0.7.12',
+      webUiDirectory: '/preserved/webui',
+      runtimeActivationError: expect.stringContaining('(23)'),
+      runtimeValidationFailures: [expect.objectContaining({
+        version: '0.21.0',
+        directory: invalidRuntime,
+        reason: expect.stringContaining('(23)'),
+      })],
+    })
+  })
+
+  it('marks every failed Runtime unavailable so the version can be downloaded again', async () => {
+    state.appHome = mkdtempSync(join(tmpdir(), 'hermes-selection-'))
+    temporaryDirectories.push(state.appHome)
+    const failingCli = createManagedRuntime(state.appHome, '0.20.0', {
+      command: '#!/bin/sh\nexit 23\n',
+    })
+    const runtimeDirectory = join(state.appHome, 'desktop-runtime', 'hermes', '0.20.0', platformKey())
+    const activeVersionPath = join(state.appHome, 'desktop-runtime', 'active-version.json')
+    const active = JSON.parse(readFileSync(activeVersionPath, 'utf8'))
+    writeFileSync(activeVersionPath, JSON.stringify({ ...active, webUiVersion: '0.7.12' }))
+    const home = join(state.appHome, 'empty-home')
+    mkdirSync(home)
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      HOME: home,
+      HERMES_HOME: join(home, '.hermes'),
+      HERMES_DESKTOP: undefined,
+      HERMES_RUNTIME_SELECTION_LOCKED: undefined,
+      HERMES_BIN: failingCli,
+      PATH: [dirname(failingCli), '/usr/bin', '/bin'].join(delimiter),
+    }
+
+    const { configurePreferredHermesRuntime } = await import('../../packages/server/src/modules/hermes/services/runtime/selection')
+    const selected = await configurePreferredHermesRuntime(env)
+    const versionManager = await import('../../packages/server/src/modules/hermes/services/runtime/version-manager')
+    const persisted = JSON.parse(readFileSync(activeVersionPath, 'utf8'))
+
+    expect(selected).toEqual({ source: 'none', path: '', version: '' })
+    expect(versionManager.listInstalledRuntimeVersions()).toEqual([])
+    expect(persisted.runtimeDirectory).toBeUndefined()
+    expect(persisted.hermesRuntimeVersion).toBeUndefined()
+    expect(persisted.webUiVersion).toBe('0.7.12')
+    expect(persisted.runtimeValidationFailures).toEqual([
+      expect.objectContaining({
+        version: '0.20.0',
+        directory: runtimeDirectory,
+        reason: expect.stringContaining('(23)'),
+      }),
+    ])
   })
 })

--- a/tests/server/run-chat-clarify-respond.test.ts
+++ b/tests/server/run-chat-clarify-respond.test.ts
@@ -17,7 +17,7 @@ vi.mock('../../packages/server/src/modules/ekko/services/clarifications', () => 
 
 vi.mock('../../packages/server/src/modules/studio/public/chat-agent-runtime', () => ({
   createPrimaryAgentBridge: vi.fn(() => bridgeMock),
-  getPrimaryAgentBridgeManager: vi.fn(() => ({ ensureReady: vi.fn() })),
+  getPrimaryAgentBridgeManager: vi.fn(() => ({ start: vi.fn(async () => {}), ensureReady: vi.fn() })),
   redactPrimaryAgentBridgeError: (error?: string) => error,
   chatCodingAgentRunManager: {
     resolveApproval: vi.fn(() => ({ handled: false, resolved: false })),

--- a/tests/server/run-chat-queued-item.test.ts
+++ b/tests/server/run-chat-queued-item.test.ts
@@ -67,7 +67,7 @@ vi.mock('../../packages/server/src/modules/coding-agents/services/runtime/run-ma
 
 vi.mock('../../packages/server/src/modules/studio/public/chat-agent-runtime', () => ({
   createPrimaryAgentBridge: vi.fn(() => bridgeMock),
-  getPrimaryAgentBridgeManager: vi.fn(() => ({ ensureReady: ensureReadyMock })),
+  getPrimaryAgentBridgeManager: vi.fn(() => ({ start: vi.fn(async () => {}), ensureReady: ensureReadyMock })),
   redactPrimaryAgentBridgeError: (error?: string) => error,
   chatCodingAgentRunManager: codingAgentRunManagerMock,
   handleChatCodingAgentSessionCommand: sessionCommandMocks.handleSessionCommand,

--- a/tests/server/run-chat-run-started-at.test.ts
+++ b/tests/server/run-chat-run-started-at.test.ts
@@ -53,6 +53,7 @@ vi.mock('../../packages/server/src/modules/hermes/services/bridge/manager', () =
 vi.mock('../../packages/server/src/modules/studio/public/chat-agent-runtime', () => ({
   createPrimaryAgentBridge: vi.fn(() => bridgeMock),
   getPrimaryAgentBridgeManager: vi.fn(() => ({
+    start: vi.fn(async () => {}),
     ensureReady: ensureReadyMock,
     getRuntimeState: getRuntimeStateMock,
   })),

--- a/tests/server/runtime-version-manager.test.ts
+++ b/tests/server/runtime-version-manager.test.ts
@@ -34,6 +34,9 @@ function runtimePlatformKey(): string {
 }
 
 function createRuntime(root: string, version: string, options: { missingNode?: boolean } = {}): void {
+  mkdirSync(join(root, 'python'), { recursive: true })
+  writeFileSync(join(root, 'python', 'run_agent.py'), '')
+  writeFileSync(join(root, 'python', 'cli.py'), '')
   if (process.platform === 'win32') {
     mkdirSync(join(root, 'python', 'venv', 'Scripts'), { recursive: true })
     mkdirSync(join(root, 'git', 'cmd'), { recursive: true })
@@ -65,6 +68,15 @@ describe('runtime version manager storage migration', () => {
     vi.resetModules()
     process.env = { ...originalEnv }
     process.env.HERMES_DESKTOP = 'true'
+    delete process.env.HERMES_BIN
+    delete process.env.HERMES_RUNTIME_SELECTION_LOCKED
+    delete process.env.HERMES_RUNTIME_SOURCE
+    delete process.env.HERMES_RUNTIME_VERSION
+    delete process.env.HERMES_MANAGED_RUNTIME_VERSION
+    delete process.env.HERMES_AGENT_BRIDGE_PYTHON
+    delete process.env.HERMES_AGENT_CLI_PYTHON
+    delete process.env.HERMES_AGENT_ROOT
+    process.env.PATH = ''
     delete process.env.HERMES_DESKTOP_RUNTIME_DIR
     delete process.env.HERMES_WEB_UI_VERSION_MANIFEST_URL
     state.appHome = tempDir('hermes-runtime-version-home-')
@@ -354,6 +366,35 @@ describe('runtime version manager storage migration', () => {
 
     expect(active.runtimeDirectory).toBe(runtime)
     expect(active.runtimeActivationError).toBe('')
+  })
+
+  it('clears a Runtime validation failure when that version is activated after repair', async () => {
+    const platform = runtimePlatformKey()
+    const runtime = join(state.appHome, 'desktop-runtime', 'hermes', '0.20.0', platform)
+    const activeVersionPath = join(state.appHome, 'desktop-runtime', 'active-version.json')
+    createRuntime(runtime, '0.20.0')
+    mkdirSync(join(state.appHome, 'desktop-runtime'), { recursive: true })
+    writeFileSync(activeVersionPath, JSON.stringify({
+      schema: 1,
+      platform,
+      runtimeValidationFailures: [{
+        version: '0.20.0',
+        platform,
+        directory: runtime,
+        reason: 'previous validation failure',
+        failedAt: new Date(0).toISOString(),
+      }],
+    }))
+
+    const {
+      activateInstalledRuntimeVersion,
+      listInstalledRuntimeVersions,
+    } = await import('../../packages/server/src/modules/hermes/services/runtime/version-manager')
+
+    expect(listInstalledRuntimeVersions()).toEqual([])
+    const active = activateInstalledRuntimeVersion('0.20.0')
+    expect(active.runtimeValidationFailures).toEqual([])
+    expect(listInstalledRuntimeVersions(active).map(item => item.version)).toEqual(['0.20.0'])
   })
 
   it('accepts hermes.exe after a Windows CLI update replaces hermes.cmd', async () => {


### PR DESCRIPTION
## Summary
- validate user Hermes CLI and managed Runtime candidates sequentially with isolated environments
- require `hermes --version`, `python/run_agent.py`, and `python/cli.py` before selecting a managed Runtime
- persist exact Runtime validation failures, skip each broken candidate, and continue to the next installed version
- expose failed Runtime versions as downloadable again in both Desktop and standalone Web UI
- wait for Agent Bridge startup before chat readiness checks and surface Runtime activation errors directly

## Impact
Incomplete or damaged Runtime installations no longer remain marked as installed. A failed version is quarantined in `active-version.json`, fallback continues one version at a time, and a verified re-download clears the failure marker.

## Validation
- `npm run harness:check`
- `npm run build`
- `npm --prefix packages/desktop run build:main`
- focused Runtime, Bridge, Desktop, and version-management Vitest suites: 102 tests passed
- `PORT=8648 npm test`: Runtime and server suites passed; the local aggregate run still reported 45 unrelated client test failures from shared browser mocks and browser-externalized `fs`

## Known limitations
- Existing Runtime directories are retained on disk; failed versions are marked unavailable and can be replaced through download.