### PR TITLE
fix(ekko-agent): bound oversized tool output

### DIFF
--- a/docs/chat-chain-changes/2026-09-02-ekko-tool-output-limits.md
+++ b/docs/chat-chain-changes/2026-09-02-ekko-tool-output-limits.md
@@ -2,5 +2,6 @@
 
 - Date: 2026-09-02
 - Area: direct chat / Ekko Agent tool execution
-- Change: bound `terminal_exec` stdout and stderr previews, persist oversized streams under the workspace temporary directory, and add a provider-request safety limit for every textual tool result.
-- Impact: large command output remains available for paged `read_file` access or bounded searches without placing multi-megabyte tool results into the same model request.
+- Change: bound `terminal_exec` stdout and stderr previews, persist capped oversized-stream artifacts under the ignored workspace temporary directory, and add a provider-request safety limit for every textual tool result that still returns a preview when artifact persistence fails.
+- Impact: large command output remains available for paged `read_file` access or bounded searches without placing multi-megabyte tool results into the same model request or allowing an unbounded artifact to exhaust local disk space.
+- UX: tool-call progress text must be a complete sentence, and dangling `:` / `：` preambles are normalized before they are persisted or reused as model context.

--- a/docs/chat-chain-changes/2026-09-02-ekko-tool-output-limits.md
+++ b/docs/chat-chain-changes/2026-09-02-ekko-tool-output-limits.md
@@ -1,0 +1,6 @@
+# Ekko tool output limits
+
+- Date: 2026-09-02
+- Area: direct chat / Ekko Agent tool execution
+- Change: bound `terminal_exec` stdout and stderr previews, persist oversized streams under the workspace temporary directory, and add a provider-request safety limit for every textual tool result.
+- Impact: large command output remains available for paged `read_file` access or bounded searches without placing multi-megabyte tool results into the same model request.

