### PR TITLE
fix(runtime): persist handled restart prompts

### DIFF
--- a/packages/client/src/components/layout/RuntimeRestartPrompt.vue
+++ b/packages/client/src/components/layout/RuntimeRestartPrompt.vue
@@ -26,12 +26,12 @@ let restartWaitTimer: ReturnType<typeof setInterval> | null = null
 
 function restoreHandledJobs() {
   try {
-    const stored = JSON.parse(sessionStorage.getItem(HANDLED_JOBS_KEY) || '[]')
+    const stored = JSON.parse(localStorage.getItem(HANDLED_JOBS_KEY) || '[]')
     if (Array.isArray(stored)) {
       for (const id of stored) if (typeof id === 'string') handledJobIds.add(id)
     }
   } catch {
-    // Ignore malformed or unavailable session storage.
+    // Ignore malformed or unavailable storage.
   }
 }
 
@@ -39,7 +39,7 @@ function rememberHandledJob(jobId?: string) {
   if (!jobId) return
   handledJobIds.add(jobId)
   try {
-    sessionStorage.setItem(HANDLED_JOBS_KEY, JSON.stringify([...handledJobIds]))
+    localStorage.setItem(HANDLED_JOBS_KEY, JSON.stringify([...handledJobIds]))
   } catch {
     // The in-memory marker still prevents duplicate prompts in this page.
   }

--- a/tests/client/runtime-restart-prompt.test.ts
+++ b/tests/client/runtime-restart-prompt.test.ts
@@ -53,6 +53,7 @@ describe('RuntimeRestartPrompt', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     sessionStorage.clear()
+    localStorage.clear()
     useRuntimeRestartPrompt().clearRuntimeRestart()
     api.fetchVersionDownloadJobs.mockReset()
     api.restartWebUiAfterRuntimeChange.mockReset()
@@ -103,5 +104,23 @@ describe('RuntimeRestartPrompt', () => {
 
     expect(api.restartWebUiAfterRuntimeChange).toHaveBeenCalledTimes(1)
     wrapper.unmount()
+  })
+
+  it('keeps handled Runtime downloads suppressed after an app relaunch', async () => {
+    const first = mount(RuntimeRestartPrompt)
+    await flushPromises()
+
+    await first.get('[data-testid="runtime-restart-later"]').trigger('click')
+    expect(first.find('[data-testid="runtime-restart-prompt"]').exists()).toBe(false)
+    first.unmount()
+
+    sessionStorage.clear()
+
+    const second = mount(RuntimeRestartPrompt)
+    await flushPromises()
+
+    expect(second.find('[data-testid="runtime-restart-prompt"]').exists()).toBe(false)
+    expect(api.restartWebUiAfterRuntimeChange).not.toHaveBeenCalled()
+    second.unmount()
   })
 })


### PR DESCRIPTION
## Summary
- Persist handled runtime restart job ids in `localStorage` so the same completed job is not re-prompted after a relaunch.
- Add a regression test that clears session storage between mounts to simulate a relaunch and verify the prompt stays suppressed.

Fixes #2813

## Validation
- `npm test -- tests/client/runtime-restart-prompt.test.ts tests/client/version-management-modal.test.ts`
- `npm run build`