### PR TITLE
fix(desktop): let tray quit cancel pending relaunch

### DIFF
--- a/packages/desktop/src/main/app-lifecycle.ts
+++ b/packages/desktop/src/main/app-lifecycle.ts
@@ -1,0 +1,81 @@
+export interface DesktopAppLifecycleHost {
+  quit: () => void
+  relaunch: () => void
+  exit: (exitCode?: number) => void
+}
+
+export interface DesktopAppLifecycle {
+  readonly isQuitting: boolean
+  quit: () => void
+  prepareShutdown: () => void
+  scheduleRestart: (delayMs?: number) => boolean
+  finalizeExit: (exitCode?: number) => boolean
+}
+
+/**
+ * Coordinate normal quits and requested restarts without registering a
+ * relaunch until graceful shutdown has finished. A later explicit quit can
+ * therefore override a restart while shutdown is still in progress.
+ */
+export function createDesktopAppLifecycle(host: DesktopAppLifecycleHost): DesktopAppLifecycle {
+  let isQuitting = false
+  let restartScheduled = false
+  let relaunchAfterShutdown = false
+  let exitFinalized = false
+  let restartTimer: ReturnType<typeof setTimeout> | null = null
+
+  function cancelRestart(): void {
+    if (restartTimer) clearTimeout(restartTimer)
+    restartTimer = null
+    restartScheduled = false
+    relaunchAfterShutdown = false
+  }
+
+  return {
+    get isQuitting() {
+      return isQuitting
+    },
+
+    quit() {
+      // A user-initiated quit always wins over a pending or in-progress
+      // restart request.
+      cancelRestart()
+      if (exitFinalized) return
+      isQuitting = true
+      host.quit()
+    },
+
+    prepareShutdown() {
+      isQuitting = true
+    },
+
+    scheduleRestart(delayMs = 100) {
+      if (restartScheduled || relaunchAfterShutdown) return true
+      if (isQuitting || exitFinalized) return false
+      restartScheduled = true
+      restartTimer = setTimeout(() => {
+        restartTimer = null
+        if (isQuitting || exitFinalized) {
+          restartScheduled = false
+          return
+        }
+        relaunchAfterShutdown = true
+        isQuitting = true
+        host.quit()
+      }, delayMs)
+      restartTimer.unref?.()
+      return true
+    },
+
+    finalizeExit(exitCode = 0) {
+      if (exitFinalized) return false
+      exitFinalized = true
+      if (restartTimer) clearTimeout(restartTimer)
+      restartTimer = null
+      restartScheduled = false
+      if (relaunchAfterShutdown) host.relaunch()
+      host.exit(exitCode)
+      return true
+    },
+  }
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -45,6 +45,7 @@ import { BrowserManager } from './browser/browser-manager'
 import { BrowserBroker } from './browser/browser-broker'
 import type { BrowserBounds } from './browser/browser-types'
 import { migratePendingLegacyWindowsData } from './legacy-windows-data-migration'
+import { createDesktopAppLifecycle } from './app-lifecycle'
 
 const PORT = Number(process.env.HERMES_DESKTOP_PORT) || 8748
 const START_HIDDEN = process.argv.includes('--hidden')
@@ -69,7 +70,6 @@ let petWindowLoadPromise: Promise<void> | null = null
 const chatWindows = new Map<string, BrowserWindow>()
 let serverUrl: string | null = null
 let tray: Tray | null = null
-let isQuitting = false
 let appShutdownPromise: Promise<void> | null = null
 let isBootstrapping = false
 let isResettingLogin = false
@@ -81,7 +81,7 @@ let unexpectedWebUiExitCount = 0
 let unexpectedWebUiExitWindowStartedAt = 0
 let rendererRecoveryCount = 0
 let rendererRecoveryWindowStartedAt = 0
-let appRestartScheduled = false
+const appLifecycle = createDesktopAppLifecycle(app)
 
 // Custom Session paths do not need Chromium's optional compression-dictionary
 // disk cache; disabling it leaves the normal HTTP cache enabled and isolated.
@@ -142,23 +142,15 @@ function showMainWindow() {
 }
 
 function quitApp() {
-  isQuitting = true
-  app.quit()
+  appLifecycle.quit()
 }
 
 function scheduleAppRestart(delayMs = 100): boolean {
-  if (appRestartScheduled) return true
-  if (isQuitting) return false
-  appRestartScheduled = true
-  setTimeout(() => {
-    app.relaunch()
-    quitApp()
-  }, delayMs).unref?.()
-  return true
+  return appLifecycle.scheduleRestart(delayMs)
 }
 
 async function prepareAppShutdown(): Promise<void> {
-  isQuitting = true
+  appLifecycle.prepareShutdown()
   if (!appShutdownPromise) {
     appShutdownPromise = (async () => {
       cancelWindowFade()
@@ -521,7 +513,7 @@ async function createWindow(): Promise<void> {
   })
 
   mainWindow.webContents.on('render-process-gone', (_event, details) => {
-    if (isQuitting || !mainWindow || mainWindow.isDestroyed()) return
+    if (appLifecycle.isQuitting || !mainWindow || mainWindow.isDestroyed()) return
     console.error(`[desktop] main renderer exited reason=${details.reason} code=${details.exitCode}`)
     const now = Date.now()
     if (now - rendererRecoveryWindowStartedAt > FAILURE_RECOVERY_WINDOW_MS) {
@@ -534,13 +526,13 @@ async function createWindow(): Promise<void> {
       return
     }
     setTimeout(() => {
-      if (!mainWindow || mainWindow.isDestroyed() || isQuitting) return
+      if (!mainWindow || mainWindow.isDestroyed() || appLifecycle.isQuitting) return
       mainWindow.reload()
     }, 250).unref?.()
   })
 
   mainWindow.on('close', (event) => {
-    if (isQuitting) return
+    if (appLifecycle.isQuitting) return
     event.preventDefault()
     cancelWindowFade()
     mainWindow?.hide()
@@ -1015,7 +1007,7 @@ async function loadServiceFailurePage(error: unknown): Promise<void> {
 }
 
 async function recoverUnexpectedWebUiExit(details: { code: number | null; signal: NodeJS.Signals | null }): Promise<void> {
-  if (isQuitting) return
+  if (appLifecycle.isQuitting) return
   serverUrl = null
   updateTrayMenu()
 
@@ -1276,7 +1268,7 @@ function runDesktopApp() {
   })
   const gotLock = app.requestSingleInstanceLock(QUIT_EXISTING ? { quit: true } : undefined)
   if (!gotLock) {
-    app.quit()
+    quitApp()
     return
   }
 
@@ -1317,15 +1309,15 @@ function runDesktopApp() {
   }).catch(error => {
     console.error('[desktop] failed during Electron startup:', error)
     dialog.showErrorBox('Hermes Studio', String(error instanceof Error ? error.message : error))
-    app.quit()
+    quitApp()
   })
 
   app.on('window-all-closed', () => {
-    if (isQuitting && process.platform !== 'darwin') app.quit()
+    if (appLifecycle.isQuitting && process.platform !== 'darwin') app.quit()
   })
 
   app.on('before-quit', async (e) => {
-    if (!isQuitting && process.platform !== 'darwin') {
+    if (!appLifecycle.isQuitting && process.platform !== 'darwin') {
       e.preventDefault()
       mainWindow?.hide()
       updateTrayMenu()
@@ -1335,7 +1327,7 @@ function runDesktopApp() {
     try {
       await prepareAppShutdown()
     } finally {
-      app.exit(0)
+      appLifecycle.finalizeExit(0)
     }
   })
 }

--- a/tests/desktop/app-lifecycle.test.ts
+++ b/tests/desktop/app-lifecycle.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createDesktopAppLifecycle } from '../../packages/desktop/src/main/app-lifecycle'
+
+function host() {
+  return {
+    quit: vi.fn(),
+    relaunch: vi.fn(),
+    exit: vi.fn(),
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('desktop app lifecycle', () => {
+  it('registers a relaunch only after graceful shutdown finishes', () => {
+    vi.useFakeTimers()
+    const app = host()
+    const lifecycle = createDesktopAppLifecycle(app)
+
+    expect(lifecycle.scheduleRestart(100)).toBe(true)
+    vi.advanceTimersByTime(100)
+
+    expect(app.quit).toHaveBeenCalledOnce()
+    expect(app.relaunch).not.toHaveBeenCalled()
+
+    lifecycle.prepareShutdown()
+    expect(lifecycle.finalizeExit()).toBe(true)
+
+    expect(app.relaunch).toHaveBeenCalledOnce()
+    expect(app.exit).toHaveBeenCalledWith(0)
+  })
+
+  it('lets a tray quit cancel a restart before its delay elapses', () => {
+    vi.useFakeTimers()
+    const app = host()
+    const lifecycle = createDesktopAppLifecycle(app)
+
+    lifecycle.scheduleRestart(100)
+    lifecycle.quit()
+    vi.advanceTimersByTime(100)
+    lifecycle.finalizeExit()
+
+    expect(app.quit).toHaveBeenCalledOnce()
+    expect(app.relaunch).not.toHaveBeenCalled()
+    expect(app.exit).toHaveBeenCalledWith(0)
+  })
+
+  it('lets a tray quit override a restart while shutdown is in progress', () => {
+    vi.useFakeTimers()
+    const app = host()
+    const lifecycle = createDesktopAppLifecycle(app)
+
+    lifecycle.scheduleRestart(100)
+    vi.advanceTimersByTime(100)
+    expect(lifecycle.isQuitting).toBe(true)
+
+    lifecycle.quit()
+    lifecycle.prepareShutdown()
+    lifecycle.finalizeExit()
+
+    expect(app.quit).toHaveBeenCalledTimes(2)
+    expect(app.relaunch).not.toHaveBeenCalled()
+    expect(app.exit).toHaveBeenCalledWith(0)
+  })
+
+  it('finalizes only once when Electron emits overlapping quit events', () => {
+    vi.useFakeTimers()
+    const app = host()
+    const lifecycle = createDesktopAppLifecycle(app)
+
+    lifecycle.scheduleRestart(0)
+    vi.runAllTimers()
+
+    expect(lifecycle.finalizeExit()).toBe(true)
+    expect(lifecycle.finalizeExit()).toBe(false)
+    expect(app.relaunch).toHaveBeenCalledOnce()
+    expect(app.exit).toHaveBeenCalledOnce()
+    expect(app.relaunch.mock.invocationCallOrder[0]).toBeLessThan(app.exit.mock.invocationCallOrder[0])
+  })
+})

--- a/tests/desktop/updater.test.ts
+++ b/tests/desktop/updater.test.ts
@@ -42,7 +42,7 @@ describe('desktop updater helpers', () => {
     expect(mainSource).toContain('async function prepareAppShutdown(): Promise<void>')
     expect(mainSource).toContain('await stopWebUiServer().catch(() => undefined)')
     expect(mainSource).toContain('initAutoUpdater({ beforeQuitAndInstall: prepareAppShutdown })')
-    expect(mainSource).toContain('try {\n      await prepareAppShutdown()\n    } finally {\n      app.exit(0)')
+    expect(mainSource).toContain('try {\n      await prepareAppShutdown()\n    } finally {\n      appLifecycle.finalizeExit(0)')
 
     const prepareCurrentInstance = updaterSource.indexOf('await options.beforeQuitAndInstall?.()')
     const stopOtherInstances = updaterSource.indexOf('await stopOtherWindowsAppInstances()', prepareCurrentInstance)


### PR DESCRIPTION
## Summary

- defer app.relaunch until graceful desktop shutdown has completed
- let an explicit tray quit cancel both pending and in-progress restart requests
- guard exit finalization against overlapping Electron quit events
- route startup failures through the coordinated quit path

## Context

After accepting the legacy Windows data migration, Studio schedules an app restart. Previously app.relaunch was registered before shutdown, so selecting Quit from the tray during shutdown could not cancel the relaunch and Studio opened again.

## Validation

- npm --prefix packages/desktop run build:main
- npx vitest run tests/desktop
- 145 tests passed, 1 platform-specific test skipped