### PR TITLE
fix: resume Grok sessions after failed turns

### DIFF
--- a/packages/server/src/modules/coding-agents/services/codex/proxy.ts
+++ b/packages/server/src/modules/coding-agents/services/codex/proxy.ts
@@ -112,14 +112,28 @@ function anthropicMessagesUrl(target: CodexProxyTarget): string {
 }
 
 export function normalizeGrokResponsesRequest(body: any): any {
-  if (!body || typeof body !== 'object' || !Array.isArray(body.input)) return body
+  if (!body || typeof body !== 'object') return body
   let changed = false
-  const input = body.input.map((item: any) => {
+  const input = Array.isArray(body.input) ? body.input.map((item: any) => {
     if (!item || typeof item !== 'object' || item.role !== 'system') return item
     changed = true
     return { ...item, role: 'developer' }
+  }) : body.input
+  const normalized = changed ? { ...body, input } : body
+  if (!Object.prototype.hasOwnProperty.call(normalized, 'max_output_tokens')) return normalized
+  const { max_output_tokens: _maxOutputTokens, ...withoutMaxOutputTokens } = normalized
+  return withoutMaxOutputTokens
+}
+
+export function normalizeGrokChatCompletionsRequest(body: any): any {
+  if (!body || typeof body !== 'object' || !Array.isArray(body.messages)) return body
+  let changed = false
+  const messages = body.messages.map((message: any) => {
+    if (!message || typeof message !== 'object' || message.role !== 'system') return message
+    changed = true
+    return { ...message, role: 'developer' }
   })
-  return changed ? { ...body, input } : body
+  return changed ? { ...body, messages } : body
 }
 
 function nativeResponsesBody(target: CodexProxyTarget, body: any, stream?: boolean): any {
@@ -137,7 +151,8 @@ async function callOpenAiChat(target: CodexProxyTarget, body: any): Promise<any>
     ;(err as any).status = 501
     throw err
   }
-  const chatBody = responsesToOpenAiChat(body, target)
+  const adapted = responsesToOpenAiChat(body, target)
+  const chatBody = target.agentId === 'grok' ? normalizeGrokChatCompletionsRequest(adapted) : adapted
   return agentRunGateway.completeJson({
     url: chatCompletionsUrl(target),
     apiKey: target.apiKey,
@@ -219,7 +234,8 @@ async function openAiChatToResponsesSseStream(target: CodexProxyTarget, body: an
     throw err
   }
 
-  const chatBody = responsesToOpenAiChat(body, target, true)
+  const adapted = responsesToOpenAiChat(body, target, true)
+  const chatBody = target.agentId === 'grok' ? normalizeGrokChatCompletionsRequest(adapted) : adapted
   const stream = await agentRunGateway.streamBytes({
     url: chatCompletionsUrl(target),
     apiKey: target.apiKey,
@@ -276,7 +292,10 @@ export async function codexProxyResponses(ctx: Context) {
   try {
     // Sanitize once before API-mode dispatch so native Responses, Chat
     // Completions, and Anthropic adapters all receive the same bounded history.
-    const requestBody = stripHistoricalResponsesInlineImages(ctx.request.body || {})
+    const sanitizedBody = stripHistoricalResponsesInlineImages(ctx.request.body || {})
+    const requestBody = target.agentId === 'grok'
+      ? normalizeGrokResponsesRequest(sanitizedBody)
+      : sanitizedBody
     if ((requestBody as any).stream === true) {
       const stream = target.apiMode === 'anthropic_messages'
         ? await anthropicMessagesToResponsesSseStream(target, requestBody)

--- a/packages/server/src/modules/coding-agents/services/codex/proxy.ts
+++ b/packages/server/src/modules/coding-agents/services/codex/proxy.ts
@@ -111,6 +111,26 @@ function anthropicMessagesUrl(target: CodexProxyTarget): string {
   return resolveAnthropicMessagesUrl(target.baseUrl)
 }
 
+export function normalizeGrokResponsesRequest(body: any): any {
+  if (!body || typeof body !== 'object' || !Array.isArray(body.input)) return body
+  let changed = false
+  const input = body.input.map((item: any) => {
+    if (!item || typeof item !== 'object' || item.role !== 'system') return item
+    changed = true
+    return { ...item, role: 'developer' }
+  })
+  return changed ? { ...body, input } : body
+}
+
+function nativeResponsesBody(target: CodexProxyTarget, body: any, stream?: boolean): any {
+  const normalized = target.agentId === 'grok' ? normalizeGrokResponsesRequest(body) : body
+  return truncateResponsesToolOutputs({
+    ...normalized,
+    model: target.model,
+    ...(stream === undefined ? {} : { stream }),
+  })
+}
+
 async function callOpenAiChat(target: CodexProxyTarget, body: any): Promise<any> {
   if (target.apiMode !== 'chat_completions') {
     const err = new Error(`Codex proxy only supports chat_completions targets, got ${target.apiMode}`)
@@ -149,7 +169,7 @@ async function callOpenAiResponses(target: CodexProxyTarget, body: any): Promise
     ;(err as any).status = 501
     throw err
   }
-  const responsesBody = truncateResponsesToolOutputs({ ...body, model: target.model })
+  const responsesBody = nativeResponsesBody(target, body)
   return agentRunGateway.completeJson({
     url: resolveResponsesUrl(target.baseUrl),
     apiKey: target.apiKey,
@@ -241,7 +261,7 @@ async function openAiResponsesSseStream(target: CodexProxyTarget, body: any): Pr
     throw err
   }
 
-  const responsesBody = truncateResponsesToolOutputs({ ...body, model: target.model, stream: true })
+  const responsesBody = nativeResponsesBody(target, body, true)
   const stream = await agentRunGateway.streamBytes({
     url: resolveResponsesUrl(target.baseUrl),
     apiKey: target.apiKey,

--- a/packages/server/src/modules/coding-agents/services/codex/proxy.ts
+++ b/packages/server/src/modules/coding-agents/services/codex/proxy.ts
@@ -216,11 +216,16 @@ function responseEventForCodexClient(target: CodexProxyTarget, event: CanonicalR
 }
 
 function observableResponsesEvents(target: CodexProxyTarget, events: AsyncIterable<CanonicalResponsesEvent>): AsyncIterable<CanonicalResponsesEvent> {
-  async function* observe() {
+async function* observe() {
     for await (const event of normalizeResponsesSseEvents(events)) {
       codingAgentRunManager.handleProxyUsageEvent(target.agentSessionId, event)
       const clientEvent = responseEventForCodexClient(target, event)
-      codingAgentRunManager.handleResponseEvent(target.agentSessionId, clientEvent)
+      // Grok prints the same streamed text through its `streaming-json`
+      // stdout. Feeding proxy events directly into the run as well would
+      // append every model delta twice.
+      if (target.agentId !== 'grok') {
+        codingAgentRunManager.handleResponseEvent(target.agentSessionId, clientEvent)
+      }
       yield clientEvent
     }
   }

--- a/packages/server/src/modules/coding-agents/services/grok/turn-process.ts
+++ b/packages/server/src/modules/coding-agents/services/grok/turn-process.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto'
-import { readFileSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { spawn, type ChildProcess } from 'child_process'
 import type { CodingAgentImageInput } from '../../protocol/types'
@@ -80,6 +80,23 @@ export function buildGrokTurnArgs(
     '--output-format', 'streaming-json',
     '--prompt-file', promptPath,
   ]
+}
+
+export function grokSessionExists(rootDir: string, workspaceDir: string, nativeSessionId: string): boolean {
+  const sessionId = String(nativeSessionId || '').trim()
+  if (!sessionId) return false
+  const sessionsRoot = join(rootDir, 'sessions')
+  const directPath = join(sessionsRoot, encodeURIComponent(workspaceDir), sessionId)
+  if (existsSync(directPath)) return true
+
+  // Grok replaces very long encoded workspace names with a slug plus hash.
+  // Check each workspace bucket so failed first turns can still be resumed.
+  try {
+    return readdirSync(sessionsRoot, { withFileTypes: true })
+      .some(entry => entry.isDirectory() && existsSync(join(sessionsRoot, entry.name, sessionId)))
+  } catch {
+    return false
+  }
 }
 
 export function startGrokTurnProcess(input: GrokTurnProcessInput): ChildProcess {

--- a/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
+++ b/packages/server/src/modules/coding-agents/services/runtime/run-manager.ts
@@ -24,7 +24,7 @@ import { attachPiJsonlReader } from '../pi/jsonl-parser'
 import { normalizePiThinkingLevel } from '../pi/thinking'
 import { compactCodexThread } from './codex-compact'
 import { updateManagedPromptFileSync } from '../prompt-file'
-import { startGrokTurnProcess } from '../grok/turn-process'
+import { grokSessionExists, startGrokTurnProcess } from '../grok/turn-process'
 import { applyGrokStreamEvent } from '../grok/event-adapter'
 
 const DEFAULT_IDLE_MS = 30 * 60 * 1000
@@ -2372,15 +2372,20 @@ export class CodingAgentRunManager {
 
     const rootDir = String(run.launch.env?.GROK_HOME || '').trim()
     if (!rootDir) throw new Error('Grok runtime home is missing')
+    const workspaceDir = existsSync(run.launch.workspaceDir) ? run.launch.workspaceDir : homedir()
+    const nativeSessionId = String(run.launch.agentNativeSessionId || '')
+    if (!run.nativeResumeReady && grokSessionExists(rootDir, workspaceDir, nativeSessionId)) {
+      run.nativeResumeReady = true
+    }
     const child = startGrokTurnProcess({
       command: run.launch.command,
       baseArgs: run.launch.args,
       rootDir,
-      workspaceDir: existsSync(run.launch.workspaceDir) ? run.launch.workspaceDir : homedir(),
+      workspaceDir,
       env: run.launch.mode === 'global'
         ? { ...process.env, ...(run.launch.env || {}) }
         : isolatedCodingAgentChildEnv(run.launch.env),
-      nativeSessionId: String(run.launch.agentNativeSessionId || ''),
+      nativeSessionId,
       resume: run.nativeResumeReady === true,
       input,
       images,

--- a/tests/server/agent-runner/grok/grok-runtime.test.ts
+++ b/tests/server/agent-runner/grok/grok-runtime.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { mkdir } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
@@ -10,7 +10,10 @@ import {
 } from '../../../../packages/server/src/modules/coding-agents/services/grok/config'
 import { applyGrokStreamEvent } from '../../../../packages/server/src/modules/coding-agents/services/grok/event-adapter'
 import { parseGrokStreamingJsonLine } from '../../../../packages/server/src/modules/coding-agents/services/grok/streaming-json'
-import { buildGrokTurnArgs } from '../../../../packages/server/src/modules/coding-agents/services/grok/turn-process'
+import {
+  buildGrokTurnArgs,
+  grokSessionExists,
+} from '../../../../packages/server/src/modules/coding-agents/services/grok/turn-process'
 import { updateManagedPromptFileSync } from '../../../../packages/server/src/modules/coding-agents/services/prompt-file'
 
 const roots: string[] = []
@@ -118,6 +121,16 @@ describe('Grok streaming JSON adaptation', () => {
     ])
     expect(resumedTurn).toContain('--resume')
     expect(resumedTurn).not.toContain('--session-id')
+  })
+
+  it('detects persisted sessions after a failed first turn', () => {
+    const root = makeRoot()
+    const workspace = join(root, 'workspace with spaces')
+    const sessionId = '9bf2543c-3b57-43de-b5f6-838c2f73a554'
+    mkdirSync(join(root, 'sessions', encodeURIComponent(workspace), sessionId), { recursive: true })
+
+    expect(grokSessionExists(root, workspace, sessionId)).toBe(true)
+    expect(grokSessionExists(root, workspace, '11111111-1111-4111-8111-111111111111')).toBe(false)
   })
 
   it('parses the documented event stream and maps terminal tool updates', () => {

--- a/tests/server/coding-agent-run-manager-windows.test.ts
+++ b/tests/server/coding-agent-run-manager-windows.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
@@ -143,6 +143,49 @@ describe('coding agent Windows process launch', () => {
     } finally {
       if (originalDatabaseUrl === undefined) delete process.env.DATABASE_URL
       else process.env.DATABASE_URL = originalDatabaseUrl
+      rmSync(grokHome, { recursive: true, force: true })
+    }
+  })
+
+  it('resumes a Grok session that persisted before an error event ended the first turn', () => {
+    const grokHome = mkdtempSync(join(tmpdir(), 'hermes-grok-resume-'))
+    try {
+      const manager = new CodingAgentRunManager()
+      ;(manager as any).handleClaudePrintResponseEvent = vi.fn()
+      const sessionId = '11111111-1111-4111-8111-111111111111'
+      const workspaceDir = process.cwd()
+      mkdirSync(join(grokHome, 'sessions', encodeURIComponent(workspaceDir), sessionId), { recursive: true })
+      const run: any = {
+        id: 'agent-session-grok-resume',
+        launch: {
+          agentSessionId: 'agent-session-grok-resume',
+          agentNativeSessionId: sessionId,
+          agentId: 'grok',
+          mode: 'scoped',
+          profile: 'default',
+          provider: 'custom',
+          model: 'test-model',
+          sessionId: 'chat-session-grok-resume',
+          command: 'C:\\Tools\\grok.cmd',
+          args: ['--always-approve'],
+          shellCommand: 'grok',
+          workspaceDir,
+          env: { GROK_HOME: grokHome },
+        },
+        state: { messages: [], isWorking: false, events: [], queue: [] },
+        lastActiveAt: Date.now(),
+        startedAt: Date.now(),
+        exited: false,
+        nativeResumeReady: false,
+      }
+
+      ;(manager as any).startGrokPrintTurn(run, 'retry')
+
+      const commandLine = JSON.stringify(testState.spawnCalls[0]?.args)
+      expect(commandLine).toContain('--resume')
+      expect(commandLine).not.toContain('--session-id')
+      expect(run.nativeResumeReady).toBe(true)
+    } finally {
       rmSync(grokHome, { recursive: true, force: true })
     }
   })

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -8,6 +8,7 @@ import {
   codexProxyModels,
   codexProxyResponses,
   isAuthorizedCodexProxyRequest,
+  normalizeGrokChatCompletionsRequest,
   normalizeGrokResponsesRequest,
   registerCodexProxyTarget,
 } from '../../packages/server/src/modules/coding-agents/services/codex/proxy'
@@ -72,6 +73,7 @@ describe('coding agent launch preparation', () => {
   it('maps Grok system input messages to Responses developer messages', () => {
     const body = {
       instructions: 'Keep top-level instructions.',
+      max_output_tokens: 4096,
       input: [
         { role: 'system', content: [{ type: 'input_text', text: 'Grok project rules' }] },
         { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
@@ -79,13 +81,33 @@ describe('coding agent launch preparation', () => {
     }
 
     expect(normalizeGrokResponsesRequest(body)).toEqual({
-      ...body,
+      instructions: body.instructions,
       input: [
         { role: 'developer', content: [{ type: 'input_text', text: 'Grok project rules' }] },
         body.input[1],
       ],
     })
     expect(body.input[0].role).toBe('system')
+    expect(body.max_output_tokens).toBe(4096)
+  })
+
+  it('maps Grok Chat Completions system messages to developer messages', () => {
+    const body = {
+      model: 'grok-test',
+      messages: [
+        { role: 'system', content: 'Project rules' },
+        { role: 'user', content: 'Hello' },
+      ],
+    }
+
+    expect(normalizeGrokChatCompletionsRequest(body)).toEqual({
+      ...body,
+      messages: [
+        { role: 'developer', content: 'Project rules' },
+        body.messages[1],
+      ],
+    })
+    expect(body.messages[0].role).toBe('system')
   })
 
   it('gates Codex tool_search feature flags by CLI version', () => {
@@ -2127,19 +2149,57 @@ describe('coding agent launch preparation', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     await codexProxyResponses(makeProxyContext(target.routeKey, target.token, {
+      max_output_tokens: 4096,
       input: [
         { role: 'system', content: [{ type: 'input_text', text: 'Project rules' }] },
         { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
       ],
     }))
 
-    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
+    const forwarded = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(forwarded).toMatchObject({
       model: 'grok-test',
       input: [
         { role: 'developer', content: [{ type: 'input_text', text: 'Project rules' }] },
         { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
       ],
     })
+    expect(forwarded).not.toHaveProperty('max_output_tokens')
+  })
+
+  it('normalizes Grok requests before forwarding to Chat Completions providers', async () => {
+    const target = registerCodexProxyTarget({
+      profile: 'default',
+      provider: 'custom',
+      model: 'grok-chat-test',
+      baseUrl: 'https://api.example.com/v1',
+      apiKey: 'sk-upstream',
+      apiMode: 'chat_completions',
+      agentId: 'grok',
+    })
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      id: 'chatcmpl_grok',
+      choices: [{ finish_reason: 'stop', message: { role: 'assistant', content: 'ok' } }],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await codexProxyResponses(makeProxyContext(target.routeKey, target.token, {
+      instructions: 'Top-level rules',
+      max_output_tokens: 4096,
+      input: [
+        { role: 'system', content: [{ type: 'input_text', text: 'Project rules' }] },
+        { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+      ],
+    }))
+
+    const forwarded = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(forwarded.messages[0]).toMatchObject({
+      role: 'developer',
+      content: expect.stringContaining('Top-level rules'),
+    })
+    expect(forwarded.messages[0].content).toContain('Project rules')
+    expect(forwarded).not.toHaveProperty('max_tokens')
+    expect(forwarded).not.toHaveProperty('max_output_tokens')
   })
 
   it('exposes Codex proxy models with route-token authentication', async () => {

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -8,6 +8,7 @@ import {
   codexProxyModels,
   codexProxyResponses,
   isAuthorizedCodexProxyRequest,
+  normalizeGrokResponsesRequest,
   registerCodexProxyTarget,
 } from '../../packages/server/src/modules/coding-agents/services/codex/proxy'
 import {
@@ -68,6 +69,25 @@ function makeProxyContext(routeKey: string, token: string, body: any): any {
 }
 
 describe('coding agent launch preparation', () => {
+  it('maps Grok system input messages to Responses developer messages', () => {
+    const body = {
+      instructions: 'Keep top-level instructions.',
+      input: [
+        { role: 'system', content: [{ type: 'input_text', text: 'Grok project rules' }] },
+        { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+      ],
+    }
+
+    expect(normalizeGrokResponsesRequest(body)).toEqual({
+      ...body,
+      input: [
+        { role: 'developer', content: [{ type: 'input_text', text: 'Grok project rules' }] },
+        body.input[1],
+      ],
+    })
+    expect(body.input[0].role).toBe('system')
+  })
+
   it('gates Codex tool_search feature flags by CLI version', () => {
     expect(codexToolSearchConfig('0.127.0')).toEqual({ toolSearch: false, alwaysDefer: false })
     expect(codexToolSearchConfig('0.128.0')).toEqual({ toolSearch: true, alwaysDefer: true })
@@ -2087,6 +2107,39 @@ describe('coding agent launch preparation', () => {
       reasoning: { effort: 'high', summary: 'auto' },
     })
     expect(sse).toContain('"usage":{"input_tokens":11,"output_tokens":2,"total_tokens":13}')
+  })
+
+  it('maps Grok system messages before forwarding native Responses requests', async () => {
+    const target = registerCodexProxyTarget({
+      profile: 'default',
+      provider: 'openai-api',
+      model: 'grok-test',
+      baseUrl: 'https://api.openai.com/v1',
+      apiKey: 'sk-upstream',
+      apiMode: 'codex_responses',
+      agentId: 'grok',
+    })
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      id: 'resp_grok',
+      status: 'completed',
+      output: [],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await codexProxyResponses(makeProxyContext(target.routeKey, target.token, {
+      input: [
+        { role: 'system', content: [{ type: 'input_text', text: 'Project rules' }] },
+        { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+      ],
+    }))
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
+      model: 'grok-test',
+      input: [
+        { role: 'developer', content: [{ type: 'input_text', text: 'Project rules' }] },
+        { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+      ],
+    })
   })
 
   it('exposes Codex proxy models with route-token authentication', async () => {

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -23,6 +23,7 @@ import {
   normalizePiThinkingLevel,
   piModelSupportsThinking,
 } from '../../packages/server/src/modules/coding-agents/services/pi/thinking'
+import { codingAgentRunManager } from '../../packages/server/src/modules/coding-agents/services/runtime/run-manager'
 
 const homes: string[] = []
 
@@ -2200,6 +2201,40 @@ describe('coding agent launch preparation', () => {
     expect(forwarded.messages[0].content).toContain('Project rules')
     expect(forwarded).not.toHaveProperty('max_tokens')
     expect(forwarded).not.toHaveProperty('max_output_tokens')
+  })
+
+  it('does not append Grok proxy deltas before Grok prints them through stdout', async () => {
+    const target = registerCodexProxyTarget({
+      profile: 'default',
+      provider: 'openai-api',
+      model: 'grok-stream-test',
+      baseUrl: 'https://api.openai.com/v1',
+      apiKey: 'sk-upstream',
+      apiMode: 'codex_responses',
+      agentId: 'grok',
+      agentSessionId: 'agent-session-grok-stream',
+    })
+    const handleResponseEvent = vi.spyOn(codingAgentRunManager, 'handleResponseEvent')
+    const encoder = new TextEncoder()
+    const fetchMock = vi.fn(async () => new Response(new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"hello"}\n\n'))
+        controller.enqueue(encoder.encode('event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_grok","status":"completed","output":[]}}\n\n'))
+        controller.close()
+      },
+    }), { status: 200, headers: { 'Content-Type': 'text/event-stream' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const ctx = makeProxyContext(target.routeKey, target.token, {
+      stream: true,
+      input: [{ role: 'user', content: [{ type: 'input_text', text: 'Hello' }] }],
+    })
+    await codexProxyResponses(ctx)
+    for await (const _chunk of ctx.body) {
+      // Drain the proxy stream so all observable events are processed.
+    }
+
+    expect(handleResponseEvent).not.toHaveBeenCalled()
   })
 
   it('exposes Codex proxy models with route-token authentication', async () => {


### PR DESCRIPTION
## Summary

- detect Grok sessions that were persisted before a failed turn and resume them with `--resume` instead of reusing `--session-id`
- normalize Grok Responses `system` input messages to `developer` before forwarding upstream
- add focused runtime, Windows launch, and proxy regression coverage

## Root cause

A Grok session can be written to disk before the first turn emits an error. Because the error path does not emit the normal terminal session event, Studio kept `nativeResumeReady` false and retried the existing ID with `--session-id`. Grok rejects that with `Session ID ... is already in use`.

The original failed turn was also caused by a Responses request containing a `system` role, which Grok's upstream rejects. The proxy now performs a Grok-only conversion to `developer` without changing Codex or Pi requests.

## Validation

- `vue-tsc -b --pretty false`
- `vitest run tests/server/agent-runner/grok/grok-runtime.test.ts`
- focused Grok resume test in `coding-agent-run-manager-windows.test.ts`
- focused Grok request normalization tests in `coding-agents-launch.test.ts`
- `git diff --check`

No Grok user configuration, authentication, or session history is deleted or modified.
