### PR TITLE
feat: add one-time mobile location requests

### DIFF
--- a/bin/hermes-studio-mcp.mjs
+++ b/bin/hermes-studio-mcp.mjs
@@ -1264,6 +1264,30 @@ const tools = [
     inputSchema: inputSchema(),
   },
   {
+    name: 'hermes_studio_use_mobile_location',
+    toolset: 'use',
+    description: 'Request the user’s current mobile-device location once for the current direct chat. The App always asks the user to confirm before sharing WGS84 coordinates. Never use proactively, for background tracking, or from delegated/workflow tasks.',
+    inputSchema: inputSchema({
+        session_id: {
+          type: 'string',
+          description: 'Exact current Hermes Studio direct-chat session id supplied in the run context.',
+        },
+        purpose: {
+          type: 'string',
+          description: 'Short user-visible explanation of why the current location is needed.',
+        },
+        accuracy: {
+          type: 'string',
+          enum: ['coarse', 'precise'],
+          description: 'Requested accuracy. Defaults to coarse; use precise only when necessary for the user’s request.',
+        },
+        timeout_ms: {
+          type: 'number',
+          description: 'Maximum time to wait for the user and device, from 3000 to 60000 milliseconds.',
+        },
+      }, ['session_id', 'purpose']),
+  },
+  {
     name: 'hermes_studio_use_workflows_list',
     toolset: 'use',
     description: 'List Hermes Studio workflows for the selected or requested profile.',
@@ -1621,8 +1645,8 @@ const CATEGORY_TOOLSETS = {
   },
   use: {
     name: 'hermes_studio_use_toolset',
-    coverage: 'Explicit user-requested Studio chat/coding runs; session list/count/detail/messages/context/rename/delete; usage statistics; profiles and available models; provider add/delete; worker status; workflow CRUD and workflow run list/start/stop/rerun/delete.',
-    description: 'Discover and invoke high-level Hermes Studio operations without loading every Studio-use tool schema into the model context. Covers explicit user-requested chat or coding runs, session management and clean context, usage statistics, profiles/models/providers, worker status, workflow CRUD, and workflow run lifecycle. Never use chat/session operations as an internal delegation mechanism. Use action=list for the compact operation catalog, action=describe for one full input schema, then action=call with that exact tool name and arguments.',
+    coverage: 'Explicit user-requested Studio chat/coding runs; one-time confirmed mobile location; session list/count/detail/messages/context/rename/delete; usage statistics; profiles and available models; provider add/delete; worker status; workflow CRUD and workflow run list/start/stop/rerun/delete.',
+    description: 'Discover and invoke high-level Hermes Studio operations without loading every Studio-use tool schema into the model context. Covers explicit user-requested chat or coding runs, one-time confirmed mobile location, session management and clean context, usage statistics, profiles/models/providers, worker status, workflow CRUD, and workflow run lifecycle. Never use chat/session or mobile-location operations as an internal delegation mechanism. Use action=list for the compact category catalog, action=describe for one full tool schema, then action=call with that exact tool name and arguments.',
   },
 }
 