--- a/packages/ekko-agent/docs/API.md
+++ b/packages/ekko-agent/docs/API.md
@@ -3189,6 +3189,10 @@ export function skillValidationResult( name: string, content: string, ): { statu
 ### `src/tools/terminal.ts`
 
 ```ts
+export const DEFAULT_TERMINAL_EXEC_MAX_OUTPUT_BYTES = 100_000
+
+export const DEFAULT_TERMINAL_EXEC_MAX_STDERR_BYTES = 25_000
+
 export interface TerminalExecInput extends Record<string, unknown> {
   command: string
   args?: string[]
@@ -3199,6 +3203,8 @@ export interface TerminalExecInput extends Record<string, unknown> {
 export interface TerminalExecToolOptions {
   timeoutMs?: number
   platform?: NodeJS.Platform
+  maxOutputBytes?: number
+  maxStderrBytes?: number
 }
 
 export class TerminalExecTool implements AgentTool<TerminalExecInput> {
@@ -3212,10 +3218,13 @@ export function createTerminalTools(options: TerminalExecToolOptions = {}): Agen
 ### `src/tools/tool-result-sanitizer.ts`
 
 ```ts
+export const DEFAULT_TOOL_RESULT_MAX_TEXT_BYTES = 256_000
+
 export interface ToolResultSanitizerOptions {
   tempRoot?: string
   ttlMs?: number
   maxBytes?: number
+  maxTextBytes?: number
   now?: number
 }
 

--- a/packages/ekko-agent/docs/API.md
+++ b/packages/ekko-agent/docs/API.md
@@ -2540,7 +2540,7 @@ export interface SystemPromptInput {
 
 export const EKKO_OUTPUT_FORMAT_GUIDELINES = `## Image and File Output When returning an image, video, or file to the user, use Markdown with an existing local absolute path. - Unix/macOS/WSL image: \`![description](/absolute/path/image.png)\` - Windows image: \`![description](<C:/absolute/path/image.png>)\` - Unix/macOS/WSL file: \`[filename](/absolute/path/file.pdf)\` - Windows file: \`[filename](<C:/absolute/path/file.pdf>)\` - Use forward slashes for Windows paths. - Wrap paths containing spaces, non-ASCII characters, or special characters in angle brackets. - Do not use relative paths or \`file://\` URLs. - Verify that the referenced file exists before returning it.`
 
-export const EKKO_TOOL_EXECUTION_GUIDELINES = `## Tool Execution Treat external commands, language packages, and other prerequisites named by a Skill as requirements, not proof that they are installed. - Before relying on an external dependency whose availability has not already been established, perform a lightweight availability check. - Do not run the primary dependency-based approach merely to discover whether its dependency exists. - Request independent tool calls together in one response. The runtime executes tools marked as parallel-safe concurrently while preserving serial barriers for stateful or dependent work. - When the user asks to execute or evaluate Node.js, JavaScript, or Python source code, use code_exec, including for one-line snippets. Do not probe Node or Python with terminal_exec first; code_exec resolves its runtime. - Use terminal_exec for CLI commands, project scripts, tests, builds, package managers, and other executables. - terminal_exec may use explicit absolute system paths and platform-appropriate package-manager forms. Follow the Command Environment section below; this capability is not limited to workspace files. - By default, keep downloads, clones, archives, extracted repositories, and generated intermediates inside the current workspace. Prefer the workspace's .ekko-tmp directory for disposable files so workspace-scoped file and image tools can inspect them. Use a system or external path only when the user or task explicitly requires it. - Dangerous tool calls may pause for runtime authorization. If authorization is denied, do not retry the operation through another tool or language runtime unless the user explicitly changes that decision. - After terminal_exec reports a [skill_validation] issue, do not claim the Skill installation is complete. Call skill_view for each writable local Skill and repair it with skill_manage until its frontmatter passes validation. Do not mutate read-only external Skill directories. - If a dependency is unavailable, prefer a compatible installed or built-in alternative. Install it only when installation is necessary and appropriate for the user's task. - Verify created artifacts before returning them.`
+export const EKKO_TOOL_EXECUTION_GUIDELINES = `## Tool Execution Treat external commands, language packages, and other prerequisites named by a Skill as requirements, not proof that they are installed. - Before relying on an external dependency whose availability has not already been established, perform a lightweight availability check. - Do not run the primary dependency-based approach merely to discover whether its dependency exists. - Request independent tool calls together in one response. The runtime executes tools marked as parallel-safe concurrently while preserving serial barriers for stateful or dependent work. - When accompanying a tool call with progress text, write a complete standalone sentence. Do not end tool-call preambles with ":" or "：" as though the tool result will complete the sentence; omit the preamble when it adds no value. - When the user asks to execute or evaluate Node.js, JavaScript, or Python source code, use code_exec, including for one-line snippets. Do not probe Node or Python with terminal_exec first; code_exec resolves its runtime. - Use terminal_exec for CLI commands, project scripts, tests, builds, package managers, and other executables. - terminal_exec may use explicit absolute system paths and platform-appropriate package-manager forms. Follow the Command Environment section below; this capability is not limited to workspace files. - By default, keep downloads, clones, archives, extracted repositories, and generated intermediates inside the current workspace. Prefer the workspace's .ekko-tmp directory for disposable files so workspace-scoped file and image tools can inspect them. Use a system or external path only when the user or task explicitly requires it. - Dangerous tool calls may pause for runtime authorization. If authorization is denied, do not retry the operation through another tool or language runtime unless the user explicitly changes that decision. - After terminal_exec reports a [skill_validation] issue, do not claim the Skill installation is complete. Call skill_view for each writable local Skill and repair it with skill_manage until its frontmatter passes validation. Do not mutate read-only external Skill directories. - If a dependency is unavailable, prefer a compatible installed or built-in alternative. Install it only when installation is necessary and appropriate for the user's task. - Verify created artifacts before returning them.`
 
 export const EKKO_CLARIFICATION_GUIDELINES = `## User Clarification When missing user input materially blocks or changes the task, call the clarify tool and wait for the response. - Do not present a blocking clarification question as an ordinary assistant response. - Ask one concise question that collects the necessary information; provide choices only for a short fixed set of answers. - Do not call clarify when a safe, reasonable assumption lets you continue without materially changing the outcome.`
 
@@ -3193,6 +3193,8 @@ export const DEFAULT_TERMINAL_EXEC_MAX_OUTPUT_BYTES = 100_000
 
 export const DEFAULT_TERMINAL_EXEC_MAX_STDERR_BYTES = 25_000
 
+export const DEFAULT_TERMINAL_EXEC_MAX_ARTIFACT_BYTES = 25 * 1024 * 1024
+
 export interface TerminalExecInput extends Record<string, unknown> {
   command: string
   args?: string[]
@@ -3205,6 +3207,7 @@ export interface TerminalExecToolOptions {
   platform?: NodeJS.Platform
   maxOutputBytes?: number
   maxStderrBytes?: number
+  maxArtifactBytes?: number
 }
 
 export class TerminalExecTool implements AgentTool<TerminalExecInput> {
@@ -3220,11 +3223,14 @@ export function createTerminalTools(options: TerminalExecToolOptions = {}): Agen
 ```ts
 export const DEFAULT_TOOL_RESULT_MAX_TEXT_BYTES = 256_000
 
+export const DEFAULT_TOOL_RESULT_MAX_TEXT_ARTIFACT_BYTES = 25 * 1024 * 1024
+
 export interface ToolResultSanitizerOptions {
   tempRoot?: string
   ttlMs?: number
   maxBytes?: number
   maxTextBytes?: number
+  maxTextArtifactBytes?: number
   now?: number
 }
 
@@ -3349,6 +3355,8 @@ export async function ensureWorkspaceTempRoot( context: Pick<AgentToolContext, '
 export function workspaceTempEnvironment(directory: string): NodeJS.ProcessEnv
 
 export function workspaceToolAssetDirectory( context: Pick<AgentToolContext, 'workspaceRoot' | 'cwd'> = {}, ): string
+
+export async function ensureToolAssetDirectory(directory: string): Promise<string>
 ```
 
 <!-- END GENERATED EKKO PUBLIC API -->

--- a/packages/ekko-agent/src/runtime/runtime.ts
+++ b/packages/ekko-agent/src/runtime/runtime.ts
@@ -528,7 +528,7 @@ export class AgentRuntime {
         )
         if (activeBoundaryRun?.pending) return completeBoundaryInterrupt(step - 1)
         const response = modelResult.response
-        const assistantMessage = modelResponseToAgentMessage(response)
+        const assistantMessage = normalizeToolCallPreamble(modelResponseToAgentMessage(response))
         const toolCalls = assistantMessage.toolCalls ?? []
         const blockedByRecovery = toolCalls.length === 0 && this.currentRecoveryDirective()?.active === true
         if (activeBoundaryRun && toolCalls.length > 0) {
@@ -1689,6 +1689,17 @@ function removeHistoricalSkillViews(
 
 function throwIfAborted(signal?: AbortSignal): void {
   if (signal?.aborted) throw abortError()
+}
+
+function normalizeToolCallPreamble(message: AgentOutputMessage): AgentOutputMessage {
+  if (!message.toolCalls?.length || !/[:：]\s*$/.test(message.content)) return message
+  const trailingWhitespace = message.content.match(/\s*$/)?.[0] || ''
+  const body = message.content.slice(0, message.content.length - trailingWhitespace.length)
+  const punctuation = /[\u3400-\u9fff\u3040-\u30ff\uac00-\ud7af]/u.test(body) ? '。' : '.'
+  return {
+    ...message,
+    content: `${body.slice(0, -1)}${punctuation}${trailingWhitespace}`,
+  }
 }
 
 function enterBoundaryModelPhase(

--- a/packages/ekko-agent/src/runtime/system-prompt.ts
+++ b/packages/ekko-agent/src/runtime/system-prompt.ts
@@ -38,6 +38,7 @@ Treat external commands, language packages, and other prerequisites named by a S
 - Before relying on an external dependency whose availability has not already been established, perform a lightweight availability check.
 - Do not run the primary dependency-based approach merely to discover whether its dependency exists.
 - Request independent tool calls together in one response. The runtime executes tools marked as parallel-safe concurrently while preserving serial barriers for stateful or dependent work.
+- When accompanying a tool call with progress text, write a complete standalone sentence. Do not end tool-call preambles with ":" or "：" as though the tool result will complete the sentence; omit the preamble when it adds no value.
 - When the user asks to execute or evaluate Node.js, JavaScript, or Python source code, use code_exec, including for one-line snippets. Do not probe Node or Python with terminal_exec first; code_exec resolves its runtime.
 - Use terminal_exec for CLI commands, project scripts, tests, builds, package managers, and other executables.
 - terminal_exec may use explicit absolute system paths and platform-appropriate package-manager forms. Follow the Command Environment section below; this capability is not limited to workspace files.

--- a/packages/ekko-agent/src/tools/terminal.ts
+++ b/packages/ekko-agent/src/tools/terminal.ts
@@ -1,14 +1,16 @@
 import { randomUUID } from 'node:crypto'
 import { spawn } from 'node:child_process'
 import { createWriteStream } from 'node:fs'
-import { mkdir, unlink } from 'node:fs/promises'
+import { unlink } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
+import { Transform, type TransformCallback } from 'node:stream'
 import { finished } from 'node:stream/promises'
 import type { AgentTool, AgentToolContext, AgentToolResult } from './types'
-import { ensureWorkspaceTempRoot, workspaceTempEnvironment } from './workspace-temp'
+import { ensureToolAssetDirectory, ensureWorkspaceTempRoot, workspaceTempEnvironment } from './workspace-temp'
 
 export const DEFAULT_TERMINAL_EXEC_MAX_OUTPUT_BYTES = 100_000
 export const DEFAULT_TERMINAL_EXEC_MAX_STDERR_BYTES = 25_000
+export const DEFAULT_TERMINAL_EXEC_MAX_ARTIFACT_BYTES = 25 * 1024 * 1024
 
 export interface TerminalExecInput extends Record<string, unknown> {
   command: string
@@ -22,6 +24,7 @@ export interface TerminalExecToolOptions {
   platform?: NodeJS.Platform
   maxOutputBytes?: number
   maxStderrBytes?: number
+  maxArtifactBytes?: number
 }
 
 export class TerminalExecTool implements AgentTool<TerminalExecInput> {
@@ -30,11 +33,13 @@ export class TerminalExecTool implements AgentTool<TerminalExecInput> {
   private readonly timeoutMs: number
   private readonly maxOutputBytes: number
   private readonly maxStderrBytes: number
+  private readonly maxArtifactBytes: number
 
   constructor(options: TerminalExecToolOptions = {}) {
     this.timeoutMs = positiveInteger(options.timeoutMs, 30_000)
     this.maxOutputBytes = positiveInteger(options.maxOutputBytes, DEFAULT_TERMINAL_EXEC_MAX_OUTPUT_BYTES)
     this.maxStderrBytes = positiveInteger(options.maxStderrBytes, DEFAULT_TERMINAL_EXEC_MAX_STDERR_BYTES)
+    this.maxArtifactBytes = positiveInteger(options.maxArtifactBytes, DEFAULT_TERMINAL_EXEC_MAX_ARTIFACT_BYTES)
     this.definition = terminalExecDefinition(options.platform ?? process.platform)
   }
 
@@ -55,7 +60,7 @@ export class TerminalExecTool implements AgentTool<TerminalExecInput> {
 
     const tempDirectory = await ensureWorkspaceTempRoot(context)
     const outputDirectory = join(tempDirectory, 'tool-assets')
-    await mkdir(outputDirectory, { recursive: true })
+    await ensureToolAssetDirectory(outputDirectory)
     const artifactPrefix = `${safeArtifactName(context.runId || 'run')}-${Date.now()}-${randomUUID()}`
     const stdoutArtifactPath = join(outputDirectory, `${artifactPrefix}.stdout.log`)
     const stderrArtifactPath = join(outputDirectory, `${artifactPrefix}.stderr.log`)
@@ -73,6 +78,8 @@ export class TerminalExecTool implements AgentTool<TerminalExecInput> {
       const stderr = new BoundedOutputCapture(this.maxStderrBytes)
       const stdoutArtifact = createWriteStream(stdoutArtifactPath, { flags: 'wx', mode: 0o600 })
       const stderrArtifact = createWriteStream(stderrArtifactPath, { flags: 'wx', mode: 0o600 })
+      const stdoutArtifactLimit = new ArtifactByteLimit(this.maxArtifactBytes)
+      const stderrArtifactLimit = new ArtifactByteLimit(this.maxArtifactBytes)
       const stdoutArtifactDone = settleOutputArtifact(stdoutArtifact)
       const stderrArtifactDone = settleOutputArtifact(stderrArtifact)
       let spawnError: Error | undefined
@@ -89,8 +96,8 @@ export class TerminalExecTool implements AgentTool<TerminalExecInput> {
       }
       context.signal?.addEventListener('abort', onAbort, { once: true })
 
-      child.stdout?.pipe(stdoutArtifact)
-      child.stderr?.pipe(stderrArtifact)
+      pipeOutputArtifact(child.stdout, stdoutArtifactLimit, stdoutArtifact)
+      pipeOutputArtifact(child.stderr, stderrArtifactLimit, stderrArtifact)
       child.stdout?.on('data', chunk => { stdout.append(Buffer.from(chunk)) })
       child.stderr?.on('data', chunk => { stderr.append(Buffer.from(chunk)) })
       child.on('error', error => {
@@ -109,8 +116,12 @@ export class TerminalExecTool implements AgentTool<TerminalExecInput> {
           keptStdoutArtifact ? undefined : unlink(stdoutArtifactPath).catch(() => undefined),
           keptStderrArtifact ? undefined : unlink(stderrArtifactPath).catch(() => undefined),
         ])
-        const stdoutText = stdout.text(keptStdoutArtifact ? stdoutArtifactPath : undefined).trimEnd()
-        const stderrText = stderr.text(keptStderrArtifact ? stderrArtifactPath : undefined).trimEnd()
+        const stdoutText = stdout.text(keptStdoutArtifact
+          ? artifactLocation(stdoutArtifactPath, stdoutArtifactLimit)
+          : undefined).trimEnd()
+        const stderrText = stderr.text(keptStderrArtifact
+          ? artifactLocation(stderrArtifactPath, stderrArtifactLimit)
+          : undefined).trimEnd()
         const content = [stdoutText, stderrText].filter(Boolean).join('\n')
         const error = spawnError?.message
           || (aborted
@@ -138,6 +149,14 @@ export class TerminalExecTool implements AgentTool<TerminalExecInput> {
             stderrTruncated: stderr.truncated,
             ...(keptStdoutArtifact ? { stdoutArtifactPath } : {}),
             ...(keptStderrArtifact ? { stderrArtifactPath } : {}),
+            ...(keptStdoutArtifact ? {
+              stdoutArtifactBytes: stdoutArtifactLimit.writtenBytes,
+              stdoutArtifactTruncated: stdoutArtifactLimit.truncated,
+            } : {}),
+            ...(keptStderrArtifact ? {
+              stderrArtifactBytes: stderrArtifactLimit.writtenBytes,
+              stderrArtifactTruncated: stderrArtifactLimit.truncated,
+            } : {}),
             ...(stdoutArtifactError ? { stdoutArtifactError: stdoutArtifactError.message } : {}),
             ...(stderrArtifactError ? { stderrArtifactError: stderrArtifactError.message } : {}),
             timedOut,
@@ -175,17 +194,67 @@ class BoundedOutputCapture {
     this.tail = Buffer.concat([this.tail, chunk]).subarray(-tailBytes)
   }
 
-  text(artifactPath?: string): string {
+  text(artifact?: OutputArtifactLocation): string {
     const prefix = Buffer.concat(this.prefixChunks)
     if (!this.truncated) return prefix.toString('utf8')
     const tailBytes = Math.max(1, Math.floor(this.maxBytes / 3))
     const headBytes = this.maxBytes - tailBytes
     const omittedBytes = Math.max(0, this.totalBytes - headBytes - this.tail.length)
-    const location = artifactPath
-      ? ` Full output saved to ${artifactPath}; inspect it with read_file using offsets or a bounded search.`
+    const location = artifact
+      ? artifact.truncated
+        ? ` The first ${artifact.bytes} bytes were saved to ${artifact.path}; the artifact reached its safety limit. Inspect it with read_file using offsets or a bounded search.`
+        : ` Full output saved to ${artifact.path}; inspect it with read_file using offsets or a bounded search.`
       : ''
     const marker = `\n\n[terminal_exec output truncated: ${this.totalBytes} bytes total, ${omittedBytes} bytes omitted.${location}]\n\n`
     return `${prefix.subarray(0, headBytes).toString('utf8')}${marker}${this.tail.toString('utf8')}`
+  }
+}
+
+interface OutputArtifactLocation {
+  path: string
+  bytes: number
+  truncated: boolean
+}
+
+class ArtifactByteLimit extends Transform {
+  writtenBytes = 0
+  truncated = false
+
+  constructor(private readonly maxBytes: number) {
+    super()
+  }
+
+  override _transform(chunk: Buffer | string, encoding: BufferEncoding, callback: TransformCallback): void {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding)
+    const remaining = Math.max(0, this.maxBytes - this.writtenBytes)
+    if (remaining > 0) {
+      const kept = buffer.subarray(0, remaining)
+      this.writtenBytes += kept.length
+      if (kept.length) this.push(kept)
+    }
+    if (buffer.length > remaining) this.truncated = true
+    callback()
+  }
+}
+
+function pipeOutputArtifact(
+  source: NodeJS.ReadableStream | null,
+  limit: ArtifactByteLimit,
+  artifact: ReturnType<typeof createWriteStream>,
+): void {
+  artifact.once('error', () => {
+    limit.unpipe(artifact)
+    limit.resume()
+  })
+  if (source) source.pipe(limit).pipe(artifact)
+  else artifact.end()
+}
+
+function artifactLocation(path: string, limit: ArtifactByteLimit): OutputArtifactLocation {
+  return {
+    path,
+    bytes: limit.writtenBytes,
+    truncated: limit.truncated,
   }
 }
 
@@ -230,7 +299,7 @@ function terminalExecDefinition(platform: NodeJS.Platform): AgentTool['definitio
         ? 'Commands are not confined to the workspace: explicit absolute Windows paths are supported.'
         : 'Commands are not confined to the workspace: explicit absolute paths and package-manager forms such as npx --dir are supported.',
       'Keep downloads, clones, extracted files, and generated intermediates under the current workspace (prefer .ekko-tmp) when workspace tools need to inspect them.',
-      'Large stdout and stderr are returned as bounded previews; complete streams are saved under .ekko-tmp/tool-assets for paged read_file access or bounded searches.',
+      'Large stdout and stderr are returned as bounded previews; output artifacts are saved under .ekko-tmp/tool-assets up to a per-stream safety limit for paged read_file access or bounded searches.',
       'When the user asks to execute or evaluate Node.js, JavaScript, or Python source code, use code_exec instead, even for a one-line snippet.',
       'Destructive, privileged, remote-shell, publishing, and other dangerous commands require runtime authorization before execution.',
     ].join(' '),

--- a/packages/ekko-agent/src/tools/terminal.ts
+++ b/packages/ekko-agent/src/tools/terminal.ts
@@ -1,7 +1,14 @@
+import { randomUUID } from 'node:crypto'
 import { spawn } from 'node:child_process'
-import { resolve } from 'node:path'
+import { createWriteStream } from 'node:fs'
+import { mkdir, unlink } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { finished } from 'node:stream/promises'
 import type { AgentTool, AgentToolContext, AgentToolResult } from './types'
 import { ensureWorkspaceTempRoot, workspaceTempEnvironment } from './workspace-temp'
+
+export const DEFAULT_TERMINAL_EXEC_MAX_OUTPUT_BYTES = 100_000
+export const DEFAULT_TERMINAL_EXEC_MAX_STDERR_BYTES = 25_000
 
 export interface TerminalExecInput extends Record<string, unknown> {
   command: string
@@ -13,15 +20,21 @@ export interface TerminalExecInput extends Record<string, unknown> {
 export interface TerminalExecToolOptions {
   timeoutMs?: number
   platform?: NodeJS.Platform
+  maxOutputBytes?: number
+  maxStderrBytes?: number
 }
 
 export class TerminalExecTool implements AgentTool<TerminalExecInput> {
   readonly definition: AgentTool['definition']
 
   private readonly timeoutMs: number
+  private readonly maxOutputBytes: number
+  private readonly maxStderrBytes: number
 
   constructor(options: TerminalExecToolOptions = {}) {
     this.timeoutMs = positiveInteger(options.timeoutMs, 30_000)
+    this.maxOutputBytes = positiveInteger(options.maxOutputBytes, DEFAULT_TERMINAL_EXEC_MAX_OUTPUT_BYTES)
+    this.maxStderrBytes = positiveInteger(options.maxStderrBytes, DEFAULT_TERMINAL_EXEC_MAX_STDERR_BYTES)
     this.definition = terminalExecDefinition(options.platform ?? process.platform)
   }
 
@@ -41,6 +54,11 @@ export class TerminalExecTool implements AgentTool<TerminalExecInput> {
     }
 
     const tempDirectory = await ensureWorkspaceTempRoot(context)
+    const outputDirectory = join(tempDirectory, 'tool-assets')
+    await mkdir(outputDirectory, { recursive: true })
+    const artifactPrefix = `${safeArtifactName(context.runId || 'run')}-${Date.now()}-${randomUUID()}`
+    const stdoutArtifactPath = join(outputDirectory, `${artifactPrefix}.stdout.log`)
+    const stderrArtifactPath = join(outputDirectory, `${artifactPrefix}.stderr.log`)
     return new Promise<AgentToolResult>((resolveResult) => {
       const child = spawn(normalized.command, args, {
         cwd,
@@ -51,8 +69,13 @@ export class TerminalExecTool implements AgentTool<TerminalExecInput> {
         shell: false,
         windowsHide: true,
       })
-      let stdout = ''
-      let stderr = ''
+      const stdout = new BoundedOutputCapture(this.maxOutputBytes)
+      const stderr = new BoundedOutputCapture(this.maxStderrBytes)
+      const stdoutArtifact = createWriteStream(stdoutArtifactPath, { flags: 'wx', mode: 0o600 })
+      const stderrArtifact = createWriteStream(stderrArtifactPath, { flags: 'wx', mode: 0o600 })
+      const stdoutArtifactDone = settleOutputArtifact(stdoutArtifact)
+      const stderrArtifactDone = settleOutputArtifact(stderrArtifact)
+      let spawnError: Error | undefined
       let timedOut = false
       let aborted = false
 
@@ -66,36 +89,57 @@ export class TerminalExecTool implements AgentTool<TerminalExecInput> {
       }
       context.signal?.addEventListener('abort', onAbort, { once: true })
 
-      child.stdout?.setEncoding('utf8')
-      child.stderr?.setEncoding('utf8')
-      child.stdout?.on('data', chunk => { stdout += chunk })
-      child.stderr?.on('data', chunk => { stderr += chunk })
+      child.stdout?.pipe(stdoutArtifact)
+      child.stderr?.pipe(stderrArtifact)
+      child.stdout?.on('data', chunk => { stdout.append(Buffer.from(chunk)) })
+      child.stderr?.on('data', chunk => { stderr.append(Buffer.from(chunk)) })
       child.on('error', error => {
-        clearTimeout(timer)
-        context.signal?.removeEventListener('abort', onAbort)
-        resolveResult({
-          ok: false,
-          content: error.message,
-          error: error.message,
-          data: { command: normalized.command, args, cwd, originalCommand: input.command },
-        })
+        spawnError = error
       })
-      child.on('close', code => {
+      child.on('close', async code => {
         clearTimeout(timer)
         context.signal?.removeEventListener('abort', onAbort)
-        const content = [stdout.trimEnd(), stderr.trimEnd()].filter(Boolean).join('\n')
+        const [stdoutArtifactError, stderrArtifactError] = await Promise.all([
+          stdoutArtifactDone,
+          stderrArtifactDone,
+        ])
+        const keptStdoutArtifact = stdout.truncated && !stdoutArtifactError
+        const keptStderrArtifact = stderr.truncated && !stderrArtifactError
+        await Promise.all([
+          keptStdoutArtifact ? undefined : unlink(stdoutArtifactPath).catch(() => undefined),
+          keptStderrArtifact ? undefined : unlink(stderrArtifactPath).catch(() => undefined),
+        ])
+        const stdoutText = stdout.text(keptStdoutArtifact ? stdoutArtifactPath : undefined).trimEnd()
+        const stderrText = stderr.text(keptStderrArtifact ? stderrArtifactPath : undefined).trimEnd()
+        const content = [stdoutText, stderrText].filter(Boolean).join('\n')
+        const error = spawnError?.message
+          || (aborted
+            ? 'Command aborted.'
+            : timedOut
+              ? `Command timed out after ${timeoutMs}ms`
+              : code === 0
+                ? undefined
+                : `Command exited with code ${code}`)
         resolveResult({
-          ok: code === 0 && !timedOut && !aborted,
-          content: content || (aborted ? 'Command aborted.' : content),
-          error: aborted ? 'Command aborted.' : timedOut ? `Command timed out after ${timeoutMs}ms` : code === 0 ? undefined : `Command exited with code ${code}`,
+          ok: !spawnError && code === 0 && !timedOut && !aborted,
+          content: content || error || '',
+          error,
           data: {
             command: normalized.command,
             args,
             cwd,
             originalCommand: input.command,
             exitCode: code,
-            stdout,
-            stderr,
+            stdout: stdoutText,
+            stderr: stderrText,
+            stdoutBytes: stdout.totalBytes,
+            stderrBytes: stderr.totalBytes,
+            stdoutTruncated: stdout.truncated,
+            stderrTruncated: stderr.truncated,
+            ...(keptStdoutArtifact ? { stdoutArtifactPath } : {}),
+            ...(keptStderrArtifact ? { stderrArtifactPath } : {}),
+            ...(stdoutArtifactError ? { stdoutArtifactError: stdoutArtifactError.message } : {}),
+            ...(stderrArtifactError ? { stderrArtifactError: stderrArtifactError.message } : {}),
             timedOut,
             aborted,
             tempDirectory,
@@ -104,6 +148,58 @@ export class TerminalExecTool implements AgentTool<TerminalExecInput> {
       })
     })
   }
+}
+
+class BoundedOutputCapture {
+  private readonly prefixChunks: Buffer[] = []
+  private prefixBytes = 0
+  private tail = Buffer.alloc(0)
+  totalBytes = 0
+
+  constructor(private readonly maxBytes: number) {}
+
+  get truncated(): boolean {
+    return this.totalBytes > this.maxBytes
+  }
+
+  append(chunk: Buffer): void {
+    this.totalBytes += chunk.length
+    if (this.prefixBytes < this.maxBytes) {
+      const kept = chunk.subarray(0, this.maxBytes - this.prefixBytes)
+      if (kept.length) {
+        this.prefixChunks.push(kept)
+        this.prefixBytes += kept.length
+      }
+    }
+    const tailBytes = Math.max(1, Math.floor(this.maxBytes / 3))
+    this.tail = Buffer.concat([this.tail, chunk]).subarray(-tailBytes)
+  }
+
+  text(artifactPath?: string): string {
+    const prefix = Buffer.concat(this.prefixChunks)
+    if (!this.truncated) return prefix.toString('utf8')
+    const tailBytes = Math.max(1, Math.floor(this.maxBytes / 3))
+    const headBytes = this.maxBytes - tailBytes
+    const omittedBytes = Math.max(0, this.totalBytes - headBytes - this.tail.length)
+    const location = artifactPath
+      ? ` Full output saved to ${artifactPath}; inspect it with read_file using offsets or a bounded search.`
+      : ''
+    const marker = `\n\n[terminal_exec output truncated: ${this.totalBytes} bytes total, ${omittedBytes} bytes omitted.${location}]\n\n`
+    return `${prefix.subarray(0, headBytes).toString('utf8')}${marker}${this.tail.toString('utf8')}`
+  }
+}
+
+async function settleOutputArtifact(stream: ReturnType<typeof createWriteStream>): Promise<Error | undefined> {
+  try {
+    await finished(stream)
+    return undefined
+  } catch (error) {
+    return error instanceof Error ? error : new Error(String(error))
+  }
+}
+
+function safeArtifactName(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]+/g, '-').slice(0, 80) || 'run'
 }
 
 function terminalExecDefinition(platform: NodeJS.Platform): AgentTool['definition'] {
@@ -134,6 +230,7 @@ function terminalExecDefinition(platform: NodeJS.Platform): AgentTool['definitio
         ? 'Commands are not confined to the workspace: explicit absolute Windows paths are supported.'
         : 'Commands are not confined to the workspace: explicit absolute paths and package-manager forms such as npx --dir are supported.',
       'Keep downloads, clones, extracted files, and generated intermediates under the current workspace (prefer .ekko-tmp) when workspace tools need to inspect them.',
+      'Large stdout and stderr are returned as bounded previews; complete streams are saved under .ekko-tmp/tool-assets for paged read_file access or bounded searches.',
       'When the user asks to execute or evaluate Node.js, JavaScript, or Python source code, use code_exec instead, even for a one-line snippet.',
       'Destructive, privileged, remote-shell, publishing, and other dangerous commands require runtime authorization before execution.',
     ].join(' '),

--- a/packages/ekko-agent/src/tools/tool-result-sanitizer.ts
+++ b/packages/ekko-agent/src/tools/tool-result-sanitizer.ts
@@ -10,11 +10,13 @@ const BASE64_FIELD_RE = /^(?:base64|b64|bodyBase64|dataUrl|image_base64|audio_ba
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000
 const DEFAULT_MAX_BYTES = 25 * 1024 * 1024
 const MIN_RAW_BASE64_CHARS = 4_096
+export const DEFAULT_TOOL_RESULT_MAX_TEXT_BYTES = 256_000
 
 export interface ToolResultSanitizerOptions {
   tempRoot?: string
   ttlMs?: number
   maxBytes?: number
+  maxTextBytes?: number
   now?: number
 }
 
@@ -26,11 +28,15 @@ export async function sanitizeAgentToolResult(
   await cleanupExpiredToolAssets(tempRoot, options.ttlMs ?? DEFAULT_TTL_MS, options.now ?? Date.now())
   const seen = new WeakSet<object>()
   const sanitize = (value: unknown, key = ''): Promise<unknown> => sanitizeValue(value, key, tempRoot, options, seen)
+  const content = String(await sanitizeStructuredText(result.content, sanitize))
+  const error = result.error === undefined
+    ? undefined
+    : String(await sanitizeStructuredText(result.error, sanitize))
   return {
     ...result,
-    content: String(await sanitizeStructuredText(result.content, sanitize)),
+    content: await boundToolResultText(content, tempRoot, options.maxTextBytes),
     data: result.data === undefined ? undefined : await sanitize(result.data),
-    error: result.error === undefined ? undefined : String(await sanitizeStructuredText(result.error, sanitize)),
+    error: error === undefined ? undefined : await boundToolResultText(error, tempRoot, options.maxTextBytes),
     contentParts: result.contentParts?.reduce<AgentToolContentPart[]>((parts, part) => {
       if (part.type === 'text') parts.push({ type: 'text', text: part.text.slice(0, 100_000) })
       else if (/^image\/(?:png|jpeg|webp|gif)$/i.test(part.mimeType)
@@ -41,6 +47,40 @@ export async function sanitizeAgentToolResult(
       return parts
     }, []),
   }
+}
+
+async function boundToolResultText(
+  text: string,
+  tempRoot: string,
+  requestedMaxBytes = DEFAULT_TOOL_RESULT_MAX_TEXT_BYTES,
+): Promise<string> {
+  const maxBytes = positiveInteger(requestedMaxBytes, DEFAULT_TOOL_RESULT_MAX_TEXT_BYTES)
+  const buffer = Buffer.from(text)
+  if (buffer.length <= maxBytes) return text
+  const digest = createHash('sha256').update(buffer).digest('hex')
+  const artifactPath = join(tempRoot, `tool-result-${digest}.txt`)
+  await mkdir(tempRoot, { recursive: true })
+  try {
+    await writeFile(artifactPath, buffer, { flag: 'wx', mode: 0o600 })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
+  }
+  const tailBytes = Math.max(1, Math.floor(maxBytes / 3))
+  const headBytes = maxBytes - tailBytes
+  const omittedBytes = buffer.length - maxBytes
+  const marker = [
+    '',
+    '',
+    `[tool result truncated: ${buffer.length} bytes total, ${omittedBytes} bytes omitted.`,
+    `Full output saved to ${artifactPath}; inspect it with read_file using offsets or a bounded search.]`,
+    '',
+    '',
+  ].join('\n')
+  return `${buffer.subarray(0, headBytes).toString('utf8')}${marker}${buffer.subarray(-tailBytes).toString('utf8')}`
+}
+
+function positiveInteger(value: number | undefined, fallback: number): number {
+  return Number.isFinite(value) && Number(value) > 0 ? Math.floor(Number(value)) : fallback
 }
 
 export async function cleanupExpiredToolAssets(

--- a/packages/ekko-agent/src/tools/tool-result-sanitizer.ts
+++ b/packages/ekko-agent/src/tools/tool-result-sanitizer.ts
@@ -1,9 +1,10 @@
 import { createHash } from 'node:crypto'
-import { mkdir, readdir, stat, unlink, writeFile } from 'node:fs/promises'
+import { readdir, stat, unlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import type { AgentToolContentPart, AgentToolResult } from './types'
+import { ensureToolAssetDirectory } from './workspace-temp'
 
 const DATA_URL_RE = /data:([a-zA-Z0-9.+-]+\/[a-zA-Z0-9.+-]+);base64,([a-zA-Z0-9+/=\r\n]+)/g
 const BASE64_FIELD_RE = /^(?:base64|b64|bodyBase64|dataUrl|image_base64|audio_base64)$/i
@@ -11,12 +12,14 @@ const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000
 const DEFAULT_MAX_BYTES = 25 * 1024 * 1024
 const MIN_RAW_BASE64_CHARS = 4_096
 export const DEFAULT_TOOL_RESULT_MAX_TEXT_BYTES = 256_000
+export const DEFAULT_TOOL_RESULT_MAX_TEXT_ARTIFACT_BYTES = 25 * 1024 * 1024
 
 export interface ToolResultSanitizerOptions {
   tempRoot?: string
   ttlMs?: number
   maxBytes?: number
   maxTextBytes?: number
+  maxTextArtifactBytes?: number
   now?: number
 }
 
@@ -34,9 +37,11 @@ export async function sanitizeAgentToolResult(
     : String(await sanitizeStructuredText(result.error, sanitize))
   return {
     ...result,
-    content: await boundToolResultText(content, tempRoot, options.maxTextBytes),
+    content: await boundToolResultText(content, tempRoot, options.maxTextBytes, options.maxTextArtifactBytes),
     data: result.data === undefined ? undefined : await sanitize(result.data),
-    error: error === undefined ? undefined : await boundToolResultText(error, tempRoot, options.maxTextBytes),
+    error: error === undefined
+      ? undefined
+      : await boundToolResultText(error, tempRoot, options.maxTextBytes, options.maxTextArtifactBytes),
     contentParts: result.contentParts?.reduce<AgentToolContentPart[]>((parts, part) => {
       if (part.type === 'text') parts.push({ type: 'text', text: part.text.slice(0, 100_000) })
       else if (/^image\/(?:png|jpeg|webp|gif)$/i.test(part.mimeType)
@@ -53,17 +58,33 @@ async function boundToolResultText(
   text: string,
   tempRoot: string,
   requestedMaxBytes = DEFAULT_TOOL_RESULT_MAX_TEXT_BYTES,
+  requestedMaxArtifactBytes = DEFAULT_TOOL_RESULT_MAX_TEXT_ARTIFACT_BYTES,
 ): Promise<string> {
   const maxBytes = positiveInteger(requestedMaxBytes, DEFAULT_TOOL_RESULT_MAX_TEXT_BYTES)
+  const maxArtifactBytes = positiveInteger(
+    requestedMaxArtifactBytes,
+    DEFAULT_TOOL_RESULT_MAX_TEXT_ARTIFACT_BYTES,
+  )
   const buffer = Buffer.from(text)
   if (buffer.length <= maxBytes) return text
   const digest = createHash('sha256').update(buffer).digest('hex')
-  const artifactPath = join(tempRoot, `tool-result-${digest}.txt`)
-  await mkdir(tempRoot, { recursive: true })
+  const candidateArtifactPath = join(tempRoot, `tool-result-${digest}.txt`)
+  const artifactBuffer = buffer.subarray(0, maxArtifactBytes)
+  const artifactTruncated = artifactBuffer.length < buffer.length
+  let artifactPath: string | undefined
   try {
-    await writeFile(artifactPath, buffer, { flag: 'wx', mode: 0o600 })
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
+    await ensureToolAssetDirectory(tempRoot)
+    try {
+      await writeFile(candidateArtifactPath, artifactBuffer, { flag: 'wx', mode: 0o600 })
+      artifactPath = candidateArtifactPath
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+        const existing = await stat(candidateArtifactPath).catch(() => undefined)
+        if (existing?.isFile() && existing.size === artifactBuffer.length) artifactPath = candidateArtifactPath
+      }
+    }
+  } catch {
+    // The bounded preview remains usable even when artifact persistence is unavailable.
   }
   const tailBytes = Math.max(1, Math.floor(maxBytes / 3))
   const headBytes = maxBytes - tailBytes
@@ -72,7 +93,11 @@ async function boundToolResultText(
     '',
     '',
     `[tool result truncated: ${buffer.length} bytes total, ${omittedBytes} bytes omitted.`,
-    `Full output saved to ${artifactPath}; inspect it with read_file using offsets or a bounded search.]`,
+    artifactPath && artifactTruncated
+      ? `The first ${artifactBuffer.length} bytes were saved to ${artifactPath}; the artifact reached its safety limit. Use a narrower tool query to retrieve later sections.]`
+      : artifactPath
+        ? `Full output saved to ${artifactPath}; inspect it with read_file using offsets or a bounded search.]`
+      : 'Full output could not be saved; use a narrower tool query to retrieve the omitted section.]',
     '',
     '',
   ].join('\n')
@@ -187,7 +212,7 @@ async function materializeBinary(
   if (buffer.length > maxBytes) return `[base64 omitted: ${mime}, ${buffer.length} bytes exceeds limit]`
   const digest = createHash('sha256').update(buffer).digest('hex')
   const path = join(tempRoot, `${digest}.${extensionForMime(mime)}`)
-  await mkdir(tempRoot, { recursive: true })
+  await ensureToolAssetDirectory(tempRoot)
   try {
     await writeFile(path, buffer, { flag: 'wx', mode: 0o600 })
   } catch (error) {

--- a/packages/ekko-agent/src/tools/workspace-temp.ts
+++ b/packages/ekko-agent/src/tools/workspace-temp.ts
@@ -1,6 +1,6 @@
-import { mkdir } from 'node:fs/promises'
+import { mkdir, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 import type { AgentToolContext } from './types'
 
 export const EKKO_WORKSPACE_TEMP_DIRECTORY = '.ekko-tmp'
@@ -23,6 +23,7 @@ export async function ensureWorkspaceTempRoot(
 ): Promise<string> {
   const directory = workspaceTempRoot(context)
   await mkdir(directory, { recursive: true })
+  await ignoreWorkspaceTempRoot(directory)
   return directory
 }
 
@@ -38,4 +39,24 @@ export function workspaceToolAssetDirectory(
   context: Pick<AgentToolContext, 'workspaceRoot' | 'cwd'> = {},
 ): string {
   return join(workspaceTempRoot(context), 'tool-assets')
+}
+
+export async function ensureToolAssetDirectory(directory: string): Promise<string> {
+  await mkdir(directory, { recursive: true })
+  const parent = dirname(directory)
+  if (
+    basename(directory) === 'tool-assets' &&
+    (basename(parent) === EKKO_WORKSPACE_TEMP_DIRECTORY || basename(parent) === 'ekko-agent')
+  ) {
+    await ignoreWorkspaceTempRoot(parent)
+  }
+  return directory
+}
+
+async function ignoreWorkspaceTempRoot(directory: string): Promise<void> {
+  try {
+    await writeFile(join(directory, '.gitignore'), '*\n', { flag: 'wx', mode: 0o600 })
+  } catch {
+    // Ignore metadata is best-effort and must never block temporary output.
+  }
 }

--- a/tests/ekko-agent/runtime.test.ts
+++ b/tests/ekko-agent/runtime.test.ts
@@ -416,7 +416,7 @@ describe('ekko-agent runtime', () => {
     tools.register(echoTool)
     const client = modelClient((_request, call) => call === 1
       ? {
-          content: '',
+          content: '继续检查:',
           toolCalls: [{ id: 'call_1', name: 'echo', arguments: { text: 'from-tool' } }],
           finishReason: 'tool_calls',
         }
@@ -429,7 +429,7 @@ describe('ekko-agent runtime', () => {
     expect(result.messages).toMatchObject([
       { role: 'system' },
       { role: 'user', content: 'use echo' },
-      { role: 'assistant', toolCalls: [{ id: 'call_1', name: 'echo' }] },
+      { role: 'assistant', content: '继续检查。', toolCalls: [{ id: 'call_1', name: 'echo' }] },
       { role: 'tool', toolCallId: 'call_1', name: 'echo', content: 'from-tool' },
       { role: 'assistant', content: 'tool said from-tool' },
     ])
@@ -2206,6 +2206,8 @@ describe('ekko-agent runtime', () => {
     expect(prompt).toContain('prerequisites named by a Skill as requirements, not proof that they are installed')
     expect(prompt).toContain('perform a lightweight availability check')
     expect(prompt).toContain('Request independent tool calls together in one response')
+    expect(prompt).toContain('complete standalone sentence')
+    expect(prompt).toContain('Do not end tool-call preambles with ":" or "："')
     expect(prompt).toContain('use code_exec, including for one-line snippets')
     expect(prompt).toContain('Do not probe Node or Python with terminal_exec first')
     expect(prompt).toContain('Use terminal_exec for CLI commands')

--- a/tests/ekko-agent/runtime.test.ts
+++ b/tests/ekko-agent/runtime.test.ts
@@ -10,6 +10,7 @@ import {
   DelegateTaskTool,
   DEFAULT_AGENT_MAX_STEPS,
   DEFAULT_AGENT_MODEL_MAX_RETRIES,
+  DEFAULT_TOOL_RESULT_MAX_TEXT_BYTES,
   ModelProviderError,
   ViewImageTool,
   buildSystemPrompt,
@@ -969,6 +970,48 @@ describe('ekko-agent runtime', () => {
         .run({ messages: ['list profiles'], toolContext: { workspaceRoot } })
       expect(result.output.content).toBe('done')
       expect(fileURLToPath(assetUrl)).toContain(join(workspaceRoot, '.ekko-tmp', 'tool-assets'))
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('bounds oversized tool results before the next model request', async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'ekko-runtime-large-result-'))
+    const largeContent = `head-${'x'.repeat(DEFAULT_TOOL_RESULT_MAX_TEXT_BYTES)}-tail`
+    const largeTool: AgentTool = {
+      definition: {
+        name: 'large_result',
+        description: 'Return oversized text',
+        parameters: { type: 'object' },
+      },
+      async execute() {
+        return { ok: true, content: largeContent }
+      },
+    }
+    const tools = new AgentToolRegistry()
+    tools.register(largeTool)
+    let artifactPath = ''
+    const client = modelClient((request, call) => {
+      if (call === 1) {
+        return {
+          content: '',
+          toolCalls: [{ id: 'call_large', name: 'large_result', arguments: {} }],
+          finishReason: 'tool_calls',
+        }
+      }
+      const toolMessage = request.messages.find(message => message.role === 'tool')
+      expect(Buffer.byteLength(toolMessage?.content || '')).toBeLessThan(DEFAULT_TOOL_RESULT_MAX_TEXT_BYTES + 1_000)
+      expect(toolMessage?.content).toContain('tool result truncated')
+      artifactPath = toolMessage?.content.match(/Full output saved to (.+?); inspect it/)?.[1] || ''
+      return { content: 'done', finishReason: 'stop' }
+    })
+
+    try {
+      const result = await new AgentRuntime({ modelClient: client, tools })
+        .run({ messages: ['run large tool'], toolContext: { workspaceRoot } })
+      expect(result.output.content).toBe('done')
+      expect(artifactPath).toContain(join(workspaceRoot, '.ekko-tmp', 'tool-assets'))
+      await expect(readFile(artifactPath, 'utf8')).resolves.toBe(largeContent)
     } finally {
       await rm(workspaceRoot, { recursive: true, force: true })
     }

--- a/tests/ekko-agent/tools.test.ts
+++ b/tests/ekko-agent/tools.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, readdir, realpath, rm, stat, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   AgentToolError,
   DEFAULT_READ_FILE_MAX_BYTES,
+  DEFAULT_TOOL_RESULT_MAX_TEXT_BYTES,
   DelegateTaskTool,
   ReadFileTool,
   TerminalExecTool,
@@ -48,6 +49,26 @@ describe('ekko-agent tools', () => {
     expect(fileURLToPath(url)).toContain(toolAssets)
     await expect(readFile(fileURLToPath(url), 'utf8')).resolves.toBe('avatar-png')
     expect(JSON.stringify(result.data)).not.toContain('base64')
+  })
+
+  it('applies a provider-safe fallback limit to every textual tool result', async () => {
+    const toolAssets = path.join(workspaceRoot, '.ekko-tmp', 'tool-assets')
+    const content = `start-${'z'.repeat(DEFAULT_TOOL_RESULT_MAX_TEXT_BYTES)}-finish`
+    const result = await sanitizeAgentToolResult({
+      ok: true,
+      content,
+    }, {
+      tempRoot: toolAssets,
+      maxTextBytes: 120,
+    })
+
+    expect(Buffer.byteLength(result.content)).toBeLessThan(1_000)
+    expect(result.content).toContain('tool result truncated')
+    expect(result.content).toContain('start-')
+    expect(result.content).toContain('-finish')
+    const artifactPath = result.content.match(/Full output saved to (.+?); inspect it/)?.[1]
+    expect(artifactPath).toBeTruthy()
+    await expect(readFile(artifactPath!, 'utf8')).resolves.toBe(content)
   })
 
   it('writes and reads files inside the workspace', async () => {
@@ -226,6 +247,56 @@ describe('ekko-agent tools', () => {
         exitCode: 0,
       },
     })
+  })
+
+  it('bounds terminal output and saves the complete streams for paged inspection', async () => {
+    const terminal = new TerminalExecTool({ maxOutputBytes: 90, maxStderrBytes: 30 })
+    const stdout = `head-${'x'.repeat(180)}-tail`
+    const stderr = `error-${'y'.repeat(60)}-end`
+    const result = await terminal.execute({
+      command: process.execPath,
+      args: ['-e', 'process.stdout.write(process.argv[1]); process.stderr.write(process.argv[2])', stdout, stderr],
+    }, { workspaceRoot, runId: 'large-output-test' })
+
+    expect(result.ok).toBe(true)
+    expect(Buffer.byteLength(result.content)).toBeLessThan(1_000)
+    expect(result.content).toContain('terminal_exec output truncated')
+    expect(result.content).toContain('inspect it with read_file using offsets or a bounded search')
+    expect(result.data).toMatchObject({
+      stdoutBytes: Buffer.byteLength(stdout),
+      stderrBytes: Buffer.byteLength(stderr),
+      stdoutTruncated: true,
+      stderrTruncated: true,
+    })
+    const data = result.data as {
+      stdoutArtifactPath: string
+      stderrArtifactPath: string
+    }
+    await expect(readFile(data.stdoutArtifactPath, 'utf8')).resolves.toBe(stdout)
+    await expect(readFile(data.stderrArtifactPath, 'utf8')).resolves.toBe(stderr)
+  })
+
+  it('removes terminal artifacts when output stays within the context limit', async () => {
+    const terminal = new TerminalExecTool({ maxOutputBytes: 100, maxStderrBytes: 100 })
+    const result = await terminal.execute({
+      command: process.execPath,
+      args: ['-e', 'process.stdout.write("small")'],
+    }, { workspaceRoot, runId: 'small-output-test' })
+
+    expect(result).toMatchObject({
+      ok: true,
+      content: 'small',
+      data: {
+        stdout: 'small',
+        stdoutBytes: 5,
+        stdoutTruncated: false,
+        stderrBytes: 0,
+        stderrTruncated: false,
+      },
+    })
+    expect(result.data).not.toHaveProperty('stdoutArtifactPath')
+    expect(result.data).not.toHaveProperty('stderrArtifactPath')
+    await expect(readdir(path.join(workspaceRoot, '.ekko-tmp', 'tool-assets'))).resolves.toEqual([])
   })
 
   it('defaults command temporary files to the current workspace', async () => {

--- a/tests/ekko-agent/tools.test.ts
+++ b/tests/ekko-agent/tools.test.ts
@@ -69,6 +69,39 @@ describe('ekko-agent tools', () => {
     const artifactPath = result.content.match(/Full output saved to (.+?); inspect it/)?.[1]
     expect(artifactPath).toBeTruthy()
     await expect(readFile(artifactPath!, 'utf8')).resolves.toBe(content)
+    await expect(readFile(path.join(workspaceRoot, '.ekko-tmp', '.gitignore'), 'utf8')).resolves.toBe('*\n')
+  })
+
+  it('keeps a bounded text preview when the complete result cannot be persisted', async () => {
+    const blockedTempRoot = path.join(workspaceRoot, 'blocked-tool-assets')
+    const content = `start-${'z'.repeat(500)}-finish`
+    await writeFile(blockedTempRoot, 'not-a-directory')
+
+    const result = await sanitizeAgentToolResult({ ok: true, content }, {
+      tempRoot: blockedTempRoot,
+      maxTextBytes: 120,
+    })
+
+    expect(result.content).toContain('tool result truncated')
+    expect(result.content).toContain('Full output could not be saved')
+    expect(result.content).toContain('start-')
+    expect(result.content).toContain('-finish')
+  })
+
+  it('caps persisted fallback text artifacts', async () => {
+    const toolAssets = path.join(workspaceRoot, '.ekko-tmp', 'tool-assets')
+    const content = `start-${'z'.repeat(500)}-finish`
+    const result = await sanitizeAgentToolResult({ ok: true, content }, {
+      tempRoot: toolAssets,
+      maxTextBytes: 120,
+      maxTextArtifactBytes: 64,
+    })
+
+    expect(result.content).toContain('first 64 bytes were saved')
+    expect(result.content).toContain('artifact reached its safety limit')
+    const artifactPath = result.content.match(/saved to (.+?); the artifact/)?.[1]
+    expect(artifactPath).toBeTruthy()
+    await expect(readFile(artifactPath!, 'utf8')).resolves.toBe(content.slice(0, 64))
   })
 
   it('writes and reads files inside the workspace', async () => {
@@ -276,6 +309,28 @@ describe('ekko-agent tools', () => {
     await expect(readFile(data.stderrArtifactPath, 'utf8')).resolves.toBe(stderr)
   })
 
+  it('caps persisted terminal artifacts while continuing to drain command output', async () => {
+    const terminal = new TerminalExecTool({ maxOutputBytes: 40, maxArtifactBytes: 64 })
+    const stdout = `head-${'x'.repeat(180)}-tail`
+    const result = await terminal.execute({
+      command: process.execPath,
+      args: ['-e', 'process.stdout.write(process.argv[1])', stdout],
+    }, { workspaceRoot, runId: 'artifact-cap-test' })
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        stdoutBytes: Buffer.byteLength(stdout),
+        stdoutTruncated: true,
+        stdoutArtifactBytes: 64,
+        stdoutArtifactTruncated: true,
+      },
+    })
+    expect(result.content).toContain('artifact reached its safety limit')
+    const artifactPath = (result.data as { stdoutArtifactPath: string }).stdoutArtifactPath
+    await expect(readFile(artifactPath, 'utf8')).resolves.toBe(stdout.slice(0, 64))
+  })
+
   it('removes terminal artifacts when output stays within the context limit', async () => {
     const terminal = new TerminalExecTool({ maxOutputBytes: 100, maxStderrBytes: 100 })
     const result = await terminal.execute({
@@ -310,6 +365,7 @@ describe('ekko-agent tools', () => {
     expect(result.ok).toBe(true)
     expect(JSON.parse(result.content)).toEqual({ TMPDIR: expected, TMP: expected, TEMP: expected })
     expect((await stat(expected)).isDirectory()).toBe(true)
+    await expect(readFile(path.join(expected, '.gitignore'), 'utf8')).resolves.toBe('*\n')
   })
 
   it('allows an explicit terminal working directory outside workspaceRoot', async () => {


### PR DESCRIPTION
## Summary

- bound `terminal_exec` stdout/stderr in memory and return head/tail previews
- persist complete oversized command streams under `.ekko-tmp/tool-assets` for paged `read_file` or bounded search
- add a provider-request fallback that truncates oversized textual tool results before they enter the next model request
- add runtime/tool regression coverage and update generated API/change documentation

## Why

A command such as a recursive search over a minified JavaScript bundle can produce a single multi-megabyte line. The previous `terminal_exec` implementation accumulated the entire stream and appended it to the same conversation turn, which could exceed the upstream request-body/context limit and leave the session unable to continue.

## Validation

- `npm run test -- tests/ekko-agent/tools.test.ts tests/ekko-agent/runtime.test.ts` — 82 passed
- `npm run harness:check` — passed
- `npm run build` — passed
- `npm run test:coverage` — completed with 31 failing files / 69 failing tests in existing unrelated server/client areas (for example Studio MCP autoinject, agent bridge path expectations, recovery database expectations, and several timeout/UI tests); the focused Ekko suites above pass
