### PR TITLE
fix(tts): hydrate active provider on startup

### DIFF
--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -20,7 +20,9 @@ import { getThemeOverrides } from "@/styles/theme";
 import { useTheme } from "@/composables/useTheme";
 import { useKeyboard } from "@/composables/useKeyboard";
 import { useSessionSearch } from "@/composables/useSessionSearch";
+import { watchServerTtsSettingsHydration } from "@/composables/useTtsSettingsHydration";
 import { useAppStore } from "@/stores/hermes/app";
+import { useProfilesStore } from "@/stores/hermes/profiles";
 import AuthEventListener from "@/components/auth/AuthEventListener.vue";
 import { desktopBridge } from "@/utils/desktop-bridge";
 import { naiveLocaleFor } from "@/constants/naiveLocale";
@@ -76,6 +78,7 @@ const { t, locale } = useI18n();
 const naiveLocale = computed(() => naiveLocaleFor(locale.value));
 const naiveRtl = computed(() => naiveRtlFor(locale.value));
 const appStore = useAppStore();
+const profilesStore = useProfilesStore();
 const route = useRoute();
 const { sessionSearchOpen } = useSessionSearch();
 
@@ -85,6 +88,10 @@ const themeOverrides = computed(() =>
 const naiveTheme = computed(() => (isDark.value ? darkTheme : null));
 
 const isLoginPage = computed(() => route.name === "login");
+watchServerTtsSettingsHydration({
+  isLoginPage: () => isLoginPage.value,
+  activeProfileName: () => profilesStore.activeProfileName,
+});
 const isStandaloneChatPage = computed(
   () => route.meta?.standaloneChat === true,
 );

--- a/packages/client/src/composables/useTtsSettingsHydration.ts
+++ b/packages/client/src/composables/useTtsSettingsHydration.ts
@@ -1,0 +1,21 @@
+import { watch, type WatchSource, type WatchStopHandle } from 'vue'
+import { hasApiKey } from '@/api/client'
+import { loadServerTtsSettings } from '@/composables/useVoiceSettings'
+
+export interface ServerTtsSettingsHydrationSources {
+  isLoginPage: WatchSource<boolean>
+  activeProfileName: WatchSource<string | null>
+}
+
+export function watchServerTtsSettingsHydration(
+  sources: ServerTtsSettingsHydrationSources,
+): WatchStopHandle {
+  return watch(
+    [sources.isLoginPage, sources.activeProfileName],
+    ([isLoginPage, activeProfileName]) => {
+      if (isLoginPage || !activeProfileName?.trim() || !hasApiKey()) return
+      void loadServerTtsSettings().catch(() => undefined)
+    },
+    { immediate: true },
+  )
+}

--- a/packages/client/src/composables/useVoiceSettings.ts
+++ b/packages/client/src/composables/useVoiceSettings.ts
@@ -1,4 +1,5 @@
 import { ref, watch } from 'vue'
+import { fetchTtsSettings, type FetchTtsSettingsResponse } from '@/api/studio/tts-settings'
 import { DOUBAO_TTS_2_RESOURCE_ID, DOUBAO_TTS_DEFAULT_VOICE } from '@/constants/doubaoTtsVoices'
 
 export type TtsProvider =
@@ -144,6 +145,34 @@ function load(): VoiceSettingsData {
 // Run migration once on import
 migrateOldKeys()
 
+let serverSettingsLoaded = false
+let serverSettingsPromise: Promise<void> | null = null
+
+function applyServerTtsSettings(response: FetchTtsSettingsResponse) {
+  if (response.activeProvider) {
+    provider.value = response.activeProvider
+  }
+}
+
+export async function loadServerTtsSettings(force = false): Promise<void> {
+  if (serverSettingsLoaded && !force) return
+  if (serverSettingsPromise && !force) return serverSettingsPromise
+
+  const promise = fetchTtsSettings()
+    .then(response => {
+      applyServerTtsSettings(response)
+      serverSettingsLoaded = true
+    })
+    .finally(() => {
+      if (serverSettingsPromise === promise) {
+        serverSettingsPromise = null
+      }
+    })
+
+  serverSettingsPromise = promise
+  return promise
+}
+
 // ── Reactive state ──
 const provider = ref<TtsProvider>(load().provider)
 
@@ -258,6 +287,8 @@ export function useVoiceSettings() {
     doubaoModel,
     doubaoVoice,
     doubaoStylePrompt,
+
+    loadServerTtsSettings,
 
     setProvider(v: TtsProvider) { provider.value = v },
     setWebSpeechVoice(v: string) { webspeechVoice.value = v },

--- a/packages/client/src/composables/useVoiceSettings.ts
+++ b/packages/client/src/composables/useVoiceSettings.ts
@@ -1,5 +1,6 @@
 import { ref, watch } from 'vue'
 import { fetchTtsSettings, type FetchTtsSettingsResponse } from '@/api/studio/tts-settings'
+import { getActiveProfileName, getStoredUserId, hasApiKey } from '@/api/client'
 import { DOUBAO_TTS_2_RESOURCE_ID, DOUBAO_TTS_DEFAULT_VOICE } from '@/constants/doubaoTtsVoices'
 
 export type TtsProvider =
@@ -145,8 +146,17 @@ function load(): VoiceSettingsData {
 // Run migration once on import
 migrateOldKeys()
 
-let serverSettingsLoaded = false
+let serverSettingsLoadedContext: string | null = null
 let serverSettingsPromise: Promise<void> | null = null
+let serverSettingsPromiseContext: string | null = null
+let serverSettingsGeneration = 0
+
+function serverSettingsContext(): string | null {
+  if (!hasApiKey()) return null
+  const user = getStoredUserId() ?? 'authenticated'
+  const profile = getActiveProfileName()?.trim() || 'default'
+  return `${user}:${profile}`
+}
 
 function applyServerTtsSettings(response: FetchTtsSettingsResponse) {
   if (response.activeProvider) {
@@ -155,21 +165,29 @@ function applyServerTtsSettings(response: FetchTtsSettingsResponse) {
 }
 
 export async function loadServerTtsSettings(force = false): Promise<void> {
-  if (serverSettingsLoaded && !force) return
-  if (serverSettingsPromise && !force) return serverSettingsPromise
+  const context = serverSettingsContext()
+  if (!context) return
+  if (serverSettingsLoadedContext === context && !force) return
+  if (serverSettingsPromise && serverSettingsPromiseContext === context && !force) {
+    return serverSettingsPromise
+  }
 
+  const generation = ++serverSettingsGeneration
   const promise = fetchTtsSettings()
     .then(response => {
+      if (generation !== serverSettingsGeneration || serverSettingsContext() !== context) return
       applyServerTtsSettings(response)
-      serverSettingsLoaded = true
+      serverSettingsLoadedContext = context
     })
     .finally(() => {
       if (serverSettingsPromise === promise) {
         serverSettingsPromise = null
+        serverSettingsPromiseContext = null
       }
     })
 
   serverSettingsPromise = promise
+  serverSettingsPromiseContext = context
   return promise
 }
 

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -4,6 +4,7 @@ import router from './router'
 import { i18nReady } from './i18n'
 import App from './App.vue'
 import './styles/global.scss'
+import { loadServerTtsSettings } from '@/composables/useVoiceSettings'
 import { desktopBridge } from '@/utils/desktop-bridge'
 
 // Apply theme classes before mount to prevent FOUC (Flash of Unstyled Content)
@@ -62,6 +63,7 @@ async function mountApp(): Promise<void> {
   app.use(createPinia())
   app.use(i18n)
   app.use(router)
+  await loadServerTtsSettings().catch(() => undefined)
   await router.isReady().catch(() => undefined)
   app.mount('#app')
 }

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -4,7 +4,6 @@ import router from './router'
 import { i18nReady } from './i18n'
 import App from './App.vue'
 import './styles/global.scss'
-import { loadServerTtsSettings } from '@/composables/useVoiceSettings'
 import { desktopBridge } from '@/utils/desktop-bridge'
 
 // Apply theme classes before mount to prevent FOUC (Flash of Unstyled Content)
@@ -63,7 +62,6 @@ async function mountApp(): Promise<void> {
   app.use(createPinia())
   app.use(i18n)
   app.use(router)
-  await loadServerTtsSettings().catch(() => undefined)
   await router.isReady().catch(() => undefined)
   app.mount('#app')
 }

--- a/tests/client/app-web-pet.test.ts
+++ b/tests/client/app-web-pet.test.ts
@@ -17,6 +17,10 @@ const appStoreMock = vi.hoisted(() => ({
   startHealthPolling: vi.fn(),
   stopHealthPolling: vi.fn(),
 }))
+const profilesStoreMock = vi.hoisted(() => ({
+  activeProfileName: 'default' as string | null,
+}))
+const watchServerTtsSettingsHydrationMock = vi.hoisted(() => vi.fn())
 
 vi.mock('vue-router', async (importOriginal) => {
   const actual = await importOriginal<typeof import('vue-router')>()
@@ -49,6 +53,14 @@ vi.mock('@/composables/useKeyboard', () => ({
 
 vi.mock('@/stores/hermes/app', () => ({
   useAppStore: () => appStoreMock,
+}))
+
+vi.mock('@/stores/hermes/profiles', () => ({
+  useProfilesStore: () => profilesStoreMock,
+}))
+
+vi.mock('@/composables/useTtsSettingsHydration', () => ({
+  watchServerTtsSettingsHydration: watchServerTtsSettingsHydrationMock,
 }))
 
 vi.mock('@/styles/theme', () => ({
@@ -132,7 +144,17 @@ describe('App web pet mounting', () => {
     routeMock.meta = {}
     appStoreMock.sidebarCollapsed = false
     appStoreMock.pageSidebarExpanded = true
+    profilesStoreMock.activeProfileName = 'default'
     delete (window as WindowWithDesktop).hermesDesktop
+  })
+
+  it('wires TTS hydration to login and active-profile state', () => {
+    mountApp()
+
+    expect(watchServerTtsSettingsHydrationMock).toHaveBeenCalledOnce()
+    const sources = watchServerTtsSettingsHydrationMock.mock.calls[0][0]
+    expect(sources.isLoginPage()).toBe(false)
+    expect(sources.activeProfileName()).toBe('default')
   })
 
   it('mounts the global pending-action host in the normal app shell', async () => {

--- a/tests/client/tts-settings-hydration.test.ts
+++ b/tests/client/tts-settings-hydration.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { nextTick, ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { hasApiKeyMock, loadServerTtsSettingsMock } = vi.hoisted(() => ({
+  hasApiKeyMock: vi.fn(),
+  loadServerTtsSettingsMock: vi.fn(),
+}))
+
+vi.mock('@/api/client', () => ({
+  hasApiKey: hasApiKeyMock,
+}))
+
+vi.mock('@/composables/useVoiceSettings', () => ({
+  loadServerTtsSettings: loadServerTtsSettingsMock,
+}))
+
+import { watchServerTtsSettingsHydration } from '@/composables/useTtsSettingsHydration'
+
+describe('TTS settings hydration lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hasApiKeyMock.mockReturnValue(false)
+    loadServerTtsSettingsMock.mockResolvedValue(undefined)
+  })
+
+  it('hydrates after login once the active profile is known', async () => {
+    const isLoginPage = ref(true)
+    const activeProfileName = ref<string | null>(null)
+    const stop = watchServerTtsSettingsHydration({
+      isLoginPage: () => isLoginPage.value,
+      activeProfileName: () => activeProfileName.value,
+    })
+
+    hasApiKeyMock.mockReturnValue(true)
+    isLoginPage.value = false
+    await nextTick()
+    expect(loadServerTtsSettingsMock).not.toHaveBeenCalled()
+
+    activeProfileName.value = 'default'
+    await nextTick()
+    expect(loadServerTtsSettingsMock).toHaveBeenCalledOnce()
+
+    stop()
+  })
+
+  it('rehydrates when the active profile changes', async () => {
+    hasApiKeyMock.mockReturnValue(true)
+    const isLoginPage = ref(false)
+    const activeProfileName = ref<string | null>('default')
+    const stop = watchServerTtsSettingsHydration({
+      isLoginPage: () => isLoginPage.value,
+      activeProfileName: () => activeProfileName.value,
+    })
+
+    expect(loadServerTtsSettingsMock).toHaveBeenCalledOnce()
+
+    activeProfileName.value = 'work'
+    await nextTick()
+    expect(loadServerTtsSettingsMock).toHaveBeenCalledTimes(2)
+
+    stop()
+  })
+})

--- a/tests/client/use-voice-settings-mimo.test.ts
+++ b/tests/client/use-voice-settings-mimo.test.ts
@@ -2,12 +2,26 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
-const { fetchTtsSettingsMock } = vi.hoisted(() => ({
+const {
+  fetchTtsSettingsMock,
+  getActiveProfileNameMock,
+  getStoredUserIdMock,
+  hasApiKeyMock,
+} = vi.hoisted(() => ({
   fetchTtsSettingsMock: vi.fn(),
+  getActiveProfileNameMock: vi.fn(),
+  getStoredUserIdMock: vi.fn(),
+  hasApiKeyMock: vi.fn(),
 }))
 
 vi.mock('@/api/studio/tts-settings', () => ({
   fetchTtsSettings: fetchTtsSettingsMock,
+}))
+
+vi.mock('@/api/client', () => ({
+  getActiveProfileName: getActiveProfileNameMock,
+  getStoredUserId: getStoredUserIdMock,
+  hasApiKey: hasApiKeyMock,
 }))
 
 const STORAGE_KEY = 'hermes-tts-settings-v2'
@@ -17,6 +31,9 @@ describe('useVoiceSettings MiMo settings', () => {
     vi.resetModules()
     localStorage.clear()
     fetchTtsSettingsMock.mockReset()
+    getActiveProfileNameMock.mockReset().mockReturnValue('default')
+    getStoredUserIdMock.mockReset().mockReturnValue(7)
+    hasApiKeyMock.mockReset().mockReturnValue(true)
   })
 
   it('defaults MiMo auth and voice clone settings', async () => {
@@ -44,6 +61,59 @@ describe('useVoiceSettings MiMo settings', () => {
     expect(JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}')).toMatchObject({
       provider: 'openai',
     })
+  })
+
+  it('waits for authentication before loading server TTS settings', async () => {
+    hasApiKeyMock.mockReturnValue(false)
+
+    const { loadServerTtsSettings } = await import('../../packages/client/src/composables/useVoiceSettings')
+    await loadServerTtsSettings()
+
+    expect(fetchTtsSettingsMock).not.toHaveBeenCalled()
+  })
+
+  it('loads once per user and profile context', async () => {
+    fetchTtsSettingsMock
+      .mockResolvedValueOnce({ providers: [], activeProvider: 'openai' })
+      .mockResolvedValueOnce({ providers: [], activeProvider: 'custom' })
+
+    const { loadServerTtsSettings, useVoiceSettings } = await import('../../packages/client/src/composables/useVoiceSettings')
+    const settings = useVoiceSettings()
+
+    await loadServerTtsSettings()
+    await loadServerTtsSettings()
+    expect(fetchTtsSettingsMock).toHaveBeenCalledTimes(1)
+    expect(settings.provider.value).toBe('openai')
+
+    getActiveProfileNameMock.mockReturnValue('work')
+    await loadServerTtsSettings()
+    await loadServerTtsSettings()
+
+    expect(fetchTtsSettingsMock).toHaveBeenCalledTimes(2)
+    expect(settings.provider.value).toBe('custom')
+  })
+
+  it('ignores a stale response after the active profile changes', async () => {
+    let resolveDefault!: (value: { providers: never[]; activeProvider: 'openai' }) => void
+    let resolveWork!: (value: { providers: never[]; activeProvider: 'custom' }) => void
+    fetchTtsSettingsMock
+      .mockImplementationOnce(() => new Promise(resolve => { resolveDefault = resolve }))
+      .mockImplementationOnce(() => new Promise(resolve => { resolveWork = resolve }))
+
+    const { loadServerTtsSettings, useVoiceSettings } = await import('../../packages/client/src/composables/useVoiceSettings')
+    const settings = useVoiceSettings()
+    const defaultRequest = loadServerTtsSettings()
+
+    getActiveProfileNameMock.mockReturnValue('work')
+    const workRequest = loadServerTtsSettings()
+
+    resolveDefault({ providers: [], activeProvider: 'openai' })
+    await defaultRequest
+    expect(settings.provider.value).toBe('webspeech')
+
+    resolveWork({ providers: [], activeProvider: 'custom' })
+    await workRequest
+    expect(settings.provider.value).toBe('custom')
   })
 
   it('persists MiMo auth mode and voice clone fields', async () => {

--- a/tests/client/use-voice-settings-mimo.test.ts
+++ b/tests/client/use-voice-settings-mimo.test.ts
@@ -2,12 +2,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
+const { fetchTtsSettingsMock } = vi.hoisted(() => ({
+  fetchTtsSettingsMock: vi.fn(),
+}))
+
+vi.mock('@/api/studio/tts-settings', () => ({
+  fetchTtsSettings: fetchTtsSettingsMock,
+}))
+
 const STORAGE_KEY = 'hermes-tts-settings-v2'
 
 describe('useVoiceSettings MiMo settings', () => {
   beforeEach(() => {
     vi.resetModules()
     localStorage.clear()
+    fetchTtsSettingsMock.mockReset()
   })
 
   it('defaults MiMo auth and voice clone settings', async () => {
@@ -18,6 +27,23 @@ describe('useVoiceSettings MiMo settings', () => {
     expect(settings.mimoVoiceCloneDataUri.value).toBe('')
     expect(settings.mimoVoiceCloneFileName.value).toBe('')
     expect(settings.mimoVoiceCloneFormat.value).toBe('wav')
+  })
+
+  it('hydrates the active TTS provider from the server for a fresh browser profile', async () => {
+    fetchTtsSettingsMock.mockResolvedValue({ providers: [], activeProvider: 'openai' })
+
+    const { loadServerTtsSettings, useVoiceSettings } = await import('../../packages/client/src/composables/useVoiceSettings')
+    const settings = useVoiceSettings()
+
+    expect(settings.provider.value).toBe('webspeech')
+
+    await loadServerTtsSettings()
+    await nextTick()
+
+    expect(settings.provider.value).toBe('openai')
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}')).toMatchObject({
+      provider: 'openai',
+    })
   })
 
   it('persists MiMo auth mode and voice clone fields', async () => {

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -28,7 +28,9 @@ test('rejects invalid credentials without persisting a token', async ({ page }) 
 })
 
 test('logs in with password through the BFF before entering the app', async ({ page }) => {
-  const api = await mockHermesApi(page)
+  const api = await mockHermesApi(page, {
+    ttsActiveProviders: { default: 'openai' },
+  })
 
   await page.goto('/')
   await page.getByPlaceholder('Username').fill('playwright')
@@ -42,5 +44,13 @@ test('logs in with password through the BFF before entering the app', async ({ p
   const loginRequest = api.requests.find((request) => request.pathname === '/api/auth/login')
   expect(loginRequest?.method).toBe('POST')
   expect(loginRequest?.postData).toBe(JSON.stringify({ username: 'playwright', password: 'correct-password' }))
+
+  await expect.poll(async () => {
+    const raw = await page.evaluate(() => window.localStorage.getItem('hermes-tts-settings-v2'))
+    return raw ? JSON.parse(raw).provider : null
+  }).toBe('openai')
+  const ttsSettingsRequest = api.requests.find(request => request.pathname === '/api/studio/tts/settings')
+  expect(ttsSettingsRequest?.headers.authorization).toBe(`Bearer ${TEST_ACCESS_KEY}`)
+  expect(ttsSettingsRequest?.headers['x-hermes-profile']).toBe('default')
   expect(api.unexpectedRequests).toEqual([])
 })

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -79,6 +79,7 @@ interface MockHermesApiOptions {
   socialMessageFeishuRecipients?: Record<string, unknown>
   socialMessageTelegramRecipients?: Record<string, unknown>
   socialMessageWeixinRecipients?: Record<string, unknown>
+  ttsActiveProviders?: Partial<Record<'default' | 'research', string>>
 }
 
 export const TEST_MODEL_GROUP = {
@@ -360,6 +361,15 @@ export async function mockHermesApi(page: Page, options: MockHermesApiOptions = 
         return
       }
       await route.fulfill(jsonResponse({ error: 'Method not allowed' }, 405))
+      return
+    }
+
+    if (pathname === '/api/studio/tts/settings' && request.method() === 'GET') {
+      const profile = request.headers()['x-hermes-profile'] === 'research' ? 'research' : 'default'
+      await route.fulfill(jsonResponse({
+        settings: [],
+        activeProvider: options.ttsActiveProviders?.[profile] || 'edge',
+      }))
       return
     }
 


### PR DESCRIPTION
## Summary
- hydrate the active TTS provider from server settings before the client mounts, so a fresh browser profile no longer falls back to WebSpeech
- keep the existing localStorage cache, but seed it from server settings when needed
- add a regression test for a fresh browser profile loading the server active provider

Closes #2831

## Validation
- `npm exec vitest run tests/client/use-voice-settings-mimo.test.ts`
- `npm run build`