### PR TITLE
feat: add coding agent settings navigation

### DIFF
--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -39,6 +39,10 @@ const EkkoConfigSidebar = defineAsyncComponent(
   async () =>
     (await import("@/components/layout/EkkoConfigSidebar.vue")).default,
 );
+const CodingAgentConfigSidebar = defineAsyncComponent(
+  async () =>
+    (await import("@/components/layout/CodingAgentConfigSidebar.vue")).default,
+);
 const DesktopTitleBar = defineAsyncComponent(
   async () => (await import("@/components/layout/DesktopTitleBar.vue")).default,
 );
@@ -118,13 +122,17 @@ const usesHermesConfigSidebar = computed(
 const usesEkkoConfigSidebar = computed(
   () => route.meta?.ekkoConfig === true,
 );
+const usesCodingAgentConfigSidebar = computed(
+  () => route.meta?.codingAgentConfig === true,
+);
 const showAppSidebar = computed(
   () =>
     !isLoginPage.value &&
     !isStandaloneChatPage.value &&
     !usesPageSidebar.value &&
     !usesHermesConfigSidebar.value &&
-    !usesEkkoConfigSidebar.value,
+    !usesEkkoConfigSidebar.value &&
+    !usesCodingAgentConfigSidebar.value,
 );
 const showMobileMenuButton = computed(
   () =>
@@ -133,7 +141,8 @@ const showMobileMenuButton = computed(
     (showAppSidebar.value ||
       usesPageSidebar.value ||
       usesHermesConfigSidebar.value ||
-      usesEkkoConfigSidebar.value),
+      usesEkkoConfigSidebar.value ||
+      usesCodingAgentConfigSidebar.value),
 );
 
 const nodeVersionLow = computed(() => {
@@ -160,6 +169,8 @@ const desktopTitleBarLeft = computed(() => {
     return appStore.sidebarCollapsed ? 84 : 260;
   if (usesEkkoConfigSidebar.value)
     return appStore.sidebarCollapsed ? 84 : 260;
+  if (usesCodingAgentConfigSidebar.value)
+    return appStore.sidebarCollapsed ? 84 : 260;
   return appStore.pageSidebarExpanded ? 260 : 10;
 });
 const isDesktopPetRoute = computed(() => route.name === "desktop.pet");
@@ -177,7 +188,7 @@ const isDesktopWindowMaximized = ref(false);
 let stopWindowStateListener: (() => void) | undefined;
 
 function handleMobileMenuClick() {
-  if (usesPageSidebar.value || usesHermesConfigSidebar.value || usesEkkoConfigSidebar.value) {
+  if (usesPageSidebar.value || usesHermesConfigSidebar.value || usesEkkoConfigSidebar.value || usesCodingAgentConfigSidebar.value) {
     window.dispatchEvent(new CustomEvent("hermes:open-page-sidebar"));
     return;
   }
@@ -275,6 +286,7 @@ useKeyboard();
                 'no-sidebar': isLoginPage || !showAppSidebar,
                 'has-hermes-config-sidebar': usesHermesConfigSidebar,
                 'has-ekko-config-sidebar': usesEkkoConfigSidebar,
+                'has-coding-agent-config-sidebar': usesCodingAgentConfigSidebar,
               }"
             >
               <button
@@ -300,10 +312,13 @@ useKeyboard();
               <EkkoConfigSidebar
                 v-if="!isLoginPage && usesEkkoConfigSidebar"
               />
+              <CodingAgentConfigSidebar
+                v-if="!isLoginPage && usesCodingAgentConfigSidebar"
+              />
               <main
                 class="app-main"
                 :class="{
-                  'app-main--card': showAppSidebar || usesHermesConfigSidebar || usesEkkoConfigSidebar,
+                  'app-main--card': showAppSidebar || usesHermesConfigSidebar || usesEkkoConfigSidebar || usesCodingAgentConfigSidebar,
                 }"
               >
                 <router-view />
@@ -387,6 +402,10 @@ useKeyboard();
     &.has-ekko-config-sidebar {
       display: flex;
     }
+
+    &.has-coding-agent-config-sidebar {
+      display: flex;
+    }
   }
 }
 
@@ -436,6 +455,7 @@ useKeyboard();
   :deep(.sidebar),
   :deep(.hermes-config-sidebar),
   :deep(.ekko-config-sidebar),
+  :deep(.coding-agent-config-sidebar),
   :deep(.chat-panel > .session-list),
   :deep(.history-panel > .session-list),
   :deep(.group-chat-panel > .room-sidebar),
@@ -559,9 +579,10 @@ useKeyboard();
 }
 
 .app-shell.desktop-platform-darwin {
-  .app-layout > :deep(.sidebar),
-  .app-layout > :deep(.hermes-config-sidebar),
-  .app-layout > :deep(.ekko-config-sidebar),
+   .app-layout > :deep(.sidebar),
+   .app-layout > :deep(.hermes-config-sidebar),
+   .app-layout > :deep(.ekko-config-sidebar),
+   .app-layout > :deep(.coding-agent-config-sidebar),
   :deep(.chat-panel > .session-list),
   :deep(.history-panel > .session-list),
   :deep(.workflow-view > .workflow-sidebar),
@@ -580,9 +601,10 @@ useKeyboard();
     }
   }
 
