### PR TITLE
fix(skills): encode reserved characters in skill paths

### DIFF
--- a/packages/client/src/api/hermes/skills.ts
+++ b/packages/client/src/api/hermes/skills.ts
@@ -122,8 +122,12 @@ function targetQuery(target: SkillTarget = 'hermes'): string {
   return `?target=${encodeURIComponent(target)}`
 }
 
+function encodeSkillPath(path: string): string {
+  return path.split('/').map(segment => encodeURIComponent(segment)).join('/')
+}
+
 export async function fetchSkillContent(skillPath: string, target: SkillTarget = 'hermes'): Promise<string> {
-  const res = await request<{ content: string }>(`/api/hermes/skills/${skillPath}${targetQuery(target)}`)
+  const res = await request<{ content: string }>(`/api/hermes/skills/${encodeSkillPath(skillPath)}${targetQuery(target)}`)
   return res.content
 }
 
@@ -142,7 +146,8 @@ export async function saveSkillContent(
 }
 
 export async function fetchSkillFiles(category: string, skill: string, target: SkillTarget = 'hermes'): Promise<SkillFileEntry[]> {
-  const res = await request<{ files: SkillFileEntry[] }>(`/api/hermes/skills/${category}/${skill}/files${targetQuery(target)}`)
+  const path = encodeSkillPath(`${category}/${skill}`)
+  const res = await request<{ files: SkillFileEntry[] }>(`/api/hermes/skills/${path}/files${targetQuery(target)}`)
   return res.files
 }
 

--- a/tests/client/skills-api-paths.test.ts
+++ b/tests/client/skills-api-paths.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockRequest = vi.hoisted(() => vi.fn())
+
+vi.mock('../../packages/client/src/api/client', () => ({
+  request: mockRequest,
+  getApiKey: vi.fn(() => ''),
+  getBaseUrlValue: vi.fn(() => ''),
+  getActiveProfileName: vi.fn(() => null),
+}))
+
+import { fetchSkillContent, fetchSkillFiles } from '../../packages/client/src/api/hermes/skills'
+
+describe('Skills API paths', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('encodes reserved characters in skill content path segments', async () => {
+    mockRequest.mockResolvedValue({ content: '# C# helper' })
+
+    await expect(fetchSkillContent('languages/C#/SKILL.md')).resolves.toBe('# C# helper')
+
+    expect(mockRequest).toHaveBeenCalledWith('/api/hermes/skills/languages/C%23/SKILL.md')
+  })
+
+  it('encodes nested file paths without encoding their separators', async () => {
+    mockRequest.mockResolvedValue({ content: 'reference' })
+
+    await fetchSkillContent('misc/why?/references/section#1.md', 'codex')
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      '/api/hermes/skills/misc/why%3F/references/section%231.md?target=codex',
+    )
+  })
+
+  it('encodes reserved characters in category and skill names when listing files', async () => {
+    mockRequest.mockResolvedValue({ files: [] })
+
+    await expect(fetchSkillFiles('language#tools', 'why?', 'pi')).resolves.toEqual([])
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      '/api/hermes/skills/language%23tools/why%3F/files?target=pi',
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- encode each skill path segment before client read requests
- preserve path separators while supporting names and files containing URL-reserved characters such as `#` and `?`
- add focused regression coverage for content reads, nested files, and file listing across agent targets

## Why
The server accepts these characters in skill and category names, but the client previously interpolated raw read paths. Browsers treat `#` as a fragment and `?` as a query delimiter, so an imported skill could appear in the list but fail to open.

## Validation
- `npm run test -- tests/client/skills-api-paths.test.ts tests/client/skill-detail-edit.test.ts tests/client/skills-view.test.ts` (Node 24.20.0; 6 tests passed)
- `npm run harness:check` (Node 24.20.0)
- `npm run build` (Node 24.20.0)

## Scope
- client API path construction only
- no server, schema, UI, or localization changes
