### PR TITLE
fix: proxy provider-unsafe Ekko MCP tool names

### DIFF
--- a/packages/ekko-agent/src/tools/mcp.ts
+++ b/packages/ekko-agent/src/tools/mcp.ts
@@ -240,13 +240,14 @@ class McpProxyTool implements AgentTool {
       ].join(' '),
       parameters: {
         type: 'object',
-        oneOf: tools.map(tool => ({
+        anyOf: tools.map(tool => ({
           type: 'object',
           title: String(tool.name),
           description: String(tool.description || `Call ${String(tool.name)}.`),
           properties: {
             tool: {
-              const: String(tool.name),
+              type: 'string',
+              enum: [String(tool.name)],
               description: 'Exact remote MCP tool name.',
             },
             arguments: isRecord(tool.inputSchema)

--- a/packages/ekko-agent/src/tools/mcp.ts
+++ b/packages/ekko-agent/src/tools/mcp.ts
@@ -21,6 +21,8 @@ type McpServerConfig = StdioMcpServerConfig | StreamableHttpMcpServerConfig
 type McpClientTransport = StdioClientTransport | StreamableHTTPClientTransport
 
 const DEFAULT_MCP_TIMEOUT_MS = 30_000
+const MODEL_TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/
+const MCP_PROXY_PREFIX = 'mcp__'
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value)
@@ -215,6 +217,85 @@ class McpTool implements AgentTool {
   }
 }
 
+class McpProxyTool implements AgentTool {
+  readonly definition: AgentTool['definition']
+  readonly concurrency: AgentTool['concurrency']
+  private readonly remoteTools: Map<string, any>
+
+  constructor(
+    proxyName: string,
+    serverName: string,
+    tools: any[],
+    private readonly session: McpClientSession,
+    supportsParallelToolCalls: boolean,
+  ) {
+    this.concurrency = supportsParallelToolCalls ? 'parallel' : 'serial'
+    this.remoteTools = new Map(tools.map(tool => [String(tool.name), tool]))
+    this.definition = {
+      name: proxyName,
+      description: [
+        `Call a tool from the ${serverName} MCP server.`,
+        'Pass the exact remote MCP tool name in "tool"; it will be preserved unchanged.',
+        ...tools.map(tool => `${String(tool.name)}: ${String(tool.description || 'No description provided.')}`),
+      ].join(' '),
+      parameters: {
+        type: 'object',
+        oneOf: tools.map(tool => ({
+          type: 'object',
+          title: String(tool.name),
+          description: String(tool.description || `Call ${String(tool.name)}.`),
+          properties: {
+            tool: {
+              const: String(tool.name),
+              description: 'Exact remote MCP tool name.',
+            },
+            arguments: isRecord(tool.inputSchema)
+              ? tool.inputSchema
+              : { type: 'object', properties: {} },
+          },
+          required: ['tool', 'arguments'],
+          additionalProperties: false,
+        })),
+      },
+    }
+  }
+
+  async execute(input: Record<string, unknown>, context: AgentToolContext = {}): Promise<AgentToolResult> {
+    const remoteName = typeof input.tool === 'string' ? input.tool : ''
+    if (!this.remoteTools.has(remoteName)) {
+      const error = `Unknown remote MCP tool: ${remoteName || '(missing)'}`
+      return { ok: false, content: error, error }
+    }
+    const remoteInput = isRecord(input.arguments) ? input.arguments : {}
+    return await this.session.callTool(remoteName, remoteInput, context.timeoutMs || DEFAULT_MCP_TIMEOUT_MS)
+  }
+}
+
+function modelSafeToolName(name: string): boolean {
+  return MODEL_TOOL_NAME_PATTERN.test(name)
+}
+
+function proxyToolName(serverName: string, usedNames: Set<string>): string {
+  const readable = serverName.replace(/[^a-zA-Z0-9_-]/g, '_') || 'server'
+  const base = `${MCP_PROXY_PREFIX}${readable}`.slice(0, 64)
+  if (!usedNames.has(base)) return base
+  const hash = stableNameHash(serverName)
+  for (let attempt = 1; ; attempt += 1) {
+    const suffix = `_${hash}${attempt === 1 ? '' : `_${attempt}`}`
+    const candidate = `${base.slice(0, 64 - suffix.length)}${suffix}`
+    if (!usedNames.has(candidate)) return candidate
+  }
+}
+
+function stableNameHash(value: string): string {
+  let hash = 2166136261
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(36)
+}
+
 export function createMcpToolProvider(): AgentToolProvider {
   const sessions = new Map<string, McpClientSession>()
   return {
@@ -238,8 +319,27 @@ export function createMcpToolProvider(): AgentToolProvider {
         }
 
         try {
-          for (const tool of await session.listTools(timeoutMs)) {
-            if (!tool?.name || usedNames.has(String(tool.name))) continue
+          const remoteTools = (await session.listTools(timeoutMs))
+            .filter(tool => !!tool?.name)
+          const requiresProxy = remoteTools.some(tool => {
+            const name = String(tool.name)
+            return !modelSafeToolName(name) || usedNames.has(name)
+          })
+
+          if (requiresProxy && remoteTools.length) {
+            const proxyName = proxyToolName(serverName, usedNames)
+            usedNames.add(proxyName)
+            tools.push(new McpProxyTool(
+              proxyName,
+              serverName,
+              remoteTools,
+              session,
+              server.supportsParallelToolCalls,
+            ))
+            continue
+          }
+
+          for (const tool of remoteTools) {
             usedNames.add(String(tool.name))
             tools.push(new McpTool(
               serverName,

--- a/tests/ekko-agent/mcp-streamable-http.test.ts
+++ b/tests/ekko-agent/mcp-streamable-http.test.ts
@@ -166,10 +166,13 @@ describe('Ekko Streamable HTTP MCP', () => {
     expect(tools[0].definition).toMatchObject({
       name: 'mcp__lazycat-shared-folder',
       parameters: {
-        oneOf: [
+        anyOf: [
           {
             properties: {
-              tool: { const: 'shared_folder.list_shared_with_me' },
+              tool: {
+                type: 'string',
+                enum: ['shared_folder.list_shared_with_me'],
+              },
               arguments: {
                 properties: { limit: { type: 'number' } },
               },
@@ -177,7 +180,10 @@ describe('Ekko Streamable HTTP MCP', () => {
           },
           {
             properties: {
-              tool: { const: 'shared_folder.leave' },
+              tool: {
+                type: 'string',
+                enum: ['shared_folder.leave'],
+              },
               arguments: {
                 properties: { id: { type: 'string' } },
                 required: ['id'],

--- a/tests/ekko-agent/mcp-streamable-http.test.ts
+++ b/tests/ekko-agent/mcp-streamable-http.test.ts
@@ -6,6 +6,8 @@ let server: ReturnType<typeof createServer>
 let endpoint = ''
 let initializeCount = 0
 let apiKeyHeaders: Array<string | undefined> = []
+let remoteTools: any[] = []
+let remoteToolCalls: Array<{ name: string; arguments: Record<string, unknown> }> = []
 
 async function readJson(request: IncomingMessage): Promise<any> {
   let body = ''
@@ -23,6 +25,16 @@ function json(response: ServerResponse, payload: unknown, session = false) {
 beforeEach(async () => {
   initializeCount = 0
   apiKeyHeaders = []
+  remoteTools = [{
+    name: 'remote_echo',
+    description: 'Echo over Streamable HTTP',
+    inputSchema: {
+      type: 'object',
+      properties: { text: { type: 'string' } },
+      required: ['text'],
+    },
+  }]
+  remoteToolCalls = []
   server = createServer(async (request, response) => {
     apiKeyHeaders.push(request.headers['x-api-key'] as string | undefined)
     if (request.method === 'DELETE') {
@@ -61,21 +73,17 @@ beforeEach(async () => {
         jsonrpc: '2.0',
         id: message.id,
         result: {
-          tools: [{
-            name: 'remote_echo',
-            description: 'Echo over Streamable HTTP',
-            inputSchema: {
-              type: 'object',
-              properties: { text: { type: 'string' } },
-              required: ['text'],
-            },
-          }],
+          tools: remoteTools,
         },
       })
       return
     }
     if (message.method === 'tools/call') {
       expect(request.headers['mcp-session-id']).toBe('ekko-test-session')
+      remoteToolCalls.push({
+        name: String(message.params.name),
+        arguments: message.params.arguments || {},
+      })
       json(response, {
         jsonrpc: '2.0',
         id: message.id,
@@ -122,6 +130,107 @@ describe('Ekko Streamable HTTP MCP', () => {
     await provider.listTools(context)
     expect(initializeCount).toBe(1)
     expect(apiKeyHeaders.every(value => value === 'test-key')).toBe(true)
+    await provider.listTools({ mcpServers: {} })
+  })
+
+  it('proxies provider-unsafe names while preserving the exact remote tool name', async () => {
+    remoteTools = [{
+      name: 'shared_folder.list_shared_with_me',
+      description: 'List folders shared with the current user',
+      inputSchema: {
+        type: 'object',
+        properties: { limit: { type: 'number' } },
+      },
+    }, {
+      name: 'shared_folder.leave',
+      description: 'Leave a shared folder',
+      inputSchema: {
+        type: 'object',
+        properties: { id: { type: 'string' } },
+        required: ['id'],
+      },
+    }]
+    const provider = createMcpToolProvider()
+    const context = {
+      mcpServers: {
+        'lazycat-shared-folder': {
+          type: 'streamable_http',
+          url: endpoint,
+        },
+      },
+      timeoutMs: 5_000,
+    }
+
+    const tools = await provider.listTools(context)
+    expect(tools).toHaveLength(1)
+    expect(tools[0].definition).toMatchObject({
+      name: 'mcp__lazycat-shared-folder',
+      parameters: {
+        oneOf: [
+          {
+            properties: {
+              tool: { const: 'shared_folder.list_shared_with_me' },
+              arguments: {
+                properties: { limit: { type: 'number' } },
+              },
+            },
+          },
+          {
+            properties: {
+              tool: { const: 'shared_folder.leave' },
+              arguments: {
+                properties: { id: { type: 'string' } },
+                required: ['id'],
+              },
+            },
+          },
+        ],
+      },
+    })
+
+    await tools[0].execute({
+      tool: 'shared_folder.list_shared_with_me',
+      arguments: { limit: 10 },
+    }, context)
+    expect(remoteToolCalls).toEqual([{
+      name: 'shared_folder.list_shared_with_me',
+      arguments: { limit: 10 },
+    }])
+
+    await provider.listTools({ mcpServers: {} })
+  })
+
+  it('uses a server proxy when direct MCP tool names overlap', async () => {
+    const provider = createMcpToolProvider()
+    const context = {
+      mcpServers: {
+        primary: {
+          type: 'streamable_http',
+          url: endpoint,
+        },
+        secondary: {
+          type: 'streamable_http',
+          url: endpoint,
+        },
+      },
+      timeoutMs: 5_000,
+    }
+
+    const tools = await provider.listTools(context)
+    expect(tools.map(tool => tool.definition.name)).toEqual([
+      'remote_echo',
+      'mcp__secondary',
+    ])
+
+    await tools[1].execute({
+      tool: 'remote_echo',
+      arguments: { text: 'from secondary' },
+    }, context)
+    expect(remoteToolCalls.at(-1)).toEqual({
+      name: 'remote_echo',
+      arguments: { text: 'from secondary' },
+    })
+
     await provider.listTools({ mcpServers: {} })
   })
 })


### PR DESCRIPTION
## Summary
- keep provider-safe MCP tools as direct Ekko function tools
- expose servers with provider-unsafe or overlapping tool names through one provider-safe MCP proxy
- preserve the exact remote MCP tool name and its input schema for dispatch instead of renaming it
- add focused coverage for dotted tool names, exact remote dispatch, and cross-server name collisions

Closes #2848

## Why

Some MCP servers publish valid MCP tool names containing characters such as `.`, while OpenAI-compatible Chat Completions providers may reject those names before the model request runs. Coding Agent adapters already avoid this class of failure through MCP namespace/proxy calls; Ekko previously submitted the raw name directly.

For an affected server, the model now calls a server proxy and passes the original tool name as data:

```json
{
  "tool": "shared_folder.list_shared_with_me",
  "arguments": {}
}
```

The MCP client still dispatches `shared_folder.list_shared_with_me` unchanged.

## Validation
- `npm run test -- tests/ekko-agent/mcp-streamable-http.test.ts tests/ekko-agent/mcp-multimodal.test.ts`
- `HOME=/tmp/hermes-nobody NODE_ENV=test ./node_modules/.bin/vitest run tests/ekko-agent` (297 passed)
- `npm run harness:check`
- `npm run build`
- `npm --prefix packages/ekko-agent run build`
- `git diff --check`
