### PR TITLE
fix(runtime): avoid restart loops and offline version checks

### DIFF
--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -60,6 +60,10 @@ const GlobalPendingActions = defineAsyncComponent(
   async () =>
     (await import("@/components/layout/GlobalPendingActions.vue")).default,
 );
+const RuntimeRestartPrompt = defineAsyncComponent(
+  async () =>
+    (await import("@/components/layout/RuntimeRestartPrompt.vue")).default,
+);
 
 const {
   isDark,
@@ -312,6 +316,9 @@ useKeyboard();
             v-if="!isDesktopPetRoute && !isStandaloneChatPage"
           />
           <GlobalPendingActions
+            v-if="!isLoginPage && !isDesktopPetRoute && !isStandaloneChatPage"
+          />
+          <RuntimeRestartPrompt
             v-if="!isLoginPage && !isDesktopPetRoute && !isStandaloneChatPage"
           />
         </NNotificationProvider>

--- a/packages/client/src/components/layout/RuntimeRestartPrompt.vue
+++ b/packages/client/src/components/layout/RuntimeRestartPrompt.vue
@@ -1,0 +1,179 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { NButton, NCard, NModal, useMessage } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import {
+  fetchVersionDownloadJobs,
+  restartWebUiAfterRuntimeChange,
+} from '@/api/hermes/runtime-versions'
+import { useRuntimeRestartPrompt } from '@/composables/useRuntimeRestartPrompt'
+import { desktopBridge } from '@/utils/desktop-bridge'
+
+const POLL_INTERVAL_MS = 2000
+const HANDLED_JOBS_KEY = 'hermes-runtime-restart-handled-jobs'
+
+const { t } = useI18n()
+const message = useMessage()
+const {
+  pendingRuntimeRestart,
+  requestRuntimeRestart,
+  clearRuntimeRestart,
+} = useRuntimeRestartPrompt()
+const restarting = ref(false)
+const handledJobIds = new Set<string>()
+let pollTimer: ReturnType<typeof setInterval> | null = null
+let restartWaitTimer: ReturnType<typeof setInterval> | null = null
+
+function restoreHandledJobs() {
+  try {
+    const stored = JSON.parse(sessionStorage.getItem(HANDLED_JOBS_KEY) || '[]')
+    if (Array.isArray(stored)) {
+      for (const id of stored) if (typeof id === 'string') handledJobIds.add(id)
+    }
+  } catch {
+    // Ignore malformed or unavailable session storage.
+  }
+}
+
+function rememberHandledJob(jobId?: string) {
+  if (!jobId) return
+  handledJobIds.add(jobId)
+  try {
+    sessionStorage.setItem(HANDLED_JOBS_KEY, JSON.stringify([...handledJobIds]))
+  } catch {
+    // The in-memory marker still prevents duplicate prompts in this page.
+  }
+}
+
+async function checkCompletedRuntimeDownloads() {
+  try {
+    const response = await fetchVersionDownloadJobs()
+    const completed = response.jobs.filter(job =>
+      job.kind === 'runtime'
+      && job.status === 'completed'
+      && !handledJobIds.has(job.id),
+    )
+    if (completed.length === 0) return
+    if (pendingRuntimeRestart.value) {
+      for (const job of completed) rememberHandledJob(job.id)
+      return
+    }
+    for (const job of completed.slice(1)) rememberHandledJob(job.id)
+    requestRuntimeRestart(completed[0].version, completed[0].id)
+  } catch {
+    // Authentication and transient network failures are retried by the poller.
+  }
+}
+
+function restartStandaloneWebUi() {
+  let attempts = 0
+  let sawUnavailable = false
+  restartWaitTimer = setInterval(async () => {
+    attempts += 1
+    try {
+      const response = await fetch('/health', { cache: 'no-store' })
+      if (response.ok && (sawUnavailable || attempts >= 15)) {
+        if (restartWaitTimer) clearInterval(restartWaitTimer)
+        restartWaitTimer = null
+        window.location.reload()
+      }
+    } catch {
+      sawUnavailable = true
+    }
+    if (attempts >= 60) {
+      if (restartWaitTimer) clearInterval(restartWaitTimer)
+      restartWaitTimer = null
+      window.location.reload()
+    }
+  }, 1000)
+}
+
+async function restartNow() {
+  if (!pendingRuntimeRestart.value || restarting.value) return
+  restarting.value = true
+  try {
+    const bridge = desktopBridge()
+    if (bridge?.isDesktop === true) {
+      if (!bridge.restartApp) throw new Error('Desktop restart is unavailable')
+      await bridge.restartApp()
+    } else {
+      await restartWebUiAfterRuntimeChange()
+      restartStandaloneWebUi()
+    }
+    rememberHandledJob(pendingRuntimeRestart.value.jobId)
+  } catch (err) {
+    restarting.value = false
+    message.error(`${t('runtimeVersions.restartFailed')}: ${err instanceof Error ? err.message : String(err)}`)
+  }
+}
+
+function restartLater() {
+  rememberHandledJob(pendingRuntimeRestart.value?.jobId)
+  clearRuntimeRestart()
+}
+
+onMounted(() => {
+  restoreHandledJobs()
+  void checkCompletedRuntimeDownloads()
+  pollTimer = setInterval(() => {
+    void checkCompletedRuntimeDownloads()
+  }, POLL_INTERVAL_MS)
+})
+
+onBeforeUnmount(() => {
+  if (pollTimer) clearInterval(pollTimer)
+  if (restartWaitTimer) clearInterval(restartWaitTimer)
+})
+</script>
+
+<template>
+  <NModal
+    :show="!!pendingRuntimeRestart"
+    :mask-closable="false"
+    :close-on-esc="false"
+  >
+    <NCard
+      data-testid="runtime-restart-prompt"
+      role="dialog"
+      :title="t('runtimeVersions.restartPromptTitle')"
+      :bordered="false"
+      style="width: min(460px, calc(100vw - 32px))"
+    >
+      <p>
+        {{ t('runtimeVersions.restartPromptContent', { version: pendingRuntimeRestart?.version || '-' }) }}
+      </p>
+      <template #footer>
+        <div class="actions">
+          <NButton
+            data-testid="runtime-restart-later"
+            :disabled="restarting"
+            @click="restartLater"
+          >
+            {{ t('runtimeVersions.restartLater') }}
+          </NButton>
+          <NButton
+            data-testid="runtime-restart-now"
+            type="primary"
+            :loading="restarting"
+            @click="restartNow"
+          >
+            {{ t('runtimeVersions.restartNow') }}
+          </NButton>
+        </div>
+      </template>
+    </NCard>
+  </NModal>
+</template>
+
+<style scoped lang="scss">
+p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+</style>

--- a/packages/client/src/components/layout/VersionManagementModal.vue
+++ b/packages/client/src/components/layout/VersionManagementModal.vue
@@ -8,7 +8,6 @@ import {
   downloadRuntimeVersion,
   fetchRuntimeVersionStatus,
   fetchVersionDownloadJobs,
-  restartWebUiAfterRuntimeChange,
   selectRuntimeRoot,
   type InstalledRuntimeVersion,
   type RuntimeVersionStatus,
@@ -18,6 +17,7 @@ import {
   type VersionDownloadSource,
 } from '@/api/hermes/runtime-versions'
 import HermesDataDirectoryHint from '@/components/hermes/HermesDataDirectoryHint.vue'
+import { useRuntimeRestartPrompt } from '@/composables/useRuntimeRestartPrompt'
 import { desktopBridge } from '@/utils/desktop-bridge'
 
 const props = defineProps<{ show: boolean }>()
@@ -25,6 +25,7 @@ const emit = defineEmits<{ (event: 'update:show', value: boolean): void }>()
 
 const { t } = useI18n()
 const message = useMessage()
+const { requestRuntimeRestart } = useRuntimeRestartPrompt()
 
 const status = ref<RuntimeVersionStatus | null>(null)
 const jobs = ref<VersionDownloadJob[]>([])
@@ -33,7 +34,6 @@ const actionLoading = ref<Record<string, boolean>>({})
 const loadError = ref('')
 const cliDetailsShow = ref(false)
 let pollTimer: ReturnType<typeof setInterval> | null = null
-let restartWaitTimer: ReturnType<typeof setInterval> | null = null
 
 const canSelectRuntimeDirectory = computed(() => typeof desktopBridge()?.selectRuntimeDirectory === 'function')
 const isDefaultRuntimeDirectory = computed(() => {
@@ -73,7 +73,6 @@ watch(() => props.show, show => {
 
 onBeforeUnmount(() => {
   stopPolling()
-  if (restartWaitTimer) clearInterval(restartWaitTimer)
 })
 
 function updateShow(show: boolean) {
@@ -120,40 +119,6 @@ async function refreshJobs() {
   } catch {
     stopPolling()
   }
-}
-
-async function restartRuntimeHost() {
-  const bridge = desktopBridge()
-  if (bridge?.isDesktop === true) {
-    if (!bridge.restartApp) throw new Error('Desktop restart is unavailable')
-    await bridge.restartApp()
-    return
-  }
-  await restartWebUiAfterRuntimeChange()
-  waitForWebUiRestart()
-}
-
-function waitForWebUiRestart() {
-  let attempts = 0
-  let sawUnavailable = false
-  restartWaitTimer = setInterval(async () => {
-    attempts += 1
-    try {
-      const response = await fetch('/health', { cache: 'no-store' })
-      if (response.ok && (sawUnavailable || attempts >= 15)) {
-        if (restartWaitTimer) clearInterval(restartWaitTimer)
-        restartWaitTimer = null
-        window.location.reload()
-      }
-    } catch {
-      sawUnavailable = true
-    }
-    if (attempts >= 60) {
-      if (restartWaitTimer) clearInterval(restartWaitTimer)
-      restartWaitTimer = null
-      window.location.reload()
-    }
-  }, 1000)
 }
 
 function startPolling() {
@@ -259,7 +224,7 @@ async function useRuntime(version: string) {
   await runAction(`activate-runtime-${version}`, async () => {
     await activateRuntimeVersion(version)
     message.success(t('runtimeVersions.activateSuccess'))
-    await restartRuntimeHost()
+    requestRuntimeRestart(version)
   })
 }
 

--- a/packages/client/src/composables/useRuntimeRestartPrompt.ts
+++ b/packages/client/src/composables/useRuntimeRestartPrompt.ts
@@ -1,0 +1,25 @@
+import { readonly, ref } from 'vue'
+
+export interface PendingRuntimeRestart {
+  version: string
+  jobId?: string
+}
+
+const pendingRuntimeRestart = ref<PendingRuntimeRestart | null>(null)
+
+export function useRuntimeRestartPrompt() {
+  function requestRuntimeRestart(version: string, jobId?: string) {
+    if (pendingRuntimeRestart.value) return
+    pendingRuntimeRestart.value = { version, ...(jobId ? { jobId } : {}) }
+  }
+
+  function clearRuntimeRestart() {
+    pendingRuntimeRestart.value = null
+  }
+
+  return {
+    pendingRuntimeRestart: readonly(pendingRuntimeRestart),
+    requestRuntimeRestart,
+    clearRuntimeRestart,
+  }
+}

--- a/packages/client/src/i18n/locales/ar.ts
+++ b/packages/client/src/i18n/locales/ar.ts
@@ -474,6 +474,11 @@ export default {
     downloadTasks: 'مهام التنزيل',
     downloadStarted: 'بدأ التنزيل',
     activateSuccess: 'تم حفظ اختيار الإصدار. أعد تشغيل Hermes Studio لاستخدامه.',
+    restartPromptTitle: 'Runtime جاهز',
+    restartPromptContent: 'تم تثبيت Hermes Runtime {version}. هل تريد إعادة التشغيل الآن لاستخدامه؟',
+    restartLater: 'لاحقًا',
+    restartNow: 'إعادة التشغيل الآن',
+    restartFailed: 'فشلت إعادة التشغيل',
     jobStatus: {
       queued: 'في الانتظار',
       running: 'قيد التشغيل',

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -486,6 +486,11 @@ export default {
     downloadTasks: 'Download-Aufgaben',
     downloadStarted: 'Download gestartet',
     activateSuccess: 'Versionsauswahl gespeichert. Starten Sie Hermes Studio neu, um sie zu verwenden.',
+    restartPromptTitle: 'Runtime bereit',
+    restartPromptContent: 'Hermes Runtime {version} wurde installiert. Jetzt neu starten, um sie zu verwenden?',
+    restartLater: 'Später',
+    restartNow: 'Jetzt neu starten',
+    restartFailed: 'Neustart fehlgeschlagen',
     jobStatus: {
       queued: 'In Warteschlange',
       running: 'Läuft',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -474,6 +474,11 @@ export default {
     downloadTasks: 'Download tasks',
     downloadStarted: 'Download started',
     activateSuccess: 'Version selection saved. Restart Hermes Studio to use it.',
+    restartPromptTitle: 'Runtime ready',
+    restartPromptContent: 'Hermes Runtime {version} has been installed. Restart now to use it?',
+    restartLater: 'Later',
+    restartNow: 'Restart now',
+    restartFailed: 'Restart failed',
     jobStatus: {
       queued: 'Queued',
       running: 'Running',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -486,6 +486,11 @@ export default {
     downloadTasks: 'Tareas de descarga',
     downloadStarted: 'Descarga iniciada',
     activateSuccess: 'Selección de versión guardada. Reinicia Hermes Studio para usarla.',
+    restartPromptTitle: 'Runtime listo',
+    restartPromptContent: 'Hermes Runtime {version} se ha instalado. ¿Reiniciar ahora para usarlo?',
+    restartLater: 'Más tarde',
+    restartNow: 'Reiniciar ahora',
+    restartFailed: 'Error al reiniciar',
     jobStatus: {
       queued: 'En cola',
       running: 'En ejecución',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -486,6 +486,11 @@ export default {
     downloadTasks: 'Tâches de téléchargement',
     downloadStarted: 'Téléchargement démarré',
     activateSuccess: 'Sélection de version enregistrée. Redémarrez Hermes Studio pour l’utiliser.',
+    restartPromptTitle: 'Runtime prêt',
+    restartPromptContent: 'Hermes Runtime {version} a été installé. Redémarrer maintenant pour l’utiliser ?',
+    restartLater: 'Plus tard',
+    restartNow: 'Redémarrer maintenant',
+    restartFailed: 'Échec du redémarrage',
     jobStatus: {
       queued: 'En attente',
       running: 'En cours',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -486,6 +486,11 @@ export default {
     downloadTasks: 'ダウンロードタスク',
     downloadStarted: 'ダウンロードを開始しました',
     activateSuccess: 'バージョン選択を保存しました。Hermes Studio を再起動すると反映されます。',
+    restartPromptTitle: 'Runtime の準備が完了しました',
+    restartPromptContent: 'Hermes Runtime {version} がインストールされました。今すぐ再起動して使用しますか？',
+    restartLater: '後で',
+    restartNow: '今すぐ再起動',
+    restartFailed: '再起動に失敗しました',
     jobStatus: {
       queued: '待機中',
       running: '実行中',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -486,6 +486,11 @@ export default {
     downloadTasks: '다운로드 작업',
     downloadStarted: '다운로드를 시작했습니다',
     activateSuccess: '버전 선택이 저장되었습니다. Hermes Studio를 다시 시작하면 적용됩니다.',
+    restartPromptTitle: 'Runtime 준비 완료',
+    restartPromptContent: 'Hermes Runtime {version} 설치가 완료되었습니다. 지금 다시 시작하여 사용하시겠습니까?',
+    restartLater: '나중에',
+    restartNow: '지금 다시 시작',
+    restartFailed: '다시 시작 실패',
     jobStatus: {
       queued: '대기 중',
       running: '실행 중',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -486,6 +486,11 @@ export default {
     downloadTasks: 'Tarefas de download',
     downloadStarted: 'Download iniciado',
     activateSuccess: 'Seleção de versão salva. Reinicie o Hermes Studio para usá-la.',
+    restartPromptTitle: 'Runtime pronto',
+    restartPromptContent: 'O Hermes Runtime {version} foi instalado. Reiniciar agora para usá-lo?',
+    restartLater: 'Mais tarde',
+    restartNow: 'Reiniciar agora',
+    restartFailed: 'Falha ao reiniciar',
     jobStatus: {
       queued: 'Na fila',
       running: 'Em execução',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -396,6 +396,11 @@ export default {
     downloadTasks: 'Задачи загрузки',
     downloadStarted: 'Загрузка начата',
     activateSuccess: 'Выбор версии сохранен. Перезапустите Hermes Studio, чтобы применить его.',
+    restartPromptTitle: 'Runtime готов',
+    restartPromptContent: 'Hermes Runtime {version} установлен. Перезапустить сейчас, чтобы использовать его?',
+    restartLater: 'Позже',
+    restartNow: 'Перезапустить сейчас',
+    restartFailed: 'Не удалось перезапустить',
     jobStatus: {
       queued: 'В очереди',
       running: 'Выполняется',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -474,6 +474,11 @@ export default {
     downloadTasks: '下載任務',
     downloadStarted: '已開始下載',
     activateSuccess: '版本選擇已儲存，重啟 Hermes Studio 後生效。',
+    restartPromptTitle: 'Runtime 已就緒',
+    restartPromptContent: 'Hermes Runtime {version} 已安裝完成，是否立即重新啟動並使用此版本？',
+    restartLater: '稍後',
+    restartNow: '立即重新啟動',
+    restartFailed: '重新啟動失敗',
     jobStatus: {
       queued: '排隊中',
       running: '下載中',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -474,6 +474,11 @@ export default {
     downloadTasks: '下载任务',
     downloadStarted: '已开始下载',
     activateSuccess: '版本选择已保存，重启 Hermes Studio 后生效。',
+    restartPromptTitle: 'Runtime 已就绪',
+    restartPromptContent: 'Hermes Runtime {version} 已安装完成，是否立即重启并使用该版本？',
+    restartLater: '稍后',
+    restartNow: '立即重启',
+    restartFailed: '重启失败',
     jobStatus: {
       queued: '排队中',
       running: '下载中',

--- a/packages/desktop/src/main/hermes-environment-selection.ts
+++ b/packages/desktop/src/main/hermes-environment-selection.ts
@@ -18,6 +18,7 @@ import { promisify } from 'node:util'
 
 const execFileAsync = promisify(execFile)
 const DEFAULT_PROBE_TIMEOUT_MS = 5_000
+const HERMES_VERSION_PROBE = "import importlib.util, hermes_cli; assert importlib.util.find_spec('hermes_cli.main'); print(hermes_cli.__version__)"
 
 export type DesktopHermesSelectionSource = 'user-cli' | 'managed-runtime' | 'none'
 
@@ -296,11 +297,11 @@ function probeFailureMessage(error: unknown, timeout: number): string {
       ? detail.stderr.toString('utf8').trim()
       : ''
   if (detail?.killed || detail?.code === 'ETIMEDOUT') {
-    return `hermes --version timed out after ${timeout}ms${stderr ? `: ${stderr}` : ''}`
+    return `Hermes CLI import probe timed out after ${timeout}ms${stderr ? `: ${stderr}` : ''}`
   }
   const code = detail?.code !== undefined ? ` (${String(detail.code)})` : ''
   const message = error instanceof Error ? error.message.replace(/^Error:\s*/, '').trim() : String(error)
-  return `hermes --version failed${code}: ${stderr || message || 'unknown error'}`
+  return `Hermes CLI import probe failed${code}: ${stderr || message || 'unknown error'}`
 }
 
 async function probeHermesVersion(
@@ -312,17 +313,13 @@ async function probeHermesVersion(
   if (!selection.pythonPath) return { ok: false, error: 'Python path is not configured' }
   if (!selection.agentRoot) return { ok: false, error: 'Agent Root is not configured' }
   if (!selection.environmentRoot) return { ok: false, error: 'Python environment root is not configured' }
-  const command = process.platform === 'win32' ? selection.pythonPath : selection.path
-  const args = process.platform === 'win32'
-    ? ['-m', 'hermes_cli.main', '--version']
-    : ['--version']
   const probeEnv = withDesktopHermesSelection(env, {
     ...selection,
     source,
     version: '',
   })
   try {
-    const { stdout } = await execFileAsync(command, args, {
+    const { stdout } = await execFileAsync(selection.pythonPath, ['-c', HERMES_VERSION_PROBE], {
       encoding: 'utf8',
       timeout,
       windowsHide: true,
@@ -331,7 +328,7 @@ async function probeHermesVersion(
     const version = normalizeVersion(String(stdout || ''))
     return version
       ? { ok: true, version }
-      : { ok: false, error: 'hermes --version returned an empty version' }
+      : { ok: false, error: 'Hermes CLI import probe returned an empty version' }
   } catch (error) {
     return { ok: false, error: probeFailureMessage(error, timeout) }
   }

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -19,7 +19,6 @@ import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import {
   getToken,
-  setWebUiRuntimeRestartHandler,
   setWebUiUnexpectedExitHandler,
   startWebUiServer,
   stopWebUiServer,
@@ -1252,10 +1251,6 @@ ipcMain.handle('hermes-desktop:retry-bootstrap', async (_event, source?: Runtime
 })
 
 function runDesktopApp() {
-  setWebUiRuntimeRestartHandler(() => {
-    app.relaunch()
-    quitApp()
-  })
   setWebUiUnexpectedExitHandler(details => {
     void recoverUnexpectedWebUiExit(details)
   })

--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -47,12 +47,7 @@ const execFileAsync = promisify(execFile)
 let serverProc: ChildProcess | null = null
 let cachedToken: string | null = null
 let currentServerPort = DEFAULT_PORT
-let runtimeRestartHandler: (() => void) | null = null
 let unexpectedExitHandler: ((details: { code: number | null; signal: NodeJS.Signals | null }) => void) | null = null
-
-export function setWebUiRuntimeRestartHandler(handler: (() => void) | null): void {
-  runtimeRestartHandler = handler
-}
 
 export function setWebUiUnexpectedExitHandler(
   handler: ((details: { code: number | null; signal: NodeJS.Signals | null }) => void) | null,
@@ -775,10 +770,6 @@ async function launchWebUiServer(webUiDirectory: string, entry: string, env: Nod
   launchedProc.on('exit', (code, signal) => {
     console.error(`[webui] server exited code=${code} signal=${signal}`)
     if (serverProc === launchedProc) serverProc = null
-    if (code === 75) {
-      runtimeRestartHandler?.()
-      return
-    }
     if (startupReady && code !== 0 && app.isReady()) {
       unexpectedExitHandler?.({ code, signal })
     }

--- a/packages/server/src/bootstrap/http.ts
+++ b/packages/server/src/bootstrap/http.ts
@@ -70,12 +70,10 @@ import {
   type HermesRuntimeSelection,
 } from '../modules/hermes/services/runtime/selection'
 import {
-  configureRuntimeInstallCompletedHandler,
   getRuntimeVersionStatus,
   readActiveVersionManifest,
 } from '../modules/hermes/services/runtime/version-manager'
 import { isHermesAgentAvailable, updateAgentStatus } from '../modules/studio/public/agent-status-registry'
-import { scheduleWebUiRestart } from '../modules/studio/public/web-ui-restart'
 
 // Injected by esbuild at build time; fallback to reading package.json in dev mode
 declare const __APP_VERSION__: string
@@ -398,16 +396,6 @@ export async function bootstrap() {
   }
   const hermesAgentAvailable = isHermesAgentAvailable()
   console.log(`[bootstrap] Hermes Agent inventory status=${hermesAgentAvailable ? 'available' : 'not-installed'}`)
-  configureRuntimeInstallCompletedHandler(() => {
-    if (isDesktopRuntime()) {
-      setTimeout(() => {
-        void getShutdownHandler()('runtime-installed', 75)
-      }, 250).unref?.()
-      return
-    }
-    scheduleWebUiRestart()
-  })
-
   await initLoginLimiter()
   if (skillInjectionDisabled()) {
     console.log('[bootstrap] bundled skill injection disabled by HERMES_WEB_UI_DISABLE_SKILL_INJECTION')

--- a/packages/server/src/modules/hermes/services/runtime/cli.ts
+++ b/packages/server/src/modules/hermes/services/runtime/cli.ts
@@ -10,6 +10,7 @@ import { isGatewayRunningForProfile } from '../gateway/autostart'
 import { startGatewayRunManaged } from '../gateway/runner'
 import { getActiveProfileDir, getActiveProfileName, getProfileDir, listProfileNamesFromDisk } from '../profiles/profile'
 import { parseProfileListRuntimeInfo, type ProfileListRuntimeInfo } from '../profiles/profile-list-parser'
+import { probeHermesCliVersion } from './discovery'
 import { execHermesWithBin, spawnHermesWithBin } from './process'
 
 const execFileAsync = promisify(execFile)
@@ -405,12 +406,8 @@ export interface LogFileInfo {
  * Get Hermes version
  */
 export async function getVersion(): Promise<string> {
-  try {
-    const { stdout } = await execHermesWithBin(resolveHermesBin(), ['--version'], { timeout: 5000, ...execOpts })
-    return stdout.trim()
-  } catch {
-    return ''
-  }
+  const probe = await probeHermesCliVersion(resolveHermesBin(), process.env)
+  return probe.version
 }
 
 /**

--- a/packages/server/src/modules/hermes/services/runtime/discovery.ts
+++ b/packages/server/src/modules/hermes/services/runtime/discovery.ts
@@ -1,16 +1,15 @@
 import { execFile } from 'child_process'
 import { existsSync, realpathSync } from 'fs'
-import { isAbsolute, resolve } from 'path'
+import { homedir } from 'os'
+import { isAbsolute, join, resolve } from 'path'
 import { promisify } from 'util'
-import {
-  normalizeWindowsCommandPath,
-  windowsCmdShimExecution,
-  windowsCommandNeedsShell,
-} from '../../../studio/public/windows-command'
+import { normalizeWindowsCommandPath } from '../../../studio/public/windows-command'
+import { resolveHermesInstallationEnvironment } from './installation'
 import { isPathWithin } from './path'
-import { execHermesWithBin, resolveHermesBin } from './process'
+import { resolveHermesBin } from './process'
 
 const execFileAsync = promisify(execFile)
+const HERMES_VERSION_PROBE = "import importlib.util, hermes_cli; assert importlib.util.find_spec('hermes_cli.main'); print(hermes_cli.__version__)"
 
 export interface HermesManagedRuntimeLocation {
   version: string
@@ -79,47 +78,47 @@ function versionProbeError(error: unknown): string {
   const stderr = typeof detail?.stderr === 'string'
     ? detail.stderr.trim()
     : Buffer.isBuffer(detail?.stderr) ? detail.stderr.toString('utf8').trim() : ''
-  if (detail?.killed || detail?.code === 'ETIMEDOUT') return 'hermes --version timed out after 5000ms'
+  if (detail?.killed || detail?.code === 'ETIMEDOUT') return 'Hermes CLI import probe timed out after 5000ms'
   const code = detail?.code !== undefined ? ` (${String(detail.code)})` : ''
   const message = error instanceof Error ? error.message.replace(/^Error:\s*/, '').trim() : String(error)
-  return `hermes --version failed${code}: ${stderr || message || 'unknown error'}`
+  return `Hermes CLI import probe failed${code}: ${stderr || message || 'unknown error'}`
+}
+
+function hermesHomeForEnvironment(env: NodeJS.ProcessEnv): string {
+  const configured = env.HERMES_HOME?.trim()
+  if (configured) return configured
+  const userHome = process.platform === 'win32'
+    ? env.USERPROFILE?.trim() || homedir()
+    : env.HOME?.trim() || homedir()
+  return join(userHome, '.hermes')
 }
 
 export async function probeHermesCliVersion(
   path: string,
   env: NodeJS.ProcessEnv,
 ): Promise<{ version: string; error: string }> {
+  const installation = resolveHermesInstallationEnvironment(
+    path,
+    hermesHomeForEnvironment(env),
+    env,
+  )
+  if (!installation.python) {
+    return { version: '', error: `Hermes Python executable could not be resolved for ${path}` }
+  }
+
   try {
-    const result = await execHermesWithBin(path, ['--version'], {
+    const { stdout } = await execFileAsync(installation.python, ['-c', HERMES_VERSION_PROBE], {
       encoding: 'utf8',
       timeout: 5000,
       windowsHide: true,
       env,
     })
-    const version = normalizeVersion(result.stdout)
+    const version = normalizeVersion(String(stdout || ''))
     return version
       ? { version, error: '' }
-      : { version: '', error: 'hermes --version returned an empty version' }
-  } catch (firstError) {
-    if (process.platform !== 'win32' || !windowsCommandNeedsShell(path)) {
-      return { version: '', error: versionProbeError(firstError) }
-    }
-    try {
-      const execution = windowsCmdShimExecution(path, ['--version'])
-      const { stdout } = await execFileAsync(execution.command, execution.args, {
-        encoding: 'utf8',
-        timeout: 5000,
-        windowsHide: true,
-        windowsVerbatimArguments: execution.windowsVerbatimArguments,
-        env,
-      })
-      const version = normalizeVersion(String(stdout || ''))
-      return version
-        ? { version, error: '' }
-        : { version: '', error: 'hermes --version returned an empty version' }
-    } catch (fallbackError) {
-      return { version: '', error: versionProbeError(fallbackError) }
-    }
+      : { version: '', error: 'Hermes CLI import probe returned an empty version' }
+  } catch (error) {
+    return { version: '', error: versionProbeError(error) }
   }
 }
 

--- a/packages/server/src/modules/hermes/services/runtime/selection.ts
+++ b/packages/server/src/modules/hermes/services/runtime/selection.ts
@@ -288,7 +288,7 @@ export async function configurePreferredHermesRuntime(
     if (!probe.version) {
       managedFailures.push({
         directory: runtime.directory,
-        reason: probe.error || 'hermes --version failed',
+        reason: probe.error || 'Hermes CLI import probe failed',
         version: runtime.version,
         platform: runtime.platform,
       })

--- a/packages/server/src/modules/hermes/services/runtime/version-manager.ts
+++ b/packages/server/src/modules/hermes/services/runtime/version-manager.ts
@@ -148,13 +148,6 @@ interface DownloadProgress {
 }
 
 type DownloadProgressHandler = (progress: DownloadProgress) => void
-type RuntimeInstallCompletedHandler = (runtime: InstalledRuntimeVersion) => void | Promise<void>
-
-let runtimeInstallCompletedHandler: RuntimeInstallCompletedHandler | null = null
-
-export function configureRuntimeInstallCompletedHandler(handler: RuntimeInstallCompletedHandler | null): void {
-  runtimeInstallCompletedHandler = handler
-}
 
 function runtimePlatformKey(platformName = process.platform, archName = process.arch): string {
   const osLabel = platformName === 'win32' ? 'win' : platformName === 'darwin' ? 'mac' : platformName
@@ -961,9 +954,6 @@ function createDownloadJob(
         job.percent = 100
         job.result = result
         job.updatedAt = new Date().toISOString()
-        if (kind === 'runtime' && runtimeInstallCompletedHandler) {
-          void Promise.resolve(runtimeInstallCompletedHandler(result as InstalledRuntimeVersion)).catch(() => undefined)
-        }
       })
       .catch(err => {
         job.status = 'failed'

--- a/packages/server/src/modules/studio/public/dev-restart-trigger.ts
+++ b/packages/server/src/modules/studio/public/dev-restart-trigger.ts
@@ -1,0 +1,1 @@
+// In development, touching this file asks nodemon to restart the Web UI server.

--- a/packages/server/src/modules/studio/public/web-ui-restart.ts
+++ b/packages/server/src/modules/studio/public/web-ui-restart.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'child_process'
-import { existsSync } from 'fs'
+import { existsSync, utimesSync } from 'fs'
 import { dirname, join, resolve } from 'path'
 import { config } from './config'
 
@@ -20,10 +20,29 @@ function webUiCliPath(): string {
   return cli
 }
 
+function developmentRestartTriggerPath(): string {
+  const candidates = [
+    join(process.cwd(), 'packages', 'server', 'src', 'modules', 'studio', 'public', 'dev-restart-trigger.ts'),
+    join(__dirname, 'dev-restart-trigger.ts'),
+  ]
+  const trigger = candidates.find(existsSync)
+  if (!trigger) throw new Error('Unable to locate the nodemon development restart trigger')
+  return trigger
+}
+
 /** Schedule a CLI-supervised standalone Web UI restart after the API response. */
 export function scheduleWebUiRestart(): void {
   if (isDesktopRuntime()) throw new Error('Desktop Runtime must restart through the desktop shell')
   if (restartScheduled) return
+  if (process.env.NODE_ENV === 'development') {
+    const trigger = developmentRestartTriggerPath()
+    restartScheduled = true
+    setTimeout(() => {
+      const now = new Date()
+      utimesSync(trigger, now, now)
+    }, 250).unref?.()
+    return
+  }
   const cli = webUiCliPath()
   restartScheduled = true
   setTimeout(() => {

--- a/tests/client/app-web-pet.test.ts
+++ b/tests/client/app-web-pet.test.ts
@@ -75,6 +75,10 @@ vi.mock('@/components/layout/GlobalPendingActions.vue', () => ({
   default: { name: 'GlobalPendingActions', template: '<div class="global-pending-actions-test" />' },
 }))
 
+vi.mock('@/components/layout/RuntimeRestartPrompt.vue', () => ({
+  default: { name: 'RuntimeRestartPrompt', template: '<div class="runtime-restart-prompt-test" />' },
+}))
+
 vi.mock('@/components/hermes/chat/SessionSearchModal.vue', () => ({
   default: { name: 'SessionSearchModal', template: '<div />' },
 }))
@@ -136,6 +140,7 @@ describe('App web pet mounting', () => {
     await flushPromises()
 
     expect(wrapper.findComponent({ name: 'GlobalPendingActions' }).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'RuntimeRestartPrompt' }).exists()).toBe(true)
   })
 
   it('mounts the web pet in the browser web app', async () => {

--- a/tests/client/runtime-restart-prompt.test.ts
+++ b/tests/client/runtime-restart-prompt.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const api = vi.hoisted(() => ({
+  fetchVersionDownloadJobs: vi.fn(),
+  restartWebUiAfterRuntimeChange: vi.fn(),
+}))
+const desktop = vi.hoisted(() => ({
+  bridge: null as null | { isDesktop: boolean; restartApp?: ReturnType<typeof vi.fn> },
+}))
+const message = vi.hoisted(() => ({ error: vi.fn() }))
+
+vi.mock('@/api/hermes/runtime-versions', () => api)
+vi.mock('@/utils/desktop-bridge', () => ({
+  desktopBridge: () => desktop.bridge,
+}))
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, unknown>) => params?.version ? `${key}:${params.version}` : key,
+  }),
+}))
+vi.mock('naive-ui', () => ({
+  NButton: {
+    props: ['disabled', 'loading'],
+    emits: ['click'],
+    template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
+  },
+  NCard: { template: '<section><h1><slot name="header" /></h1><slot /><footer><slot name="footer" /></footer></section>' },
+  NModal: { props: ['show'], template: '<div v-if="show"><slot /></div>' },
+  useMessage: () => message,
+}))
+
+import RuntimeRestartPrompt from '@/components/layout/RuntimeRestartPrompt.vue'
+import { useRuntimeRestartPrompt } from '@/composables/useRuntimeRestartPrompt'
+
+function completedRuntimeJob(id = 'runtime-job-1') {
+  return {
+    id,
+    kind: 'runtime',
+    source: 'github',
+    version: '0.20.6',
+    status: 'completed',
+    stage: 'completed',
+    message: 'runtimeVersions.jobStage.completed',
+    error: '',
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+  }
+}
+
+describe('RuntimeRestartPrompt', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    sessionStorage.clear()
+    useRuntimeRestartPrompt().clearRuntimeRestart()
+    api.fetchVersionDownloadJobs.mockReset()
+    api.restartWebUiAfterRuntimeChange.mockReset()
+    api.fetchVersionDownloadJobs.mockResolvedValue({ jobs: [completedRuntimeJob()] })
+    api.restartWebUiAfterRuntimeChange.mockResolvedValue({ success: true })
+    desktop.bridge = null
+    message.error.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('waits for confirmation after a Runtime download completes', async () => {
+    const wrapper = mount(RuntimeRestartPrompt)
+    await flushPromises()
+
+    expect(wrapper.get('[data-testid="runtime-restart-prompt"]').text()).toContain('0.20.6')
+    expect(api.restartWebUiAfterRuntimeChange).not.toHaveBeenCalled()
+
+    await wrapper.get('[data-testid="runtime-restart-later"]').trigger('click')
+
+    expect(wrapper.find('[data-testid="runtime-restart-prompt"]').exists()).toBe(false)
+    expect(api.restartWebUiAfterRuntimeChange).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('restarts only the Desktop client when confirmed in Desktop', async () => {
+    const restartApp = vi.fn().mockResolvedValue(true)
+    desktop.bridge = { isDesktop: true, restartApp }
+    const wrapper = mount(RuntimeRestartPrompt)
+    await flushPromises()
+
+    await wrapper.get('[data-testid="runtime-restart-now"]').trigger('click')
+    await flushPromises()
+
+    expect(restartApp).toHaveBeenCalledTimes(1)
+    expect(api.restartWebUiAfterRuntimeChange).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('restarts only the standalone Web UI when confirmed in a browser', async () => {
+    const wrapper = mount(RuntimeRestartPrompt)
+    await flushPromises()
+
+    await wrapper.get('[data-testid="runtime-restart-now"]').trigger('click')
+    await flushPromises()
+
+    expect(api.restartWebUiAfterRuntimeChange).toHaveBeenCalledTimes(1)
+    wrapper.unmount()
+  })
+})

--- a/tests/client/version-management-modal.test.ts
+++ b/tests/client/version-management-modal.test.ts
@@ -38,6 +38,7 @@ vi.mock('naive-ui', () => ({
 }))
 
 import VersionManagementModal from '@/components/layout/VersionManagementModal.vue'
+import { useRuntimeRestartPrompt } from '@/composables/useRuntimeRestartPrompt'
 
 function runtimeStatus() {
   return {
@@ -75,6 +76,7 @@ function runtimeStatus() {
 
 describe('VersionManagementModal Runtime storage selector', () => {
   beforeEach(() => {
+    useRuntimeRestartPrompt().clearRuntimeRestart()
     for (const mock of Object.values(api)) mock.mockReset()
     selectRuntimeDirectory.mockReset()
     message.success.mockReset()
@@ -253,7 +255,7 @@ describe('VersionManagementModal Runtime storage selector', () => {
     expect(message.success).toHaveBeenCalledWith('runtimeVersions.runtimeDirectorySaved')
   })
 
-  it('restarts standalone Web UI after selecting an installed Runtime', async () => {
+  it('requests global restart confirmation after selecting an installed Runtime', async () => {
     const status = runtimeStatus()
     status.hermes.remoteVersions = ['0.20.4']
     status.hermes.installed = [{
@@ -274,7 +276,8 @@ describe('VersionManagementModal Runtime storage selector', () => {
     await flushPromises()
 
     expect(api.activateRuntimeVersion).toHaveBeenCalledWith('0.20.4')
-    expect(api.restartWebUiAfterRuntimeChange).toHaveBeenCalledTimes(1)
+    expect(api.restartWebUiAfterRuntimeChange).not.toHaveBeenCalled()
+    expect(useRuntimeRestartPrompt().pendingRuntimeRestart.value?.version).toBe('0.20.4')
     wrapper.unmount()
   })
 })

--- a/tests/desktop/hermes-environment-selection.test.ts
+++ b/tests/desktop/hermes-environment-selection.test.ts
@@ -23,7 +23,9 @@ function userCli(root: string, version: string, succeeds = true) {
   const environmentRoot = join(agentRoot, 'venv')
   const python = executable(
     join(environmentRoot, 'bin', 'python3'),
-    `#!/bin/sh\nprintf 'Hermes Agent ${version}\\n'\n`,
+    succeeds
+      ? `#!/bin/sh\nprintf '${version}\\n'\n`
+      : '#!/bin/sh\nexit 1\n',
   )
   const agentCommand = join(agentRoot, 'hermes')
   mkdirSync(agentRoot, { recursive: true })
@@ -32,9 +34,7 @@ function userCli(root: string, version: string, succeeds = true) {
   writeFileSync(agentCommand, '')
   const command = executable(
     join(root, '.local', 'bin', 'hermes'),
-    succeeds
-      ? `#!/bin/sh\nexec "${python}" "${agentCommand}" "$@"\n`
-      : '#!/bin/sh\nexit 1\n',
+    `#!/bin/sh\nexec "${python}" "${agentCommand}" "$@"\n`,
   )
   return { command, python, agentRoot, environmentRoot, hermesHome }
 }
@@ -42,12 +42,15 @@ function userCli(root: string, version: string, succeeds = true) {
 function managedRuntime(
   root: string,
   version: string,
-  options: { name?: string; command?: string; probePath?: string } = {},
+  options: { name?: string; command?: string; pythonCommand?: string; probePath?: string } = {},
 ): DesktopManagedHermesRuntime {
   const directory = join(root, options.name || 'managed-runtime')
   const agentRoot = join(directory, 'python')
   const environmentRoot = join(agentRoot, 'venv')
-  const pythonPath = executable(join(environmentRoot, 'bin', 'python3'), '#!/bin/sh\nexit 0\n')
+  const pythonPath = executable(
+    join(environmentRoot, 'bin', 'python3'),
+    options.pythonCommand || `#!/bin/sh\nprintf '${version}\\n'\n`,
+  )
   const path = executable(
     join(environmentRoot, 'bin', 'hermes'),
     options.command || `#!/bin/sh\nprintf 'Hermes Agent ${version}\\n'\n`,
@@ -168,12 +171,12 @@ describe.skipIf(process.platform === 'win32')('desktop Hermes environment select
     const attempts = join(root, 'attempts.log')
     const first = managedRuntime(root, '0.21.0', {
       name: 'first-runtime',
-      command: `#!/bin/sh\nprintf 'first\\n' >> "${attempts}"\nexit 23\n`,
+      pythonCommand: `#!/bin/sh\nprintf 'first\\n' >> "${attempts}"\nexit 23\n`,
     })
     first.probePath = [dirname(first.path), '/usr/bin', '/bin'].join(delimiter)
     const fallback = managedRuntime(root, '0.20.6', {
       name: 'fallback-runtime',
-      command: `#!/bin/sh\nprintf 'fallback\\n' >> "${attempts}"\ncase "$PATH" in *first-runtime*) exit 41;; esac\nprintf 'Hermes Agent 0.20.6\\n'\n`,
+      pythonCommand: `#!/bin/sh\nprintf 'fallback\\n' >> "${attempts}"\ncase "$PATH" in *first-runtime*) exit 41;; esac\nprintf '0.20.6\\n'\n`,
     })
     fallback.probePath = [dirname(fallback.path), '/usr/bin', '/bin'].join(delimiter)
 
@@ -197,19 +200,19 @@ describe.skipIf(process.platform === 'win32')('desktop Hermes environment select
     expect(readFileSync(attempts, 'utf8').trim().split('\n')).toEqual(['first', 'fallback'])
   })
 
-  it('checks cli.py after hermes --version succeeds before falling back', async () => {
+  it('checks cli.py after the offline import probe succeeds before falling back', async () => {
     const root = mkdtempSync(join(tmpdir(), 'desktop-hermes-selection-'))
     temporaryDirectories.push(root)
     const attempts = join(root, 'agent-files-attempts.log')
     const incomplete = managedRuntime(root, '0.21.0', {
       name: 'missing-cli-runtime',
-      command: `#!/bin/sh\nprintf 'version-ok\\n' >> "${attempts}"\nprintf 'Hermes Agent 0.21.0\\n'\n`,
+      pythonCommand: `#!/bin/sh\nprintf 'version-ok\\n' >> "${attempts}"\nprintf '0.21.0\\n'\n`,
     })
     rmSync(join(incomplete.agentRoot, 'cli.py'))
     incomplete.probePath = [dirname(incomplete.path), '/usr/bin', '/bin'].join(delimiter)
     const fallback = managedRuntime(root, '0.20.6', {
       name: 'complete-runtime',
-      command: `#!/bin/sh\nprintf 'fallback\\n' >> "${attempts}"\nprintf 'Hermes Agent 0.20.6\\n'\n`,
+      pythonCommand: `#!/bin/sh\nprintf 'fallback\\n' >> "${attempts}"\nprintf '0.20.6\\n'\n`,
     })
     fallback.probePath = [dirname(fallback.path), '/usr/bin', '/bin'].join(delimiter)
 

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -274,6 +274,11 @@ export async function mockHermesApi(page: Page, options: MockHermesApiOptions = 
       return
     }
 
+    if (pathname === '/api/hermes/runtime-versions/jobs' && request.method() === 'GET') {
+      await route.fulfill(jsonResponse({ jobs: [] }))
+      return
+    }
+
     if (pathname === '/api/auth/status') {
       await route.fulfill(jsonResponse({ hasPasswordLogin: true, username: 'playwright' }))
       return

--- a/tests/e2e/group-chat-room-deeplink.spec.ts
+++ b/tests/e2e/group-chat-room-deeplink.spec.ts
@@ -168,6 +168,7 @@ async function mockGroupChatApi(page: Page, offlinePresence = false) {
 
     if (pathname === '/health') return json({ status: 'ok' })
     if (pathname === '/api/auth/status') return json({ hasPasswordLogin: false, username: null })
+    if (pathname === '/api/hermes/runtime-versions/jobs' && request.method() === 'GET') return json({ jobs: [] })
     if (pathname === '/api/agents/status' && request.method() === 'GET') {
       return json({
         revision: 1,

--- a/tests/e2e/history-session-deeplink.spec.ts
+++ b/tests/e2e/history-session-deeplink.spec.ts
@@ -152,6 +152,7 @@ async function mockHistoryApi(page: Page, sessions = historySessions, groupRooms
 
     if (pathname === '/health') return json({ status: 'ok' })
     if (pathname === '/api/auth/status') return json({ hasPasswordLogin: false, username: null })
+    if (pathname === '/api/hermes/runtime-versions/jobs' && request.method() === 'GET') return json({ jobs: [] })
     if (pathname === '/api/hermes/available-models') return json({ default: 'test-model', default_provider: 'test-provider', groups: [TEST_MODEL_GROUP], allProviders: [TEST_MODEL_GROUP], model_aliases: {}, model_visibility: {} })
     if (pathname === '/api/hermes/profiles') return json({ profiles: [{ name: 'default', active: true, model: 'test-model', gateway: 'test' }] })
     if (pathname === '/api/studio/group-chat/rooms') {

--- a/tests/server/hermes-cli-discovery.test.ts
+++ b/tests/server/hermes-cli-discovery.test.ts
@@ -9,8 +9,11 @@ const temporaryDirectories: string[] = []
 
 function createCli(directory: string, version: string): string {
   mkdirSync(directory, { recursive: true })
+  const python = join(directory, 'python3')
+  writeFileSync(python, `#!/bin/sh\nprintf '${version}\\n'\n`)
+  chmodSync(python, 0o755)
   const cli = join(directory, 'hermes')
-  writeFileSync(cli, `#!/bin/sh\nprintf 'Hermes Agent ${version}\\n'\n`)
+  writeFileSync(cli, '#!/bin/sh\nexit 97\n')
   chmodSync(cli, 0o755)
   return cli
 }

--- a/tests/server/hermes-cli-selection-live.test.ts
+++ b/tests/server/hermes-cli-selection-live.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -7,8 +7,13 @@ const originalHermesBin = process.env.HERMES_BIN
 const temporaryDirectories: string[] = []
 
 function versionCli(root: string, name: string, version: string): string {
-  const command = join(root, name)
-  writeFileSync(command, `#!/bin/sh\nprintf 'Hermes Agent ${version}\\n'\n`)
+  const directory = join(root, name)
+  mkdirSync(directory, { recursive: true })
+  const python = join(directory, 'python3')
+  writeFileSync(python, `#!/bin/sh\nprintf '${version}\\n'\n`)
+  chmodSync(python, 0o755)
+  const command = join(directory, 'hermes')
+  writeFileSync(command, '#!/bin/sh\nexit 97\n')
   chmodSync(command, 0o755)
   return command
 }

--- a/tests/server/hermes-runtime-selection.test.ts
+++ b/tests/server/hermes-runtime-selection.test.ts
@@ -20,18 +20,21 @@ function platformKey(): string {
   return `${osLabel}-${process.arch}`
 }
 
-function cli(path: string, version: string): string {
+function cli(path: string): string {
   mkdirSync(path, { recursive: true })
   const command = join(path, 'hermes')
-  writeFileSync(command, `#!/bin/sh\nprintf 'Hermes Agent ${version}\\n'\n`)
+  writeFileSync(command, '#!/bin/sh\nexit 97\n')
   chmodSync(command, 0o755)
   return command
 }
 
 function failingCli(path: string): string {
   mkdirSync(path, { recursive: true })
+  const python = join(path, 'python3')
+  writeFileSync(python, '#!/bin/sh\nexit 1\n')
+  chmodSync(python, 0o755)
   const command = join(path, 'hermes')
-  writeFileSync(command, '#!/bin/sh\nexit 1\n')
+  writeFileSync(command, '#!/bin/sh\nexit 97\n')
   chmodSync(command, 0o755)
   return command
 }
@@ -62,16 +65,15 @@ function createUserCli(home: string, version: string): {
 function createManagedRuntime(
   root: string,
   version: string,
-  options: { activate?: boolean; command?: string } = {},
+  options: { activate?: boolean; pythonCommand?: string } = {},
 ): string {
   const runtime = join(root, 'desktop-runtime', 'hermes', version, platformKey())
   const environmentBin = join(runtime, 'python', 'venv', 'bin')
-  const managedCli = cli(environmentBin, version)
-  if (options.command) {
-    writeFileSync(managedCli, options.command)
-    chmodSync(managedCli, 0o755)
-  }
-  writeFileSync(join(environmentBin, 'python3'), '#!/bin/sh\nexit 0\n')
+  const managedCli = cli(environmentBin)
+  writeFileSync(
+    join(environmentBin, 'python3'),
+    options.pythonCommand || `#!/bin/sh\nprintf '${version}\\n'\n`,
+  )
   chmodSync(join(environmentBin, 'python3'), 0o755)
   writeFileSync(join(runtime, 'python', 'run_agent.py'), '')
   writeFileSync(join(runtime, 'python', 'cli.py'), '')
@@ -224,10 +226,10 @@ describe.skipIf(process.platform === 'win32')('Hermes Runtime selection', () => 
     const attempts = join(state.appHome, 'attempts.log')
     const fallbackCli = createManagedRuntime(state.appHome, '0.20.6', {
       activate: false,
-      command: `#!/bin/sh\nprintf 'fallback\\n' >> "${attempts}"\ncase "$PATH" in *0.21.0*) exit 41;; esac\nprintf 'Hermes Agent 0.20.6\\n'\n`,
+      pythonCommand: `#!/bin/sh\nprintf 'fallback\\n' >> "${attempts}"\ncase "$PATH" in *0.21.0*) exit 41;; esac\nprintf '0.20.6\\n'\n`,
     })
     const failingCli = createManagedRuntime(state.appHome, '0.21.0', {
-      command: `#!/bin/sh\nprintf 'failing\\n' >> "${attempts}"\nexit 23\n`,
+      pythonCommand: `#!/bin/sh\nprintf 'failing\\n' >> "${attempts}"\nexit 23\n`,
     })
     const activeVersionPath = join(state.appHome, 'desktop-runtime', 'active-version.json')
     const active = JSON.parse(readFileSync(activeVersionPath, 'utf8'))
@@ -275,7 +277,7 @@ describe.skipIf(process.platform === 'win32')('Hermes Runtime selection', () => 
     state.appHome = mkdtempSync(join(tmpdir(), 'hermes-selection-'))
     temporaryDirectories.push(state.appHome)
     const failingCli = createManagedRuntime(state.appHome, '0.20.0', {
-      command: '#!/bin/sh\nexit 23\n',
+      pythonCommand: '#!/bin/sh\nexit 23\n',
     })
     const runtimeDirectory = join(state.appHome, 'desktop-runtime', 'hermes', '0.20.0', platformKey())
     const activeVersionPath = join(state.appHome, 'desktop-runtime', 'active-version.json')

--- a/tests/server/runtime-install-restart-wiring.test.ts
+++ b/tests/server/runtime-install-restart-wiring.test.ts
@@ -11,21 +11,29 @@ describe('Runtime install restart wiring', () => {
 
     expect(completion).toContain('activateInstalledRuntimeVersion(result.version)')
     expect(completion).toContain("getRuntimeVersionStatus({ includeRemote: false })")
-    expect(manager).toContain('runtimeInstallCompletedHandler(result as InstalledRuntimeVersion)')
+    expect(manager).not.toContain('runtimeInstallCompletedHandler')
   })
 
-  it('restarts standalone Web UI and exits Desktop Web UI with the relaunch code', () => {
+  it('does not auto-relaunch Desktop after a Runtime download and re-enter a restart loop', () => {
     const bootstrap = readFileSync('packages/server/src/bootstrap/http.ts', 'utf8')
     const desktopServer = readFileSync('packages/desktop/src/main/webui-server.ts', 'utf8')
     const desktopMain = readFileSync('packages/desktop/src/main/index.ts', 'utf8')
 
-    expect(bootstrap).toContain("getShutdownHandler()('runtime-installed', 75)")
-    expect(bootstrap).toContain('scheduleWebUiRestart()')
-    expect(desktopServer).toContain('if (code === 75) {')
-    expect(desktopServer).toContain('runtimeRestartHandler?.()')
-    expect(desktopMain).toContain('setWebUiRuntimeRestartHandler(() => {')
-    expect(desktopMain).toContain('app.relaunch()')
-    expect(desktopMain).toContain('quitApp()')
+    expect(bootstrap).not.toContain("getShutdownHandler()('runtime-installed', 75)")
+    expect(bootstrap).not.toContain('configureRuntimeInstallCompletedHandler')
+    expect(desktopServer).not.toContain('runtimeRestartHandler')
+    expect(desktopMain).toContain("ipcMain.handle('hermes-desktop:restart-app'")
+  })
+
+  it('routes source-development restarts through a nodemon watched trigger', () => {
+    const restart = readFileSync('packages/server/src/modules/studio/public/web-ui-restart.ts', 'utf8')
+    const trigger = readFileSync('packages/server/src/modules/studio/public/dev-restart-trigger.ts', 'utf8')
+    const nodemon = readFileSync('nodemon.json', 'utf8')
+
+    expect(restart).toContain("process.env.NODE_ENV === 'development'")
+    expect(restart).toContain('utimesSync(trigger, now, now)')
+    expect(trigger).toContain('nodemon')
+    expect(nodemon).toContain('"watch": ["packages/server/src"')
   })
 
   it('gates Gateway and bridge startup on the probed in-memory Hermes inventory', () => {

--- a/tests/server/web-ui-restart.test.ts
+++ b/tests/server/web-ui-restart.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const spawn = vi.hoisted(() => vi.fn())
+const existsSync = vi.hoisted(() => vi.fn(() => true))
+const utimesSync = vi.hoisted(() => vi.fn())
+
+vi.mock('child_process', () => ({ spawn }))
+vi.mock('fs', () => ({ existsSync, utimesSync }))
+
+import {
+  resetWebUiRestartForTests,
+  scheduleWebUiRestart,
+} from '../../packages/server/src/modules/studio/public/web-ui-restart'
+
+describe('Web UI restart routing', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubEnv('HERMES_DESKTOP', '')
+    vi.stubEnv('NODE_ENV', 'test')
+    spawn.mockReset()
+    existsSync.mockReset()
+    existsSync.mockReturnValue(true)
+    utimesSync.mockReset()
+    resetWebUiRestartForTests()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllEnvs()
+  })
+
+  it('touches the nodemon restart trigger in development', () => {
+    vi.stubEnv('NODE_ENV', 'development')
+
+    scheduleWebUiRestart()
+    vi.advanceTimersByTime(250)
+
+    expect(utimesSync).toHaveBeenCalledWith(
+      expect.stringContaining('packages/server/src/modules/studio/public/dev-restart-trigger.ts'),
+      expect.any(Date),
+      expect.any(Date),
+    )
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
+  it('keeps Desktop restart ownership in the Electron shell', () => {
+    vi.stubEnv('HERMES_DESKTOP', 'true')
+
+    expect(() => scheduleWebUiRestart()).toThrow('Desktop Runtime must restart through the desktop shell')
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
+  it('uses the standalone CLI supervisor outside development', () => {
+    const unref = vi.fn()
+    spawn.mockReturnValue({ unref })
+    vi.stubEnv('NODE_ENV', 'production')
+
+    scheduleWebUiRestart()
+    vi.advanceTimersByTime(250)
+
+    expect(spawn).toHaveBeenCalledWith(
+      process.execPath,
+      expect.arrayContaining(['restart', '--port', '--no-open']),
+      expect.objectContaining({ detached: true }),
+    )
+    expect(unref).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- probe Hermes versions through a local Python import so startup does not invoke CLI update checks or reject a usable Runtime because the network is unavailable
- remove the Runtime-download completion exit-code-75 Desktop relaunch path and ask the user before restarting after installation or activation
- keep restart ownership host-specific: Electron performs a clean Desktop shutdown/relaunch, production Web UI uses its CLI supervisor, and source development uses a nodemon-watched trigger
- cover the global restart prompt, host restart routing, clean shutdown process-tree behavior, locale strings, and Playwright API mocks

## Impact

Runtime downloads no longer restart Hermes Studio automatically. This removes the application-managed relaunch path that could participate in a restart loop, while explicit restarts still drain Studio-owned gateways, bridges, PTYs, coding agents, sockets, HTTP servers, Ekko, and the database before exit.

The reported macOS 0.7.13 open-on-launch restart loop could not be reproduced without reporter logs. The only automatic full-App relaunch path associated with Runtime completion has been removed; updater installation still requires user confirmation.

## Validation

- `npm run harness:check`
- `npm run build`
- focused Runtime and shutdown suite: 12 files, 57 tests passed
- `npm run test:coverage`: 4,759 tests passed; two resource-constrained 5-second timeouts passed on focused rerun (50/50)
- `npm run test:e2e`: 140/141 passed; the unrelated Workflow tooltip hover failure passed on focused rerun
- `git diff --check`