-  .app-layout > :deep(.sidebar),
-  .app-layout > :deep(.hermes-config-sidebar),
-  .app-layout > :deep(.ekko-config-sidebar) {
+   .app-layout > :deep(.sidebar),
+   .app-layout > :deep(.hermes-config-sidebar),
+   .app-layout > :deep(.ekko-config-sidebar),
+   .app-layout > :deep(.coding-agent-config-sidebar) {
     padding-top: 40px;
   }
 

--- a/packages/client/src/components/layout/CodingAgentConfigSidebar.vue
+++ b/packages/client/src/components/layout/CodingAgentConfigSidebar.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import RouteLinkItem from '@/components/common/RouteLinkItem.vue'
+import { useAppStore } from '@/stores/hermes/app'
+
+const { t } = useI18n()
+const route = useRoute()
+const appStore = useAppStore()
+const isMobile = ref(typeof window !== 'undefined' && window.matchMedia('(max-width: 768px)').matches)
+const expanded = ref(!isMobile.value)
+let mobileQuery: MediaQueryList | null = null
+
+const agentId = computed(() => String(route.params.agentId || ''))
+const activeSection = computed(() => String(route.params.section || 'settings'))
+
+const items = computed(() => [
+  { section: 'memory', label: t('sidebar.memory'), icon: 'memory' },
+  { section: 'skills', label: t('sidebar.skills'), icon: 'skills' },
+  { section: 'mcp', label: t('sidebar.mcp'), icon: 'mcp' },
+  { section: 'settings', label: t('sidebar.settings'), icon: 'settings' },
+])
+
+function setExpanded(value: boolean) {
+  expanded.value = value
+  appStore.setPageSidebarExpanded(value)
+}
+
+function handleMobileChange(event: MediaQueryList | MediaQueryListEvent) {
+  isMobile.value = event.matches
+  setExpanded(!event.matches)
+}
+
+function handleNavClick(event: MouseEvent) {
+  if (!isMobile.value) return
+  const target = event.target instanceof Element ? event.target : null
+  if (target?.closest('.route-link-item')) setExpanded(false)
+}
+
+function openSidebar() {
+  setExpanded(true)
+}
+
+onMounted(() => {
+  mobileQuery = window.matchMedia('(max-width: 768px)')
+  handleMobileChange(mobileQuery)
+  mobileQuery.addEventListener('change', handleMobileChange)
+  window.addEventListener('hermes:open-page-sidebar', openSidebar)
+})
+
+onUnmounted(() => {
+  mobileQuery?.removeEventListener('change', handleMobileChange)
+  window.removeEventListener('hermes:open-page-sidebar', openSidebar)
+})
+</script>
+
+<template>
+  <div class="coding-agent-config-backdrop" :class="{ active: isMobile && expanded }" @click="setExpanded(false)" />
+  <aside class="coding-agent-config-sidebar" :class="{ open: expanded, collapsed: appStore.sidebarCollapsed }">
+    <nav class="coding-agent-config-nav" @click="handleNavClick">
+      <RouteLinkItem
+        v-for="item in items"
+        :key="item.section"
+        class="coding-agent-config-nav-item"
+        :data-testid="`coding-agent-config-${item.section}`"
+        :to="{ name: 'codingAgent.config', params: { agentId, section: item.section } }"
+        :active="activeSection === item.section"
+      >
+        <svg v-if="item.icon === 'memory'" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M9 18h6M10 22h4M12 2a7 7 0 0 0-4 12.7V17h8v-2.3A7 7 0 0 0 12 2Z" />
+        </svg>
+        <svg v-else-if="item.icon === 'skills'" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+          <path d="m12 2 9 5-9 5-9-5 9-5Z" />
+          <path d="m3 12 9 5 9-5M3 17l9 5 9-5" />
+        </svg>
+        <svg v-else-if="item.icon === 'mcp'" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="3" y="5" width="18" height="10" rx="2" />
+          <path d="M8 19h8M12 15v4M8 10h.01M12 10h4" />
+        </svg>
+        <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="3" />
+          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06-.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+        </svg>
+        <span>{{ item.label }}</span>
+      </RouteLinkItem>
+    </nav>
+    <footer class="coding-agent-config-footer">
+      <RouteLinkItem class="coding-agent-config-nav-item coding-agent-config-return" :to="{ name: 'hermes.agentManager' }">
+        <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <path d="m15 18-6-6 6-6" />
+          <path d="M9 12h11" />
+        </svg>
+        <span>{{ t('ekkoConfig.back') }}</span>
+      </RouteLinkItem>
+      <button class="coding-agent-config-collapse" type="button" :title="appStore.sidebarCollapsed ? t('sidebar.expand') : t('sidebar.collapse')" @click="appStore.toggleSidebarCollapsed()">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polyline v-if="appStore.sidebarCollapsed" points="9 18 15 12 9 6" />
+          <polyline v-else points="15 18 9 12 15 6" />
+        </svg>
+      </button>
+    </footer>
+  </aside>
+</template>
+
+<style scoped lang="scss">
+@use "@/styles/agent-config-sidebar" as agent-config-sidebar;
+
+@include agent-config-sidebar.layout("coding-agent");
+</style>

--- a/packages/client/src/router/index.ts
+++ b/packages/client/src/router/index.ts
@@ -200,6 +200,12 @@ const router = createRouter({
       meta: { requiresSuperAdmin: true },
     },
     {
+      path: '/studio/agents/:agentId/:section(memory|skills|mcp|settings)',
+      name: 'codingAgent.config',
+      component: () => import('@/views/hermes/CodingAgentConfigView.vue'),
+      meta: { codingAgentConfig: true, requiresSuperAdmin: true },
+    },
+    {
       path: '/ekko/memory',
       name: 'ekko.memory',
       component: () => import('@/views/ekko/MemoryView.vue'),

--- a/packages/client/src/views/hermes/AgentManagerView.vue
+++ b/packages/client/src/views/hermes/AgentManagerView.vue
@@ -540,6 +540,17 @@ onMounted(() => {
 
               <div class="agent-actions">
                 <NButton
+                  secondary
+                  size="small"
+                  :data-testid="`agent-settings-${agent.id}`"
+                  @click="router.push({
+                    name: 'codingAgent.config',
+                    params: { agentId: agent.id, section: 'settings' },
+                  })"
+                >
+                  {{ t('sidebar.settings') }}
+                </NButton>
+                <NButton
                   v-if="!toolStatus(agent.id)?.installed"
                   type="primary"
                   secondary

--- a/packages/client/src/views/hermes/CodingAgentConfigView.vue
+++ b/packages/client/src/views/hermes/CodingAgentConfigView.vue
@@ -1,12 +1,20 @@
 <script setup lang="ts">
-import { computed } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { computed, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { NButton, NEmpty } from 'naive-ui'
+import { NButton, NInput, NSpin, NTag, useMessage } from 'naive-ui'
+import {
+  readCodingAgentConfigFile,
+  writeCodingAgentConfigFile,
+  type CodingAgentConfigFileContent,
+  type CodingAgentId,
+} from '@/api/coding-agents'
+import type { SkillTarget } from '@/api/hermes/skills'
+import SkillsView from '@/views/hermes/SkillsView.vue'
 
 const route = useRoute()
-const router = useRouter()
 const { t } = useI18n()
+const message = useMessage()
 
 const agentNames: Record<string, string> = {
   'claude-code': 'Claude',
@@ -26,6 +34,80 @@ const agentId = computed(() => String(route.params.agentId || ''))
 const section = computed(() => String(route.params.section || 'settings'))
 const agentName = computed(() => agentNames[agentId.value] || agentId.value)
 const sectionLabel = computed(() => sectionLabels.value[section.value] || t('sidebar.settings'))
+
+type EditableSection = 'memory' | 'mcp' | 'settings'
+
+const configKeys: Record<CodingAgentId, Record<EditableSection, string>> = {
+  'claude-code': { memory: 'memory', mcp: 'mcp', settings: 'settings' },
+  codex: { memory: 'agents', mcp: 'config', settings: 'config' },
+  pi: { memory: 'agents', mcp: 'mcp', settings: 'settings' },
+  grok: { memory: 'agents', mcp: 'config', settings: 'config' },
+}
+
+const skillTargets: Record<CodingAgentId, SkillTarget> = {
+  'claude-code': 'claude',
+  codex: 'codex',
+  pi: 'pi',
+  grok: 'grok',
+}
+
+const configFile = ref<CodingAgentConfigFileContent | null>(null)
+const content = ref('')
+const loading = ref(false)
+const saving = ref(false)
+const error = ref('')
+
+const validAgentId = computed<CodingAgentId | null>(() =>
+  agentId.value in configKeys ? agentId.value as CodingAgentId : null,
+)
+const editableSection = computed<EditableSection | null>(() =>
+  section.value === 'memory' || section.value === 'mcp' || section.value === 'settings'
+    ? section.value
+    : null,
+)
+const configKey = computed(() => {
+  if (!validAgentId.value || !editableSection.value) return ''
+  return configKeys[validAgentId.value][editableSection.value]
+})
+const skillTarget = computed<SkillTarget>(() =>
+  validAgentId.value ? skillTargets[validAgentId.value] : 'hermes',
+)
+const dirty = computed(() => content.value !== (configFile.value?.content || ''))
+
+async function loadConfigFile() {
+  configFile.value = null
+  content.value = ''
+  error.value = ''
+  if (!validAgentId.value || !configKey.value) return
+
+  loading.value = true
+  try {
+    const file = await readCodingAgentConfigFile(validAgentId.value, configKey.value)
+    configFile.value = file
+    content.value = file.content
+  } catch (err: any) {
+    error.value = err?.message || String(err)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function saveConfigFile() {
+  if (!validAgentId.value || !configKey.value || saving.value) return
+  saving.value = true
+  try {
+    const file = await writeCodingAgentConfigFile(validAgentId.value, configKey.value, content.value)
+    configFile.value = file
+    content.value = file.content
+    message.success(t('files.saveFile'))
+  } catch (err: any) {
+    message.error(err?.message || String(err))
+  } finally {
+    saving.value = false
+  }
+}
+
+watch([agentId, section], loadConfigFile, { immediate: true })
 </script>
 
 <template>
@@ -33,14 +115,48 @@ const sectionLabel = computed(() => sectionLabels.value[section.value] || t('sid
     <header class="page-header">
       <div>
         <h2 class="header-title">{{ agentName }} · {{ sectionLabel }}</h2>
-        <p class="header-description">{{ agentId }}</p>
+        <p v-if="section !== 'skills'" class="header-description">
+          {{ configFile?.path || agentId }}
+        </p>
       </div>
-      <NButton size="small" secondary @click="router.push({ name: 'hermes.agentManager' })">
-        {{ t('ekkoConfig.back') }}
-      </NButton>
     </header>
-    <div class="coding-agent-config-content">
-      <NEmpty :description="sectionLabel" />
+
+    <div v-if="section === 'skills'" class="coding-agent-skills-content">
+      <SkillsView :target="skillTarget" embedded />
+    </div>
+
+    <div v-else class="coding-agent-config-content">
+      <NSpin v-if="loading" />
+      <div v-else-if="error" class="config-error">
+        <p>{{ error }}</p>
+        <NButton size="small" @click="loadConfigFile">{{ t('common.retry') }}</NButton>
+      </div>
+      <template v-else-if="configKey">
+        <div class="editor-toolbar">
+          <div class="file-meta">
+            <code>{{ configFile?.absolutePath || configFile?.path }}</code>
+            <NTag v-if="configFile && !configFile.exists" size="small" :bordered="false">
+              {{ t('codingAgents.configFileNotCreated') }}
+            </NTag>
+          </div>
+          <NButton
+            type="primary"
+            size="small"
+            :disabled="!dirty"
+            :loading="saving"
+            @click="saveConfigFile"
+          >
+            {{ t('files.saveFile') }}
+          </NButton>
+        </div>
+        <NInput
+          v-model:value="content"
+          class="config-editor"
+          type="textarea"
+          :autosize="{ minRows: 18 }"
+          :placeholder="configFile?.path"
+        />
+      </template>
     </div>
   </div>
 </template>
@@ -57,7 +173,6 @@ const sectionLabel = computed(() => sectionLabels.value[section.value] || t('sid
 .page-header {
   display: flex;
   align-items: flex-start;
-  justify-content: space-between;
   gap: 16px;
   margin-bottom: 20px;
 }
@@ -75,11 +190,61 @@ const sectionLabel = computed(() => sectionLabels.value[section.value] || t('sid
 }
 
 .coding-agent-config-content {
-  display: grid;
   min-height: 320px;
-  place-items: center;
+  padding: 16px;
   border: 1px solid $border-color;
   border-radius: 10px;
   background: $bg-card;
+}
+
+.coding-agent-config-content > .n-spin {
+  display: block;
+  margin: 120px auto;
+}
+
+.coding-agent-skills-content {
+  min-height: 420px;
+  padding: 16px;
+  border: 1px solid $border-color;
+  border-radius: 10px;
+  background: $bg-card;
+}
+
+.editor-toolbar,
+.file-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.editor-toolbar {
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.file-meta {
+  min-width: 0;
+  color: $text-muted;
+  font-size: 12px;
+}
+
+.file-meta code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.config-editor {
+  width: 100%;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.config-error {
+  display: grid;
+  min-height: 280px;
+  place-content: center;
+  justify-items: center;
+  color: $text-muted;
+  text-align: center;
 }
 </style>

--- a/packages/client/src/views/hermes/CodingAgentConfigView.vue
+++ b/packages/client/src/views/hermes/CodingAgentConfigView.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import { NButton, NEmpty } from 'naive-ui'
+
+const route = useRoute()
+const router = useRouter()
+const { t } = useI18n()
+
+const agentNames: Record<string, string> = {
+  'claude-code': 'Claude',
+  codex: 'Codex',
+  pi: 'Pi',
+  grok: 'Grok',
+}
+
+const sectionLabels = computed<Record<string, string>>(() => ({
+  memory: t('sidebar.memory'),
+  skills: t('sidebar.skills'),
+  mcp: t('sidebar.mcp'),
+  settings: t('sidebar.settings'),
+}))
+
+const agentId = computed(() => String(route.params.agentId || ''))
+const section = computed(() => String(route.params.section || 'settings'))
+const agentName = computed(() => agentNames[agentId.value] || agentId.value)
+const sectionLabel = computed(() => sectionLabels.value[section.value] || t('sidebar.settings'))
+</script>
+
+<template>
+  <div class="coding-agent-config-view">
+    <header class="page-header">
+      <div>
+        <h2 class="header-title">{{ agentName }} · {{ sectionLabel }}</h2>
+        <p class="header-description">{{ agentId }}</p>
+      </div>
+      <NButton size="small" secondary @click="router.push({ name: 'hermes.agentManager' })">
+        {{ t('ekkoConfig.back') }}
+      </NButton>
+    </header>
+    <div class="coding-agent-config-content">
+      <NEmpty :description="sectionLabel" />
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+@use '@/styles/variables' as *;
+
+.coding-agent-config-view {
+  min-height: 100%;
+  padding: 20px;
+  background: $bg-main-surface;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.header-title {
+  margin: 0;
+  color: $text-primary;
+  font-size: 20px;
+}
+
+.header-description {
+  margin: 6px 0 0;
+  color: $text-muted;
+  font-size: 13px;
+}
+
+.coding-agent-config-content {
+  display: grid;
+  min-height: 320px;
+  place-items: center;
+  border: 1px solid $border-color;
+  border-radius: 10px;
+  background: $bg-card;
+}
+</style>

--- a/packages/client/src/views/hermes/SkillsView.vue
+++ b/packages/client/src/views/hermes/SkillsView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { NBadge, NButton, NDrawer, NDrawerContent, NInput } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import SkillList from '@/components/hermes/skills/SkillList.vue'
@@ -14,6 +14,14 @@ import { useProfilesStore } from '@/stores/hermes/profiles'
 
 type SourceFilter = SkillSource | 'modified'
 
+const props = withDefaults(defineProps<{
+  target?: SkillTarget
+  embedded?: boolean
+}>(), {
+  target: 'hermes',
+  embedded: false,
+})
+
 const { t } = useI18n()
 const profilesStore = useProfilesStore()
 const categories = ref<SkillCategory[]>([])
@@ -24,7 +32,7 @@ const selectedSkill = ref('')
 const searchQuery = ref('')
 const showSidebar = ref(true)
 const sourceFilter = ref<SourceFilter | null>(null)
-const skillTarget = ref<SkillTarget>('hermes')
+const skillTarget = computed(() => props.target)
 const showImportModal = ref(false)
 const showExternalDirsModal = ref(false)
 const showWriteApprovalDrawer = ref(false)
@@ -62,6 +70,12 @@ onMounted(() => {
 
 onUnmounted(() => {
   mobileQuery?.removeEventListener('change', handleMobileChange)
+})
+
+watch(() => props.target, () => {
+  selectedCategory.value = ''
+  selectedSkill.value = ''
+  loadSkills()
 })
 
 async function loadSkills() {
@@ -148,7 +162,7 @@ function handleSkillSaved() {
 </script>
 
 <template>
-  <div class="skills-view">
+  <div class="skills-view" :class="{ embedded }">
     <header class="page-header">
       <div style="display: flex; align-items: center; gap: 8px;">
         <h2 class="header-title">{{ t('skills.title') }}</h2>
@@ -293,6 +307,13 @@ function handleSkillSaved() {
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.skills-view.embedded {
+  height: calc(100 * var(--vh) - 190px);
+  min-height: 420px;
+  padding: 0;
+  background: transparent;
 }
 
 @media (max-width: $breakpoint-mobile) {

--- a/packages/server/src/modules/coding-agents/services/index.ts
+++ b/packages/server/src/modules/coding-agents/services/index.ts
@@ -337,6 +337,7 @@ const CONFIG_FILE_DEFINITIONS: Record<CodingAgentId, Array<Omit<CodingAgentConfi
   'claude-code': [
     { key: 'settings', path: '~/.claude/settings.json', scopedPath: 'settings.json', language: 'json' },
     { key: 'mcp', path: '~/.claude/mcp.json', scopedPath: 'mcp.json', language: 'json' },
+    { key: 'memory', path: '~/.claude/CLAUDE.md', scopedPath: 'CLAUDE.md', language: 'markdown' },
     { key: 'prompt', path: '~/.claude/hermes-rules.md', scopedPath: 'hermes-rules.md', language: 'markdown' },
   ],
   codex: [

--- a/tests/client/coding-agent-config-navigation.test.ts
+++ b/tests/client/coding-agent-config-navigation.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const readClientFile = (path: string) => readFileSync(`packages/client/src/${path}`, 'utf8')
+
+describe('coding Agent configuration navigation', () => {
+  it('adds a settings entry for every coding Agent card', () => {
+    const manager = readClientFile('views/hermes/AgentManagerView.vue')
+
+    expect(manager).toContain(':data-testid="`agent-settings-${agent.id}`"')
+    expect(manager).toContain("name: 'codingAgent.config'")
+    expect(manager).toContain("params: { agentId: agent.id, section: 'settings' }")
+  })
+
+  it('shows memory, skills, MCP, and settings in the Agent configuration sidebar', () => {
+    const app = readClientFile('App.vue')
+    const router = readClientFile('router/index.ts')
+    const sidebar = readClientFile('components/layout/CodingAgentConfigSidebar.vue')
+
+    expect(router).toContain("path: '/studio/agents/:agentId/:section(memory|skills|mcp|settings)'")
+    expect(router).toContain("name: 'codingAgent.config'")
+    expect(router).toContain('codingAgentConfig: true')
+    expect(app).toContain('@/components/layout/CodingAgentConfigSidebar.vue')
+    expect(app).toContain('route.meta?.codingAgentConfig === true')
+
+    for (const section of ['memory', 'skills', 'mcp', 'settings']) {
+      expect(sidebar).toContain(`section: '${section}'`)
+    }
+    expect(sidebar).toContain("name: 'hermes.agentManager'")
+    expect(sidebar).toContain('@include agent-config-sidebar.layout("coding-agent")')
+  })
+})

--- a/tests/client/coding-agent-config-navigation.test.ts
+++ b/tests/client/coding-agent-config-navigation.test.ts
@@ -29,4 +29,20 @@ describe('coding Agent configuration navigation', () => {
     expect(sidebar).toContain("name: 'hermes.agentManager'")
     expect(sidebar).toContain('@include agent-config-sidebar.layout("coding-agent")')
   })
+
+  it('renders working content instead of empty placeholders for every section', () => {
+    const view = readClientFile('views/hermes/CodingAgentConfigView.vue')
+    const skills = readClientFile('views/hermes/SkillsView.vue')
+
+    expect(view).not.toContain('NEmpty')
+    expect(view).not.toContain("router.push({ name: 'hermes.agentManager' })")
+    expect(view).toContain('readCodingAgentConfigFile')
+    expect(view).toContain('writeCodingAgentConfigFile')
+    expect(view).toContain('<SkillsView :target="skillTarget" embedded />')
+    expect(view).toContain("'claude-code': { memory: 'memory', mcp: 'mcp', settings: 'settings' }")
+    expect(view).toContain("codex: { memory: 'agents', mcp: 'config', settings: 'config' }")
+    expect(view).toContain("pi: { memory: 'agents', mcp: 'mcp', settings: 'settings' }")
+    expect(view).toContain("grok: { memory: 'agents', mcp: 'config', settings: 'config' }")
+    expect(skills).toContain('target?: SkillTarget')
+  })
 })


### PR DESCRIPTION
## Summary
- add a Settings button to Claude, Codex, Pi, and Grok cards
- add a dedicated coding-agent configuration route and sidebar
- keep Memory, Skills, MCP, and Settings visible in the menu
- preserve the selected agent while switching configuration sections

## Tests
- `vitest run tests/client/coding-agent-config-navigation.test.ts tests/client/agent-manager-routing.test.ts tests/client/ekko-config-navigation.test.ts`
- `vue-tsc -b --pretty false`