@@ -1903,6 +1927,11 @@ async function callTool(name, args = {}) {
       return jsonText(summarizeWorkerRuntime(
         await request('/api/studio/performance/runtime', withAuthArgs(args)),
       ))
+    case 'hermes_studio_use_mobile_location':
+      return jsonText(await request('/api/studio/mobile-location/request', withAuthArgs(args, {
+        method: 'POST',
+        body: pickDefined(args, ['session_id', 'purpose', 'accuracy', 'timeout_ms']),
+      })))
     case 'hermes_studio_use_workflows_list':
       return jsonText(await request('/api/studio/workflows', withAuthArgs(args, {
         query: pickDefined(args, ['profile']),

--- a/docs/chat-chain-changes/2026-08-31-agent-mobile-location.md
+++ b/docs/chat-chain-changes/2026-08-31-agent-mobile-location.md
@@ -1,0 +1,15 @@
+date: 2026-08-31
+feature: Agent-requested one-time mobile location
+impact: Direct-chat Agents can request the connected App's current WGS84 coordinates after an explicit one-time confirmation.
+
+- Adds the `hermes_studio_use_mobile_location` managed MCP operation for direct chats.
+- The current direct-chat session id is supplied in the run instructions so the
+  MCP request remains session scoped.
+- `/chat-run` emits `location.requested`, accepts `location.respond`, and emits
+  `location.resolved`; App Relay allowlists the response event for LAN and cloud
+  connections.
+- Location responses are validated and reduced to coordinates, accuracy,
+  optional altitude/speed, coordinate system, and timestamp. Address data is
+  never accepted or persisted.
+- Requests time out, are foreground/one-time only, and are unavailable to group
+  chats, workflow nodes, delegated tasks, and background tracking.

--- a/docs/chat-chain-changes/2026-08-31-agent-mobile-location.md
+++ b/docs/chat-chain-changes/2026-08-31-agent-mobile-location.md
@@ -11,5 +11,10 @@ impact: Direct-chat Agents can request the connected App's current WGS84 coordin
 - Location responses are validated and reduced to coordinates, accuracy,
   optional altitude/speed, coordinate system, and timestamp. Address data is
   never accepted or persisted.
+- Successful responses must explicitly declare `coordinateSystem: wgs84` and
+  provide finite numeric latitude/longitude within their valid ranges. Missing
+  or other coordinate systems and coerced values (nulls, strings, booleans,
+  arrays, or objects) resolve as `location_invalid_result`; coordinates are
+  never silently relabeled or converted. Numeric zero remains valid.
 - Requests time out, are foreground/one-time only, and are unavailable to group
   chats, workflow nodes, delegated tasks, and background tracking.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -14638,6 +14638,44 @@
         }
       }
     },
+    "/api/studio/mobile-location/request": {
+      "post": {
+        "tags": [
+          "Chat Run"
+        ],
+        "summary": "Create request",
+        "description": "POST /api/studio/mobile-location/request",
+        "operationId": "requestMobileLocation",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/studio/performance/runtime": {
       "get": {
         "tags": [

--- a/packages/server/src/modules/studio/controllers/chat-run.ts
+++ b/packages/server/src/modules/studio/controllers/chat-run.ts
@@ -2,6 +2,7 @@ import type { Context } from 'koa'
 import { randomUUID } from 'crypto'
 import { io, type Socket } from 'socket.io-client'
 import { config } from '../public/config'
+import { getChatRunServer } from '../public/chat-run'
 import { resolveModelExecutionIdentity } from '../contracts/runs/model-execution-identity'
 
 type ChatRunPayload = Record<string, unknown> & {
@@ -51,12 +52,45 @@ const CHAT_RUN_EVENTS = [
   'approval.resolved',
   'clarify.requested',
   'clarify.resolved',
+  'location.requested',
+  'location.resolved',
   'peer.user.message',
 ]
 
 const DEFAULT_TIMEOUT_MS = 300_000
 const MAX_TIMEOUT_MS = 1_800_000
 const MAX_RECORDED_EVENTS = 1000
+
+export async function requestMobileLocation(ctx: Context) {
+  const body = (ctx.request.body || {}) as Record<string, unknown>
+  const sessionId = String(body.session_id || '').trim()
+  if (!sessionId) {
+    ctx.status = 400
+    ctx.body = { ok: false, error: 'session_id is required' }
+    return
+  }
+  const server = getChatRunServer()
+  if (!server?.requestMobileLocation) {
+    ctx.status = 503
+    ctx.body = { ok: false, error: 'Chat run service is unavailable' }
+    return
+  }
+  const profile = String(ctx.state.profile?.name || 'default').trim() || 'default'
+  try {
+    const result = await server.requestMobileLocation({
+      sessionId,
+      profile,
+      purpose: body.purpose,
+      accuracy: body.accuracy,
+      timeoutMs: body.timeout_ms,
+    })
+    ctx.body = { ok: true, session_id: sessionId, ...result }
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err)
+    ctx.status = error === 'Session not found' ? 404 : 400
+    ctx.body = { ok: false, error }
+  }
+}
 
 function bearerToken(ctx: Context): string {
   const match = ctx.get('authorization').match(/^Bearer\s+(.+)$/i)

--- a/packages/server/src/modules/studio/routes/chat-run.ts
+++ b/packages/server/src/modules/studio/routes/chat-run.ts
@@ -5,3 +5,4 @@ export { getChatRunServer, setChatRunServer } from '../public/chat-run'
 export const chatRunRoutes = new Router()
 
 chatRunRoutes.post('/api/studio/chat-run/runs', ctrl.runOnce)
+chatRunRoutes.post('/api/studio/mobile-location/request', ctrl.requestMobileLocation)

--- a/packages/server/src/modules/studio/services/app-relay/client.ts
+++ b/packages/server/src/modules/studio/services/app-relay/client.ts
@@ -47,6 +47,7 @@ const ALLOWED_CHAT_RUN_CLIENT_EVENTS = new Set([
   'cancel_queued_run',
   'approval.respond',
   'clarify.respond',
+  'location.respond',
 ])
 const ALLOWED_GROUP_CHAT_CLIENT_EVENTS = new Set([
   'join',

--- a/packages/server/src/modules/studio/services/app-relay/server.ts
+++ b/packages/server/src/modules/studio/services/app-relay/server.ts
@@ -55,6 +55,7 @@ const ALLOWED_CHAT_RUN_CLIENT_EVENTS = new Set([
   'cancel_queued_run',
   'approval.respond',
   'clarify.respond',
+  'location.respond',
 ])
 const ALLOWED_GROUP_CHAT_CLIENT_EVENTS = new Set([
   'join',

--- a/packages/server/src/modules/studio/sockets/chat-run.ts
+++ b/packages/server/src/modules/studio/sockets/chat-run.ts
@@ -162,6 +162,15 @@ function isBridgeRunSource(source?: string): boolean {
   return source === 'cli' || source === 'global_agent' || source === 'workflow' || source === 'group_chat'
 }
 
+function mobileLocationRunInstruction(sessionId: string | undefined, source: string | undefined): string {
+  if (!sessionId || source === 'workflow' || source === 'group_chat') return ''
+  return [
+    `The current Hermes Studio chat session id is ${JSON.stringify(sessionId)}.`,
+    'Only when the user explicitly asks to use their current mobile-device location, use hermes_studio_use_toolset to describe and call hermes_studio_use_mobile_location with this exact session_id.',
+    'The App will show a one-time confirmation before sharing WGS84 coordinates. Never request location proactively, in a delegated subtask, in a workflow node, or for background tracking.',
+  ].join(' ')
+}
+
 type ChatRunBridgeReadiness =
   | { ok: true }
   | { ok: false; error: string; runtimeUnavailable?: true }
@@ -237,6 +246,90 @@ export interface ChatRunAndWaitResult {
 
 type ChatRunAutoApprovalChoice = 'once' | 'session' | 'always'
 
+type MobileLocationAccuracy = 'coarse' | 'precise'
+
+type MobileLocationValue = {
+  latitude: number
+  longitude: number
+  accuracyMeters: number
+  altitudeMeters?: number
+  speedMetersPerSecond?: number
+  coordinateSystem: 'wgs84'
+  timestamp: number
+}
+
+export type MobileLocationResponse =
+  | { status: 'success'; location: MobileLocationValue }
+  | { status: 'denied' }
+  | { status: 'error'; error: { code: string } }
+
+type PendingMobileLocationRequest = {
+  sessionId: string
+  profile: string
+  resolve: (response: MobileLocationResponse) => void
+  timer: NodeJS.Timeout
+}
+
+const MOBILE_LOCATION_MIN_TIMEOUT_MS = 3_000
+const MOBILE_LOCATION_MAX_TIMEOUT_MS = 60_000
+const MOBILE_LOCATION_DEVICE_TIMEOUT_MS = 30_000
+const MOBILE_LOCATION_PURPOSE_MAX_LENGTH = 240
+const MOBILE_LOCATION_ERROR_CODES = new Set([
+  'location_permission_denied',
+  'location_timeout',
+  'location_service_unavailable',
+  'location_invalid_result',
+  'location_failed',
+])
+
+function boundedMobileLocationTimeout(value: unknown): number {
+  const numeric = Math.round(Number(value))
+  if (!Number.isFinite(numeric)) return 35_000
+  return Math.max(MOBILE_LOCATION_MIN_TIMEOUT_MS, Math.min(MOBILE_LOCATION_MAX_TIMEOUT_MS, numeric))
+}
+
+function finiteLocationNumber(value: unknown): number | null {
+  const numeric = Number(value)
+  return Number.isFinite(numeric) ? numeric : null
+}
+
+function normalizeMobileLocationResponse(value: unknown): MobileLocationResponse | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const response = value as Record<string, any>
+  const status = String(response.status || '').trim()
+  if (status === 'denied') return { status: 'denied' }
+  if (status === 'error') {
+    const rawCode = String(response.error?.code || '').trim()
+    return {
+      status: 'error',
+      error: { code: MOBILE_LOCATION_ERROR_CODES.has(rawCode) ? rawCode : 'location_failed' },
+    }
+  }
+  if (status !== 'success' || !response.location || typeof response.location !== 'object') return null
+  const latitude = finiteLocationNumber(response.location.latitude)
+  const longitude = finiteLocationNumber(response.location.longitude)
+  if (
+    latitude == null
+    || longitude == null
+    || latitude < -90
+    || latitude > 90
+    || longitude < -180
+    || longitude > 180
+  ) return null
+  const location: MobileLocationValue = {
+    latitude,
+    longitude,
+    accuracyMeters: Math.max(0, finiteLocationNumber(response.location.accuracyMeters) || 0),
+    coordinateSystem: 'wgs84',
+    timestamp: Math.max(0, Math.round(finiteLocationNumber(response.location.timestamp) || Date.now())),
+  }
+  const altitude = finiteLocationNumber(response.location.altitudeMeters)
+  const speed = finiteLocationNumber(response.location.speedMetersPerSecond)
+  if (altitude != null) location.altitudeMeters = altitude
+  if (speed != null && speed >= 0) location.speedMetersPerSecond = speed
+  return { status: 'success', location }
+}
+
 export class ChatRunSocket {
   private nsp: ReturnType<Server['of']>
   private bridge = createPrimaryAgentBridge()
@@ -245,6 +338,7 @@ export class ChatRunSocket {
   private sessionMap = new Map<string, SessionState>()
   private bridgeResumePolls = new Set<string>()
   private readonly runWaiters = new Map<string, Set<(event: string, payload: any) => void>>()
+  private readonly pendingMobileLocations = new Map<string, PendingMobileLocationRequest>()
   private backgroundPollTimer?: NodeJS.Timeout
   private backgroundPollInFlight = false
   private backgroundRecoveryNeeded = true
@@ -268,6 +362,57 @@ export class ChatRunSocket {
       event: 'session.settings.updated',
       session_id: sessionId,
       ...settings,
+    })
+  }
+
+  requestMobileLocation(options: {
+    sessionId: string
+    profile: string
+    purpose?: string
+    accuracy?: MobileLocationAccuracy
+    timeoutMs?: number
+  }): Promise<MobileLocationResponse> {
+    const sessionId = String(options.sessionId || '').trim()
+    const profile = String(options.profile || '').trim() || 'default'
+    const session = getSession(sessionId)
+    if (!session) throw new Error('Session not found')
+    if ((String(session.profile || '').trim() || 'default') !== profile) {
+      throw new Error('Session is not available for this profile')
+    }
+    if (session.source === 'group_chat' || session.source === 'workflow') {
+      throw new Error('Mobile location is available only in direct chats')
+    }
+    for (const pending of this.pendingMobileLocations.values()) {
+      if (pending.sessionId === sessionId) throw new Error('A mobile location request is already pending')
+    }
+
+    const locationRequestId = randomUUID()
+    const timeoutMs = boundedMobileLocationTimeout(options.timeoutMs)
+    const purpose = String(options.purpose || '').trim().slice(0, MOBILE_LOCATION_PURPOSE_MAX_LENGTH)
+    const accuracy: MobileLocationAccuracy = options.accuracy === 'precise' ? 'precise' : 'coarse'
+
+    return new Promise<MobileLocationResponse>((resolve) => {
+      const timer = setTimeout(() => {
+        this.finishMobileLocationRequest(locationRequestId, {
+          status: 'error',
+          error: { code: 'location_timeout' },
+        })
+      }, timeoutMs)
+      timer.unref?.()
+      this.pendingMobileLocations.set(locationRequestId, {
+        sessionId,
+        profile,
+        resolve,
+        timer,
+      })
+      this.emitMobileLocationEvent(profile, sessionId, 'location.requested', {
+        event: 'location.requested',
+        location_request_id: locationRequestId,
+        purpose,
+        accuracy,
+        timeout_ms: Math.min(timeoutMs, MOBILE_LOCATION_DEVICE_TIMEOUT_MS),
+        max_age_ms: 0,
+      })
     })
   }
 
@@ -805,6 +950,48 @@ export class ChatRunSocket {
         })
       }
     })
+
+    socket.on('location.respond', (data: {
+      session_id?: string
+      location_request_id?: string
+      status?: string
+      location?: unknown
+      error?: unknown
+    }) => {
+      if (!data.session_id || !data.location_request_id) return
+      try {
+        requireSocketSessionAccess(data.session_id)
+      } catch (err) {
+        socket.emit('location.resolved', {
+          event: 'location.resolved',
+          session_id: data.session_id,
+          location_request_id: data.location_request_id,
+          resolved: false,
+          error: err instanceof Error ? err.message : String(err),
+        })
+        return
+      }
+      const pending = this.pendingMobileLocations.get(data.location_request_id)
+      if (!pending || pending.sessionId !== data.session_id) {
+        this.emitToSession(socket, data.session_id, 'location.resolved', {
+          event: 'location.resolved',
+          location_request_id: data.location_request_id,
+          resolved: false,
+          stale: true,
+          error: 'Location request is no longer pending.',
+        })
+        return
+      }
+      const response = normalizeMobileLocationResponse(data)
+      if (!response) {
+        this.finishMobileLocationRequest(data.location_request_id, {
+          status: 'error',
+          error: { code: 'location_invalid_result' },
+        })
+        return
+      }
+      this.finishMobileLocationRequest(data.location_request_id, response)
+    })
   }
 
   respondCodingAgentApproval(sessionId: string, approvalId: string, choice: string): boolean {
@@ -874,6 +1061,12 @@ export class ChatRunSocket {
     backgroundContinuationContext?: BackgroundContinuationContext,
   ) {
     const source = resolveRunSource(data.source, data.session_id)
+    const locationInstruction = mobileLocationRunInstruction(data.session_id, source)
+    if (locationInstruction) {
+      data.instructions = [String(data.instructions || '').trim(), locationInstruction]
+        .filter(Boolean)
+        .join('\n\n')
+    }
     if (data.session_id) {
       const state = getOrCreateSession(this.sessionMap, data.session_id)
       state.webhookAgent = webhookAgentForRun(data)
@@ -1961,6 +2154,13 @@ export class ChatRunSocket {
   async disposeSession(sessionId: string): Promise<void> {
     const sid = String(sessionId || '').trim()
     if (!sid) return
+    for (const [requestId, pending] of this.pendingMobileLocations.entries()) {
+      if (pending.sessionId !== sid) continue
+      this.finishMobileLocationRequest(requestId, {
+        status: 'error',
+        error: { code: 'location_failed' },
+      })
+    }
     codingAgentRunManager.stop(sid, { reportClosed: false })
     const state = this.sessionMap.get(sid)
     state?.abortController?.abort()
@@ -2120,6 +2320,52 @@ export class ChatRunSocket {
     }
   }
 
+  private finishMobileLocationRequest(
+    locationRequestId: string,
+    response: MobileLocationResponse,
+  ): boolean {
+    const pending = this.pendingMobileLocations.get(locationRequestId)
+    if (!pending) return false
+    this.pendingMobileLocations.delete(locationRequestId)
+    clearTimeout(pending.timer)
+    this.clearMobileLocationEventState(pending.sessionId, locationRequestId)
+    this.emitMobileLocationEvent(pending.profile, pending.sessionId, 'location.resolved', {
+      event: 'location.resolved',
+      location_request_id: locationRequestId,
+      status: response.status,
+      resolved: true,
+      ...(response.status === 'error' ? { error: response.error } : {}),
+    })
+    pending.resolve(response)
+    return true
+  }
+
+  private clearMobileLocationEventState(sessionId: string, locationRequestId: string): void {
+    const state = this.sessionMap.get(sessionId)
+    if (!state?.events.length) return
+    state.events = state.events.filter(({ event, data }) => {
+      if (event !== 'location.requested' && event !== 'location.resolved') return true
+      return data?.location_request_id !== locationRequestId
+    })
+  }
+
+  private emitMobileLocationEvent(
+    profile: string,
+    sessionId: string,
+    event: 'location.requested' | 'location.resolved',
+    payload: Record<string, unknown>,
+  ): void {
+    const tagged = { ...payload, session_id: sessionId }
+    const state = this.sessionMap.get(sessionId)
+    if (event === 'location.requested' && state) {
+      state.events = state.events.filter(({ event: current }) =>
+        current !== 'location.requested' && current !== 'location.resolved')
+      state.events.push({ event, data: tagged })
+    }
+    this.nsp.to(`session:${sessionId}`).emit(event, tagged)
+    this.emitPendingInteraction(profile, event, tagged)
+  }
+
   private emitToSession(socket: Socket, sessionId: string, event: string, payload: any) {
     const tagged = { ...payload, session_id: sessionId }
     const profile = this.resolvePetEventProfile(sessionId, tagged)
@@ -2148,7 +2394,8 @@ export class ChatRunSocket {
   private emitPendingInteraction(profile: string, event: string, payload: any) {
     this.emitSessionActivity(profile, event, payload)
     if (event !== 'approval.requested' && event !== 'approval.resolved'
-      && event !== 'clarify.requested' && event !== 'clarify.resolved') return
+      && event !== 'clarify.requested' && event !== 'clarify.resolved'
+      && event !== 'location.requested' && event !== 'location.resolved') return
     const sessionId = typeof payload?.session_id === 'string' ? payload.session_id : ''
     const source = sessionId
       ? this.sessionMap.get(sessionId)?.source || getSession(sessionId)?.source
@@ -2204,6 +2451,12 @@ export class ChatRunSocket {
     if (this.backgroundPollTimer) {
       clearInterval(this.backgroundPollTimer)
       this.backgroundPollTimer = undefined
+    }
+    for (const requestId of [...this.pendingMobileLocations.keys()]) {
+      this.finishMobileLocationRequest(requestId, {
+        status: 'error',
+        error: { code: 'location_failed' },
+      })
     }
     const releaseClaims: Array<Promise<unknown>> = []
     for (const [sessionId, state] of this.sessionMap.entries()) {

--- a/packages/server/src/modules/studio/sockets/chat-run.ts
+++ b/packages/server/src/modules/studio/sockets/chat-run.ts
@@ -289,8 +289,7 @@ function boundedMobileLocationTimeout(value: unknown): number {
 }
 
 function finiteLocationNumber(value: unknown): number | null {
-  const numeric = Number(value)
-  return Number.isFinite(numeric) ? numeric : null
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
 }
 
 function normalizeMobileLocationResponse(value: unknown): MobileLocationResponse | null {
@@ -306,6 +305,8 @@ function normalizeMobileLocationResponse(value: unknown): MobileLocationResponse
     }
   }
   if (status !== 'success' || !response.location || typeof response.location !== 'object') return null
+  // The App must supply WGS84 coordinates; relabeling another system does not convert it.
+  if (Array.isArray(response.location) || response.location.coordinateSystem !== 'wgs84') return null
   const latitude = finiteLocationNumber(response.location.latitude)
   const longitude = finiteLocationNumber(response.location.longitude)
   if (

--- a/tests/server/app-relay-client.test.ts
+++ b/tests/server/app-relay-client.test.ts
@@ -621,6 +621,27 @@ describe('AppRelayClient', () => {
       event: 'insert_queued_run',
     })))
 
+    const locationAck = vi.fn()
+    remote.__handlers.get('app.socket.event')({
+      id: 'relay-chat-1',
+      event: 'location.respond',
+      payload: {
+        session_id: 'session-1',
+        location_request_id: 'location-1',
+        status: 'denied',
+      },
+    }, locationAck)
+    expect(local.emit).toHaveBeenCalledWith('location.respond', {
+      session_id: 'session-1',
+      location_request_id: 'location-1',
+      status: 'denied',
+    })
+    await vi.waitFor(() => expect(locationAck).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'relay-chat-1',
+      ok: true,
+      event: 'location.respond',
+    })))
+
     local.__onAny('message.delta', { session_id: 'session-1', delta: 'hi' })
     expect(remote.emit).toHaveBeenCalledWith('app.socket.event', {
       id: 'relay-chat-1',

--- a/tests/server/app-relay-server.test.ts
+++ b/tests/server/app-relay-server.test.ts
@@ -691,6 +691,27 @@ describe('LocalAppRelayServer', () => {
       queue_id: 'queue-1',
     })
 
+    const locationAck = vi.fn()
+    app.__handlers.get('socket.event')({
+      id: 'chat-1',
+      event: 'location.respond',
+      payload: {
+        session_id: 'session-1',
+        location_request_id: 'location-1',
+        status: 'denied',
+      },
+    }, locationAck)
+    await vi.waitFor(() => expect(locationAck).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'chat-1',
+      ok: true,
+      event: 'location.respond',
+    })))
+    expect(local.emit).toHaveBeenCalledWith('location.respond', {
+      session_id: 'session-1',
+      location_request_id: 'location-1',
+      status: 'denied',
+    })
+
     local.__onAny('message.delta', { session_id: 'session-1', delta: 'hi' })
     expect(app.emit).toHaveBeenCalledWith('socket.event', {
       id: 'chat-1',

--- a/tests/server/hermes-web-ui-mcp.test.ts
+++ b/tests/server/hermes-web-ui-mcp.test.ts
@@ -440,6 +440,25 @@ describe('hermes-web-ui MCP server', () => {
         }))
         return
       }
+      if (req.url === '/api/studio/mobile-location/request' && req.method === 'POST') {
+        let raw = ''
+        req.on('data', chunk => { raw += chunk })
+        req.on('end', () => {
+          res.end(JSON.stringify({
+            ok: true,
+            status: 'success',
+            location: {
+              latitude: 31.2304,
+              longitude: 121.4737,
+              accuracyMeters: 65,
+              coordinateSystem: 'wgs84',
+              timestamp: 123456789,
+            },
+            body: raw ? JSON.parse(raw) : null,
+          }))
+        })
+        return
+      }
       if (req.url === '/api/studio/workflows?profile=default') {
         res.end(JSON.stringify({ workflows: [{ id: 'workflow-1', name: 'Demo workflow', profile: 'default' }] }))
         return
@@ -624,6 +643,19 @@ describe('hermes-web-ui MCP server', () => {
       name: 'hermes_studio_use_worker_status',
       arguments: {},
     })
+    writeRpc(child, 36, 'tools/call', {
+      name: 'hermes_studio_use_toolset',
+      arguments: {
+        action: 'call',
+        tool: 'hermes_studio_use_mobile_location',
+        arguments: {
+          session_id: 'session-1',
+          purpose: 'Find nearby restaurants',
+          accuracy: 'coarse',
+          timeout_ms: 10000,
+        },
+      },
+    })
     writeRpc(child, 20, 'tools/call', {
       name: 'hermes_studio_use_workflows_list',
       arguments: { profile: 'default' },
@@ -684,7 +716,7 @@ describe('hermes-web-ui MCP server', () => {
     expect(list.result.tools[0].description).toContain('internal delegation')
 
     const catalog = JSON.parse((await waitForRpc(responses, 32)).result.content[0].text)
-    expect(catalog).toMatchObject({ toolset: 'use', operation_count: 25 })
+    expect(catalog).toMatchObject({ toolset: 'use', operation_count: 26 })
     expect(catalog.operations.map((tool: any) => tool.name)).toEqual(expect.arrayContaining([
       'hermes_studio_use_chat_run',
       'hermes_studio_use_sessions_count',
@@ -692,6 +724,7 @@ describe('hermes-web-ui MCP server', () => {
       'hermes_studio_use_session_context',
       'hermes_studio_use_provider_add',
       'hermes_studio_use_worker_status',
+      'hermes_studio_use_mobile_location',
       'hermes_studio_use_workflows_list',
       'hermes_studio_use_workflow_rerun_node',
     ]))
@@ -706,6 +739,22 @@ describe('hermes-web-ui MCP server', () => {
     }
     const gatewaySessionCount = JSON.parse((await waitForRpc(responses, 35)).result.content[0].text)
     expect(gatewaySessionCount.count).toBe(7)
+    const mobileLocation = JSON.parse((await waitForRpc(responses, 36)).result.content[0].text)
+    expect(mobileLocation).toMatchObject({
+      ok: true,
+      status: 'success',
+      location: {
+        latitude: 31.2304,
+        longitude: 121.4737,
+        coordinateSystem: 'wgs84',
+      },
+      body: {
+        session_id: 'session-1',
+        purpose: 'Find nearby restaurants',
+        accuracy: 'coarse',
+        timeout_ms: 10000,
+      },
+    })
 
     const chatRun = JSON.parse((await waitForRpc(responses, 3)).result.content[0].text)
     expect(chatRun.body).toMatchObject({ input: 'hello', session_id: 'session-1', include_events: true })

--- a/tests/server/run-chat-mobile-location.test.ts
+++ b/tests/server/run-chat-mobile-location.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const bridgeMock = vi.hoisted(() => ({
+  statusIfLoaded: vi.fn(),
+}))
+
+vi.mock('../../packages/server/src/modules/studio/public/chat-agent-runtime', () => ({
+  createPrimaryAgentBridge: vi.fn(() => bridgeMock),
+  getPrimaryAgentBridgeManager: vi.fn(() => ({ start: vi.fn(async () => {}), ensureReady: vi.fn() })),
+  redactPrimaryAgentBridgeError: (error?: string) => error,
+  chatCodingAgentRunManager: {
+    resolveApproval: vi.fn(() => ({ handled: false, resolved: false })),
+    resolveClarification: vi.fn(() => ({ handled: false, resolved: false })),
+    stop: vi.fn(),
+  },
+  handleChatCodingAgentSessionCommand: vi.fn(),
+  parseChatCodingAgentSessionCommand: vi.fn(() => null),
+  getChatEkkoAgent: vi.fn(() => ({ requestBoundaryInterrupt: vi.fn() })),
+  respondToChatEkkoToolApproval: vi.fn(() => ({ handled: false, resolved: false })),
+  respondToChatEkkoClarification: vi.fn(() => ({ handled: false, resolved: false })),
+}))
+
+vi.mock('../../packages/server/src/modules/studio/public/logging', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const sessionStoreMock = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getSessionMetadata: vi.fn(() => null),
+  getSessionDetail: vi.fn(() => null),
+}))
+
+vi.mock('../../packages/server/src/modules/studio/repositories/session-store', () => sessionStoreMock)
+
+vi.mock('../../packages/server/src/modules/studio/public/profile-config', () => ({
+  getActiveProfileName: vi.fn(() => 'default'),
+  getProfileDir: vi.fn(() => '/tmp/hermes-default'),
+  listProfileNamesFromDisk: vi.fn(() => ['default']),
+}))
+
+vi.mock('../../packages/server/src/modules/studio/public/auth', () => ({
+  authenticateUserToken: vi.fn(),
+  isAuthEnabled: vi.fn(async () => false),
+}))
+
+vi.mock('../../packages/server/src/modules/studio/repositories/users-store', () => ({
+  userCanAccessProfile: vi.fn(() => true),
+}))
+
+function createHarness() {
+  const handlers = new Map<string, Function>()
+  const emitted: Array<{ room: string; event: string; payload: any }> = []
+  const namespace = {
+    adapter: { rooms: new Map([['session:session-1', new Set(['socket-1'])]]) },
+    sockets: new Map(),
+    to: vi.fn((room: string) => ({
+      emit: vi.fn((event: string, payload: any) => emitted.push({ room, event, payload })),
+    })),
+    use: vi.fn(),
+    on: vi.fn(),
+    emit: vi.fn(),
+  }
+  const socket = {
+    id: 'socket-1',
+    connected: true,
+    data: {},
+    handshake: { auth: {}, query: { profile: 'default' } },
+    on: vi.fn((event: string, handler: Function) => handlers.set(event, handler)),
+    join: vi.fn(),
+    emit: vi.fn(),
+  }
+  return {
+    emitted,
+    handlers,
+    io: { of: vi.fn(() => namespace) },
+    namespace,
+    socket,
+  }
+}
+
+describe('ChatRunSocket mobile location', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    sessionStoreMock.getSession.mockReturnValue({
+      id: 'session-1',
+      profile: 'default',
+      source: 'cli',
+    })
+  })
+
+  it('requests one-time WGS84 coordinates and returns only sanitized location fields', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
+    const { emitted, handlers, io, socket } = createHarness()
+    const server = new ChatRunSocket(io as any)
+    ;(server as any).sessionMap.set('session-1', {
+      messages: [],
+      events: [],
+      queue: [],
+      isWorking: true,
+      profile: 'default',
+      source: 'cli',
+    })
+    ;(server as any).onConnection(socket)
+
+    const resultPromise = server.requestMobileLocation({
+      sessionId: 'session-1',
+      profile: 'default',
+      purpose: 'Find nearby restaurants',
+      accuracy: 'precise',
+      timeoutMs: 10_000,
+    })
+    const requested = emitted.find(item =>
+      item.room === 'session:session-1' && item.event === 'location.requested')
+    expect(requested?.payload).toMatchObject({
+      event: 'location.requested',
+      session_id: 'session-1',
+      purpose: 'Find nearby restaurants',
+      accuracy: 'precise',
+      timeout_ms: 10_000,
+      max_age_ms: 0,
+    })
+
+    await handlers.get('location.respond')?.({
+      session_id: 'session-1',
+      location_request_id: requested?.payload.location_request_id,
+      status: 'success',
+      location: {
+        latitude: 31.2304,
+        longitude: 121.4737,
+        accuracyMeters: 65,
+        altitudeMeters: 12,
+        speedMetersPerSecond: 2,
+        coordinateSystem: 'gcj02',
+        timestamp: 123456789,
+        address: { street: 'must not be retained' },
+      },
+    })
+
+    await expect(resultPromise).resolves.toEqual({
+      status: 'success',
+      location: {
+        latitude: 31.2304,
+        longitude: 121.4737,
+        accuracyMeters: 65,
+        altitudeMeters: 12,
+        speedMetersPerSecond: 2,
+        coordinateSystem: 'wgs84',
+        timestamp: 123456789,
+      },
+    })
+    expect((server as any).sessionMap.get('session-1').events).toEqual([])
+    expect(emitted).toContainEqual(expect.objectContaining({
+      room: 'pending-interactions:default',
+      event: 'location.resolved',
+      payload: expect.objectContaining({
+        session_id: 'session-1',
+        status: 'success',
+        resolved: true,
+      }),
+    }))
+  })
+
+  it('returns a denial without storing location data', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
+    const { emitted, handlers, io, socket } = createHarness()
+    const server = new ChatRunSocket(io as any)
+    ;(server as any).sessionMap.set('session-1', {
+      messages: [], events: [], queue: [], isWorking: true, profile: 'default', source: 'cli',
+    })
+    ;(server as any).onConnection(socket)
+
+    const resultPromise = server.requestMobileLocation({
+      sessionId: 'session-1',
+      profile: 'default',
+      purpose: 'Use current location',
+    })
+    const request = emitted.find(item => item.event === 'location.requested')
+    await handlers.get('location.respond')?.({
+      session_id: 'session-1',
+      location_request_id: request?.payload.location_request_id,
+      status: 'denied',
+    })
+
+    await expect(resultPromise).resolves.toEqual({ status: 'denied' })
+    expect(JSON.stringify((server as any).sessionMap.get('session-1'))).not.toContain('latitude')
+  })
+
+  it('rejects cross-profile and non-direct-chat requests', async () => {
+    const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
+    const { io } = createHarness()
+    const server = new ChatRunSocket(io as any)
+
+    expect(() => server.requestMobileLocation({
+      sessionId: 'session-1',
+      profile: 'research',
+      purpose: 'test',
+    })).toThrow('Session is not available for this profile')
+
+    sessionStoreMock.getSession.mockReturnValue({
+      id: 'session-1',
+      profile: 'default',
+      source: 'workflow',
+    })
+    expect(() => server.requestMobileLocation({
+      sessionId: 'session-1',
+      profile: 'default',
+      purpose: 'test',
+    })).toThrow('Mobile location is available only in direct chats')
+  })
+})

--- a/tests/server/run-chat-mobile-location.test.ts
+++ b/tests/server/run-chat-mobile-location.test.ts
@@ -136,7 +136,7 @@ describe('ChatRunSocket mobile location', () => {
         accuracyMeters: 65,
         altitudeMeters: 12,
         speedMetersPerSecond: 2,
-        coordinateSystem: 'gcj02',
+        coordinateSystem: 'wgs84',
         timestamp: 123456789,
         address: { street: 'must not be retained' },
       },
@@ -164,6 +164,89 @@ describe('ChatRunSocket mobile location', () => {
         resolved: true,
       }),
     }))
+  })
+
+  it.each([
+    { latitude: null },
+    { longitude: '' },
+    { latitude: undefined },
+    { longitude: ' ' },
+    { latitude: false },
+    { longitude: true },
+    { latitude: [] },
+    { longitude: {} },
+    { latitude: '31.2304' },
+    { longitude: '121.4737' },
+    { latitude: NaN },
+    { longitude: Infinity },
+    { latitude: -91 },
+    { latitude: 91 },
+    { longitude: -181 },
+    { longitude: 181 },
+    { coordinateSystem: 'gcj02' },
+    { coordinateSystem: 'bd09' },
+    { coordinateSystem: undefined },
+    { coordinateSystem: null },
+    { coordinateSystem: '' },
+  ])('rejects invalid location fields %j and resolves the pending request', async (invalidFields) => {
+    const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
+    const { emitted, handlers, io, socket } = createHarness()
+    const server = new ChatRunSocket(io as any)
+    ;(server as any).sessionMap.set('session-1', {
+      messages: [], events: [], queue: [], isWorking: true, profile: 'default', source: 'cli',
+    })
+    ;(server as any).onConnection(socket)
+    const resultPromise = server.requestMobileLocation({
+      sessionId: 'session-1', profile: 'default', purpose: 'Use current location',
+    })
+    const request = emitted.find(item => item.event === 'location.requested')
+    handlers.get('location.respond')!({
+      session_id: 'session-1',
+      location_request_id: request?.payload.location_request_id,
+      status: 'success',
+      location: {
+        latitude: 31.2304, longitude: 121.4737, coordinateSystem: 'wgs84', ...invalidFields,
+      },
+    })
+    await expect(resultPromise).resolves.toEqual({
+      status: 'error', error: { code: 'location_invalid_result' },
+    })
+    expect((server as any).pendingMobileLocations.size).toBe(0)
+    expect((server as any).sessionMap.get('session-1').events).toEqual([])
+    expect(emitted).toContainEqual(expect.objectContaining({
+      event: 'location.resolved',
+      payload: expect.objectContaining({
+        resolved: true, status: 'error', error: { code: 'location_invalid_result' },
+      }),
+    }))
+  })
+
+  it.each([
+    { latitude: 0, longitude: 0 },
+    { latitude: -90, longitude: -180 },
+    { latitude: 90, longitude: 180 },
+  ])('preserves valid WGS84 coordinates %j without inventing optional values', async (coordinates) => {
+    const { ChatRunSocket } = await import('../../packages/server/src/modules/studio/sockets/chat-run')
+    const { emitted, handlers, io, socket } = createHarness()
+    const server = new ChatRunSocket(io as any)
+    ;(server as any).onConnection(socket)
+    const resultPromise = server.requestMobileLocation({
+      sessionId: 'session-1', profile: 'default', purpose: 'Use current location',
+    })
+    const request = emitted.find(item => item.event === 'location.requested')
+    handlers.get('location.respond')!({
+      session_id: 'session-1',
+      location_request_id: request?.payload.location_request_id,
+      status: 'success',
+      location: {
+        ...coordinates, coordinateSystem: 'wgs84', accuracyMeters: 10,
+        timestamp: 123456789, altitudeMeters: null, speedMetersPerSecond: '',
+      },
+    })
+    await expect(resultPromise).resolves.toEqual({
+      status: 'success',
+      location: { ...coordinates, coordinateSystem: 'wgs84', accuracyMeters: 10, timestamp: 123456789 },
+    })
   })
 
   it('returns a denial without storing location data', async () => {


### PR DESCRIPTION
## Summary

Adds the server half of Agent-requested, one-time mobile location sharing for direct chats.

This PR is for **review and integration testing only — please do not merge yet**. It depends on the App implementation in EKKOLearnAI/hermes-studio-app#49.

## Flow

1. A direct-chat Agent calls the managed `hermes_studio_use_mobile_location` operation with the exact current session id and a user-visible purpose.
2. Studio emits `location.requested` to the connected App.
3. The App asks the user to **Share once** or deny.
4. The App sends `location.respond`.
5. Studio validates and sanitizes the response, resolves the MCP call, and emits `location.resolved`.

## Privacy and scope

- Direct chats only; workflow and group-chat sessions are rejected.
- Prompt policy forbids proactive, delegated, workflow-node, and background requests.
- Foreground, one-time confirmation is required by the App for every request.
- Coordinates are normalized to WGS84.
- Address and reverse-geocode fields are discarded.
- No location history or dedicated location record is persisted by Studio.
- Pending requests are profile/session scoped, bounded by timeout, and cleaned up on completion or disposal.

## Protocol

- Server → App: `location.requested`
- App → Server: `location.respond`
- Server → App: `location.resolved`

## Validation

Passed:

- `NODE_ENV=test npm run test -- tests/server/run-chat-mobile-location.test.ts tests/server/hermes-web-ui-mcp.test.ts tests/server/chat-run-bridge-readiness.test.ts tests/server/chat-run-api-controller.test.ts tests/server/outbound-relay-client.test.ts`
- `NODE_ENV=test npm run test -- tests/server/app-relay-server.test.ts tests/server/app-relay-client.test.ts`
- `npm run harness:check`
- `npm run build`
- `git diff --check`

The full test suite reports 23 failures in this environment. The same 23 failures were reproduced unchanged on upstream `main` at `2d59a3caf010f2179e39ffe10f05b54482619ca8`; they are unrelated baseline/environment failures.

## Dependency

- App PR: EKKOLearnAI/hermes-studio-app#49
