### PR TITLE
fix: bridge remote Runtime restarts to Desktop

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -19,6 +19,7 @@ import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import {
   getToken,
+  setWebUiRestartRequestHandler,
   setWebUiUnexpectedExitHandler,
   startWebUiServer,
   stopWebUiServer,
@@ -79,6 +80,7 @@ let unexpectedWebUiExitCount = 0
 let unexpectedWebUiExitWindowStartedAt = 0
 let rendererRecoveryCount = 0
 let rendererRecoveryWindowStartedAt = 0
+let appRestartScheduled = false
 
 // Custom Session paths do not need Chromium's optional compression-dictionary
 // disk cache; disabling it leaves the normal HTTP cache enabled and isolated.
@@ -141,6 +143,17 @@ function showMainWindow() {
 function quitApp() {
   isQuitting = true
   app.quit()
+}
+
+function scheduleAppRestart(delayMs = 100): boolean {
+  if (appRestartScheduled) return true
+  if (isQuitting) return false
+  appRestartScheduled = true
+  setTimeout(() => {
+    app.relaunch()
+    quitApp()
+  }, delayMs).unref?.()
+  return true
 }
 
 async function prepareAppShutdown(): Promise<void> {
@@ -1022,11 +1035,7 @@ ipcMain.handle('hermes-desktop:restart-app', event => {
   if (!mainWindow || mainWindow.isDestroyed() || event.sender !== mainWindow.webContents) {
     throw new Error('Desktop restart can only be requested from the main window')
   }
-  setTimeout(() => {
-    app.relaunch()
-    quitApp()
-  }, 100).unref?.()
-  return true
+  return scheduleAppRestart()
 })
 ipcMain.handle('hermes-desktop:open-chat-window', (event, sessionId?: unknown, profile?: unknown) => {
   if (!mainWindow || mainWindow.isDestroyed() || event.sender !== mainWindow.webContents) {
@@ -1251,6 +1260,10 @@ ipcMain.handle('hermes-desktop:retry-bootstrap', async (_event, source?: Runtime
 })
 
 function runDesktopApp() {
+  setWebUiRestartRequestHandler(() => {
+    // Leave enough time for the authenticated relay HTTP request to flush its 202 response.
+    scheduleAppRestart(250)
+  })
   setWebUiUnexpectedExitHandler(details => {
     void recoverUnexpectedWebUiExit(details)
   })

--- a/packages/desktop/src/main/webui-server.ts
+++ b/packages/desktop/src/main/webui-server.ts
@@ -42,17 +42,31 @@ const DEFAULT_GRACEFUL_STOP_TIMEOUT_MS = 18_000
 const FORCE_KILL_COMMAND_TIMEOUT_MS = 5_000
 const AGENT_BRIDGE_STARTED_MARKER = '[bootstrap] agent bridge started'
 const AGENT_BRIDGE_FAILED_MARKER = '[bootstrap] agent bridge failed to start'
+const DESKTOP_RESTART_REQUEST = 'hermes-desktop:restart-app'
 const execFileAsync = promisify(execFile)
 
 let serverProc: ChildProcess | null = null
 let cachedToken: string | null = null
 let currentServerPort = DEFAULT_PORT
 let unexpectedExitHandler: ((details: { code: number | null; signal: NodeJS.Signals | null }) => void) | null = null
+let restartRequestHandler: (() => void) | null = null
 
 export function setWebUiUnexpectedExitHandler(
   handler: ((details: { code: number | null; signal: NodeJS.Signals | null }) => void) | null,
 ): void {
   unexpectedExitHandler = handler
+}
+
+export function setWebUiRestartRequestHandler(handler: (() => void) | null): void {
+  restartRequestHandler = handler
+}
+
+function isDesktopRestartRequest(message: unknown): boolean {
+  return Boolean(
+    message
+    && typeof message === 'object'
+    && (message as { type?: unknown }).type === DESKTOP_RESTART_REQUEST,
+  )
 }
 
 function posixDescendantPids(rootPid: number): number[] {
@@ -741,7 +755,7 @@ async function launchWebUiServer(webUiDirectory: string, entry: string, env: Nod
   serverProc = spawn(process.execPath, [entry], {
     cwd: webUiDirectory,
     env,
-    stdio: ['ignore', 'pipe', 'pipe'],
+    stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
     windowsHide: true,
   })
 
@@ -767,6 +781,14 @@ async function launchWebUiServer(webUiDirectory: string, entry: string, env: Nod
     }
   })
   launchedProc.stderr?.on('error', () => { /* EPIPE: ignore */ })
+  launchedProc.on('message', message => {
+    if (serverProc !== launchedProc || !isDesktopRestartRequest(message)) return
+    if (!restartRequestHandler) {
+      console.warn('[desktop] Web UI requested an App restart before a handler was registered')
+      return
+    }
+    restartRequestHandler()
+  })
   launchedProc.on('exit', (code, signal) => {
     console.error(`[webui] server exited code=${code} signal=${signal}`)
     if (serverProc === launchedProc) serverProc = null

--- a/packages/server/src/modules/studio/public/web-ui-restart.ts
+++ b/packages/server/src/modules/studio/public/web-ui-restart.ts
@@ -4,6 +4,7 @@ import { dirname, join, resolve } from 'path'
 import { config } from './config'
 
 let restartScheduled = false
+const DESKTOP_RESTART_REQUEST = 'hermes-desktop:restart-app'
 
 function isDesktopRuntime(): boolean {
   return String(process.env.HERMES_DESKTOP || '').trim().toLowerCase() === 'true'
@@ -30,10 +31,26 @@ function developmentRestartTriggerPath(): string {
   return trigger
 }
 
-/** Schedule a CLI-supervised standalone Web UI restart after the API response. */
+function requestDesktopAppRestart(): void {
+  if (typeof process.send !== 'function' || process.connected === false) {
+    throw new Error('Desktop restart IPC channel is unavailable')
+  }
+  restartScheduled = true
+  try {
+    process.send({ type: DESKTOP_RESTART_REQUEST })
+  } catch (err) {
+    restartScheduled = false
+    throw err
+  }
+}
+
+/** Schedule a host-owned restart after the API response. */
 export function scheduleWebUiRestart(): void {
-  if (isDesktopRuntime()) throw new Error('Desktop Runtime must restart through the desktop shell')
   if (restartScheduled) return
+  if (isDesktopRuntime()) {
+    requestDesktopAppRestart()
+    return
+  }
   if (process.env.NODE_ENV === 'development') {
     const trigger = developmentRestartTriggerPath()
     restartScheduled = true

--- a/tests/server/runtime-install-restart-wiring.test.ts
+++ b/tests/server/runtime-install-restart-wiring.test.ts
@@ -25,6 +25,20 @@ describe('Runtime install restart wiring', () => {
     expect(desktopMain).toContain("ipcMain.handle('hermes-desktop:restart-app'")
   })
 
+  it('routes authenticated App restart requests through the Desktop child IPC channel', () => {
+    const routes = readFileSync('packages/server/src/modules/hermes/routes/runtime-versions.ts', 'utf8')
+    const restart = readFileSync('packages/server/src/modules/studio/public/web-ui-restart.ts', 'utf8')
+    const desktopServer = readFileSync('packages/desktop/src/main/webui-server.ts', 'utf8')
+    const desktopMain = readFileSync('packages/desktop/src/main/index.ts', 'utf8')
+
+    expect(routes).toContain("post('/api/hermes/runtime-versions/restart-webui', requireSuperAdmin")
+    expect(restart).toContain("process.send({ type: DESKTOP_RESTART_REQUEST })")
+    expect(desktopServer).toContain("stdio: ['ignore', 'pipe', 'pipe', 'ipc']")
+    expect(desktopServer).toContain("launchedProc.on('message'")
+    expect(desktopMain).toContain('setWebUiRestartRequestHandler(() => {')
+    expect(desktopMain).toContain('scheduleAppRestart(250)')
+  })
+
   it('routes source-development restarts through a nodemon watched trigger', () => {
     const restart = readFileSync('packages/server/src/modules/studio/public/web-ui-restart.ts', 'utf8')
     const trigger = readFileSync('packages/server/src/modules/studio/public/dev-restart-trigger.ts', 'utf8')

--- a/tests/server/web-ui-restart.test.ts
+++ b/tests/server/web-ui-restart.test.ts
@@ -3,6 +3,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const spawn = vi.hoisted(() => vi.fn())
 const existsSync = vi.hoisted(() => vi.fn(() => true))
 const utimesSync = vi.hoisted(() => vi.fn())
+const originalProcessSend = process.send
+
+function setProcessSend(send: typeof process.send): void {
+  Object.defineProperty(process, 'send', {
+    configurable: true,
+    value: send,
+    writable: true,
+  })
+}
 
 vi.mock('child_process', () => ({ spawn }))
 vi.mock('fs', () => ({ existsSync, utimesSync }))
@@ -27,6 +36,7 @@ describe('Web UI restart routing', () => {
   afterEach(() => {
     vi.useRealTimers()
     vi.unstubAllEnvs()
+    setProcessSend(originalProcessSend)
   })
 
   it('touches the nodemon restart trigger in development', () => {
@@ -43,10 +53,24 @@ describe('Web UI restart routing', () => {
     expect(spawn).not.toHaveBeenCalled()
   })
 
-  it('keeps Desktop restart ownership in the Electron shell', () => {
+  it('forwards Desktop restart requests to the Electron shell over IPC', () => {
     vi.stubEnv('HERMES_DESKTOP', 'true')
+    const send = vi.fn(() => true)
+    setProcessSend(send as unknown as typeof process.send)
 
-    expect(() => scheduleWebUiRestart()).toThrow('Desktop Runtime must restart through the desktop shell')
+    scheduleWebUiRestart()
+    scheduleWebUiRestart()
+
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send).toHaveBeenCalledWith({ type: 'hermes-desktop:restart-app' })
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
+  it('rejects Desktop restart requests when the parent IPC channel is unavailable', () => {
+    vi.stubEnv('HERMES_DESKTOP', 'true')
+    setProcessSend(undefined)
+
+    expect(() => scheduleWebUiRestart()).toThrow('Desktop restart IPC channel is unavailable')
     expect(spawn).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
## Summary
- forward authenticated Runtime restart requests from the bundled WebUI process to Electron over child IPC
- reuse the Desktop clean relaunch path with duplicate restart protection
- preserve standalone WebUI restart behavior

## Verification
- focused restart tests (9 passed)
- Desktop main-process TypeScript build
- full Studio production build