### PR TITLE
fix: use official npm registry for Grok

### DIFF
--- a/packages/ekko-agent/skills/hermes-studio-installation/references/coding-agents.md
+++ b/packages/ekko-agent/skills/hermes-studio-installation/references/coding-agents.md
@@ -39,7 +39,7 @@ The Agents page install action effectively performs the following. The Pi adapte
 npm install -g @anthropic-ai/claude-code
 npm install -g @openai/codex
 npm install -g @earendil-works/pi-coding-agent@0.84.1
-npm install -g @xai-official/grok
+npm install -g @xai-official/grok --registry=https://registry.npmjs.org
 studio_home="${HERMES_WEB_UI_HOME:-$HOME/.hermes-web-ui}"
 npm install --prefix "$studio_home/coding-agent/pi-mcp-adapter" --save-exact pi-mcp-adapter@2.24.0
 ```
@@ -76,7 +76,12 @@ The Agents page **Check update** action behaves as follows:
 - Claude Code: compares the detected version with `npm view @anthropic-ai/claude-code version`.
 - Codex: compares the detected version with `npm view @openai/codex version`.
 - Pi: compares the detected version with Studio's pinned Pi version; it does not chase npm latest independently.
-- Grok: compares the detected version with `npm view @xai-official/grok version`.
+- Grok: compares the detected version with `npm view @xai-official/grok version --registry=https://registry.npmjs.org`.
+
+Studio uses the official npm Registry only for Grok installation and update
+checks. This avoids stale third-party mirror metadata selecting a
+platform-incompatible historical release. It does not modify the user's npm
+configuration or the registry used for other coding Agents.
 
 When an update is available, the update action reruns the same install operation. Revalidate the executable path and version afterward. For Pi, revalidate the adapter too.
 

--- a/packages/server/src/modules/coding-agents/services/index.ts
+++ b/packages/server/src/modules/coding-agents/services/index.ts
@@ -46,6 +46,7 @@ const PI_MCP_ADAPTER_VERSION = '2.24.0'
 const PI_MCP_ADAPTER_PACKAGE = `pi-mcp-adapter@${PI_MCP_ADAPTER_VERSION}`
 const PI_CODING_AGENT_VERSION = '0.84.1'
 const PI_CODING_AGENT_PACKAGE = `@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}`
+const GROK_NPM_REGISTRY = 'https://registry.npmjs.org'
 const PI_PROVIDER_ID = 'hermes-studio'
 const PI_PROXY_TARGET_FILE = 'proxy-target.json'
 const PI_DYNAMIC_PROMPT_FILE = 'dynamic-system-prompt.md'
@@ -2005,6 +2006,12 @@ export function getCodingAgentDefinition(id: string): CodingAgentDefinition | nu
   return TOOL_DEFINITIONS.find(tool => tool.id === id) || null
 }
 
+export function withCodingAgentRegistry(id: CodingAgentId, args: string[]): string[] {
+  return id === 'grok'
+    ? [...args, `--registry=${GROK_NPM_REGISTRY}`]
+    : [...args]
+}
+
 export function getCodingAgentConfigFileDefinitions(id: string): CodingAgentConfigFileDefinition[] {
   const tool = getCodingAgentDefinition(id)
   if (!tool) return []
@@ -2150,7 +2157,10 @@ export async function checkUpdateAgent(id: string): Promise<CodingAgentUpdateRes
       return { success: true, tool: status, latestVersion, updateAvailable }
     }
     const env = await commandEnv()
-    const { stdout } = await runNpm(['view', tool.packageName, 'version'], { timeout: 15_000, env })
+    const { stdout } = await runNpm(
+      withCodingAgentRegistry(tool.id, ['view', tool.packageName, 'version']),
+      { timeout: 15_000, env },
+    )
     const latestVersion = stdout.trim()
     const status = await getCodingAgentStatus(tool)
     const updateAvailable = !!latestVersion && status.installed && !versionGte(status.version, latestVersion)
@@ -2177,7 +2187,10 @@ export async function installCodingAgent(id: string): Promise<CodingAgentMutatio
   installingTools.add(tool.id)
   try {
     const env = await commandEnv()
-    await runNpm(['install', '-g', tool.id === 'pi' ? PI_CODING_AGENT_PACKAGE : tool.packageName], {
+    await runNpm(withCodingAgentRegistry(
+      tool.id,
+      ['install', '-g', tool.id === 'pi' ? PI_CODING_AGENT_PACKAGE : tool.packageName],
+    ), {
       timeout: 10 * 60 * 1000,
       env,
     })

--- a/tests/server/coding-agent-npm-registry.test.ts
+++ b/tests/server/coding-agent-npm-registry.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { withCodingAgentRegistry } from '../../packages/server/src/modules/coding-agents/services'
+
+describe('coding Agent npm registry policy', () => {
+  it('uses the official npm Registry for Grok package operations', () => {
+    expect(withCodingAgentRegistry('grok', ['install', '-g', '@xai-official/grok'])).toEqual([
+      'install',
+      '-g',
+      '@xai-official/grok',
+      '--registry=https://registry.npmjs.org',
+    ])
+    expect(withCodingAgentRegistry('grok', ['view', '@xai-official/grok', 'version'])).toEqual([
+      'view',
+      '@xai-official/grok',
+      'version',
+      '--registry=https://registry.npmjs.org',
+    ])
+  })
+
+  it.each(['claude-code', 'codex', 'pi'] as const)(
+    'keeps the configured npm Registry for %s',
+    (agentId) => {
+      expect(withCodingAgentRegistry(agentId, ['install', '-g', 'package'])).toEqual([
+        'install',
+        '-g',
+        'package',
+      ])
+    },
+  )
+})


### PR DESCRIPTION
## Summary
- use the official npm Registry for Grok installation
- use the same Registry for Grok update checks
- preserve the user-configured Registry for Claude Code, Codex, and Pi
- document the Grok-specific Registry behavior in the installation skill

## Root cause
The configured npmmirror metadata resolves `@xai-official/grok` latest to the historical macOS arm64-only `0.1.4`, causing `EBADPLATFORM` on Linux x64. The official npm Registry exposes a cross-platform latest release.

## Tests
- `vitest run tests/server/coding-agent-npm-registry.test.ts tests/server/coding-agents-desktop-path.test.ts` (5 passed)
- `git diff --check`

## Notes
A full server typecheck could not be completed in this worktree because its reused dependency tree does not contain the current `@modelcontextprotocol/client` and `@larksuiteoapi/node-sdk` packages; the reported errors are unrelated missing dependencies in unchanged files.