### PR TITLE
fix: show effective Grok runtime configuration

### DIFF
--- a/packages/client/src/api/coding-agents.ts
+++ b/packages/client/src/api/coding-agents.ts
@@ -93,11 +93,15 @@ export interface CodingAgentConfigFileContent {
   profile: string
   provider: string
   rootDir: string
+  writable?: boolean
+  source?: 'global' | 'runtime'
+  sessionId?: string
 }
 
 export interface CodingAgentConfigScope {
   profile?: string | null
   provider?: string | null
+  sessionId?: string | null
 }
 
 export interface CodingAgentLaunchRequest {
@@ -161,6 +165,7 @@ export async function readCodingAgentConfigFile(
   const params = new URLSearchParams()
   if (scope.profile) params.set('profile', scope.profile)
   if (scope.provider) params.set('provider', scope.provider)
+  if (scope.sessionId) params.set('sessionId', scope.sessionId)
   const query = params.toString()
   return request<CodingAgentConfigFileContent>(
     `/api/coding-agents/${id}/config-files/${encodeURIComponent(key)}${query ? `?${query}` : ''}`,
@@ -175,7 +180,7 @@ export async function writeCodingAgentConfigFile(
 ): Promise<CodingAgentConfigFileContent> {
   return request<CodingAgentConfigFileContent>(`/api/coding-agents/${id}/config-files/${encodeURIComponent(key)}`, {
     method: 'PUT',
-    body: JSON.stringify({ content, profile: scope.profile, provider: scope.provider }),
+    body: JSON.stringify({ content, profile: scope.profile, provider: scope.provider, sessionId: scope.sessionId }),
   })
 }
 

--- a/packages/client/src/views/hermes/CodingAgentConfigView.vue
+++ b/packages/client/src/views/hermes/CodingAgentConfigView.vue
@@ -11,10 +11,12 @@ import {
 } from '@/api/coding-agents'
 import type { SkillTarget } from '@/api/hermes/skills'
 import SkillsView from '@/views/hermes/SkillsView.vue'
+import { useAppStore } from '@/stores/hermes/app'
 
 const route = useRoute()
 const { t } = useI18n()
 const message = useMessage()
+const appStore = useAppStore()
 
 const agentNames: Record<string, string> = {
   'claude-code': 'Claude',
@@ -41,7 +43,7 @@ const configKeys: Record<CodingAgentId, Record<EditableSection, string>> = {
   'claude-code': { memory: 'memory', mcp: 'mcp', settings: 'settings' },
   codex: { memory: 'agents', mcp: 'config', settings: 'config' },
   pi: { memory: 'agents', mcp: 'mcp', settings: 'settings' },
-  grok: { memory: 'agents', mcp: 'config', settings: 'config' },
+  grok: { memory: 'agents', mcp: 'mcp', settings: 'settings' },
 }
 
 const skillTargets: Record<CodingAgentId, SkillTarget> = {
@@ -73,6 +75,11 @@ const skillTarget = computed<SkillTarget>(() =>
   validAgentId.value ? skillTargets[validAgentId.value] : 'hermes',
 )
 const dirty = computed(() => content.value !== (configFile.value?.content || ''))
+const configScope = computed(() => (
+  agentId.value === 'grok' && section.value === 'mcp'
+    ? { provider: appStore.selectedProvider || undefined }
+    : {}
+))
 
 async function loadConfigFile() {
   configFile.value = null
@@ -82,7 +89,7 @@ async function loadConfigFile() {
 
   loading.value = true
   try {
-    const file = await readCodingAgentConfigFile(validAgentId.value, configKey.value)
+    const file = await readCodingAgentConfigFile(validAgentId.value, configKey.value, configScope.value)
     configFile.value = file
     content.value = file.content
   } catch (err: any) {
@@ -96,7 +103,7 @@ async function saveConfigFile() {
   if (!validAgentId.value || !configKey.value || saving.value) return
   saving.value = true
   try {
-    const file = await writeCodingAgentConfigFile(validAgentId.value, configKey.value, content.value)
+    const file = await writeCodingAgentConfigFile(validAgentId.value, configKey.value, content.value, configScope.value)
     configFile.value = file
     content.value = file.content
     message.success(t('files.saveFile'))

--- a/packages/client/src/views/hermes/CodingAgentConfigView.vue
+++ b/packages/client/src/views/hermes/CodingAgentConfigView.vue
@@ -11,12 +11,10 @@ import {
 } from '@/api/coding-agents'
 import type { SkillTarget } from '@/api/hermes/skills'
 import SkillsView from '@/views/hermes/SkillsView.vue'
-import { useAppStore } from '@/stores/hermes/app'
 
 const route = useRoute()
 const { t } = useI18n()
 const message = useMessage()
-const appStore = useAppStore()
 
 const agentNames: Record<string, string> = {
   'claude-code': 'Claude',
@@ -58,6 +56,7 @@ const content = ref('')
 const loading = ref(false)
 const saving = ref(false)
 const error = ref('')
+const grokEffectiveView = ref(true)
 
 const validAgentId = computed<CodingAgentId | null>(() =>
   agentId.value in configKeys ? agentId.value as CodingAgentId : null,
@@ -76,8 +75,8 @@ const skillTarget = computed<SkillTarget>(() =>
 )
 const dirty = computed(() => content.value !== (configFile.value?.content || ''))
 const configScope = computed(() => (
-  agentId.value === 'grok' && section.value === 'mcp'
-    ? { provider: appStore.selectedProvider || undefined }
+  agentId.value === 'grok' && grokEffectiveView.value
+    ? { sessionId: 'latest' }
     : {}
 ))
 
@@ -114,7 +113,7 @@ async function saveConfigFile() {
   }
 }
 
-watch([agentId, section], loadConfigFile, { immediate: true })
+watch([agentId, section, grokEffectiveView], loadConfigFile, { immediate: true })
 </script>
 
 <template>
@@ -142,24 +141,38 @@ watch([agentId, section], loadConfigFile, { immediate: true })
         <div class="editor-toolbar">
           <div class="file-meta">
             <code>{{ configFile?.absolutePath || configFile?.path }}</code>
+            <NTag v-if="configFile?.source === 'runtime'" type="info" size="small" :bordered="false">
+              {{ configFile.sessionId }}
+            </NTag>
             <NTag v-if="configFile && !configFile.exists" size="small" :bordered="false">
               {{ t('codingAgents.configFileNotCreated') }}
             </NTag>
           </div>
-          <NButton
-            type="primary"
-            size="small"
-            :disabled="!dirty"
-            :loading="saving"
-            @click="saveConfigFile"
-          >
-            {{ t('files.saveFile') }}
-          </NButton>
+          <div class="editor-actions">
+            <NButton
+              v-if="agentId === 'grok'"
+              size="small"
+              @click="grokEffectiveView = !grokEffectiveView"
+            >
+              {{ grokEffectiveView ? t('codingAgents.launchModeGlobal') : t('codingAgents.launchModeScoped') }}
+            </NButton>
+            <NButton
+              v-if="configFile?.writable !== false"
+              type="primary"
+              size="small"
+              :disabled="!dirty"
+              :loading="saving"
+              @click="saveConfigFile"
+            >
+              {{ t('files.saveFile') }}
+            </NButton>
+          </div>
         </div>
         <NInput
           v-model:value="content"
           class="config-editor"
           type="textarea"
+          :readonly="configFile?.writable === false"
           :autosize="{ minRows: 18 }"
           :placeholder="configFile?.path"
         />
@@ -218,7 +231,8 @@ watch([agentId, section], loadConfigFile, { immediate: true })
 }
 
 .editor-toolbar,
-.file-meta {
+.file-meta,
+.editor-actions {
   display: flex;
   align-items: center;
   gap: 10px;

--- a/packages/server/src/modules/coding-agents/controllers/agents.ts
+++ b/packages/server/src/modules/coding-agents/controllers/agents.ts
@@ -11,14 +11,15 @@ import {
   startCodingAgentRun,
   stopCodingAgentRun,
   writeCodingAgentConfigFile,
-  type CodingAgentConfigScope,
+  type CodingAgentConfigRequestScope,
 } from '../services'
 
-function configScope(ctx: Context): CodingAgentConfigScope {
-  const body = ctx.request.body as { profile?: unknown; provider?: unknown } | undefined
+function configScope(ctx: Context): CodingAgentConfigRequestScope {
+  const body = ctx.request.body as { profile?: unknown; provider?: unknown; sessionId?: unknown } | undefined
   return {
     profile: ctx.state.profile?.name || (typeof ctx.query.profile === 'string' ? ctx.query.profile : '') || (typeof body?.profile === 'string' ? body.profile : ''),
     provider: (typeof ctx.query.provider === 'string' ? ctx.query.provider : '') || (typeof body?.provider === 'string' ? body.provider : ''),
+    sessionId: (typeof ctx.query.sessionId === 'string' ? ctx.query.sessionId : '') || (typeof body?.sessionId === 'string' ? body.sessionId : ''),
   }
 }
 

--- a/packages/server/src/modules/coding-agents/services/grok/config.ts
+++ b/packages/server/src/modules/coding-agents/services/grok/config.ts
@@ -55,7 +55,7 @@ function mcpServerName(header: string): string {
   return String(match?.[1] || match?.[2] || '').trim()
 }
 
-export function stripManagedGrokMcp(content: string): string {
+function grokConfigBlocks(content: string): string[][] {
   const blocks: string[][] = []
   let current: string[] = []
   for (const line of String(content || '').split(/\r?\n/)) {
@@ -66,17 +66,58 @@ export function stripManagedGrokMcp(content: string): string {
     current.push(line)
   }
   if (current.length > 0) blocks.push(current)
-
   return blocks
+}
+
+function joinGrokConfigBlocks(blocks: string[][]): string {
+  return blocks
+    .map(block => block.join('\n').trimEnd())
+    .filter(block => block.trim())
+    .join('\n\n')
+    .trim()
+}
+
+function isManagedMcpBlock(block: string[]): boolean {
+  const name = mcpServerName(block[0] || '')
+  return Boolean(name) && (
+    MANAGED_MCP_NAMES.has(name) ||
+    block.join('\n').includes(MANAGED_MCP_MARKER)
+  )
+}
+
+export function grokSettingsConfig(content: string): string {
+  const value = joinGrokConfigBlocks(
+    grokConfigBlocks(content).filter(block => !mcpServerName(block[0] || '')),
+  )
+  return value ? `${value}\n` : ''
+}
+
+export function grokUserMcpConfig(content: string): string {
+  const value = joinGrokConfigBlocks(
+    grokConfigBlocks(content).filter(block => (
+      Boolean(mcpServerName(block[0] || '')) && !isManagedMcpBlock(block)
+    )),
+  )
+  return value ? `${value}\n` : ''
+}
+
+export function stripManagedGrokMcp(content: string): string {
+  return joinGrokConfigBlocks(grokConfigBlocks(content)
     .filter((block) => {
       const name = mcpServerName(block[0] || '')
       if (!name) return true
-      return !MANAGED_MCP_NAMES.has(name) && !block.join('\n').includes(MANAGED_MCP_MARKER)
-    })
-    .map(block => block.join('\n').trimEnd())
-    .filter(Boolean)
-    .join('\n\n')
-    .trim()
+      return !isManagedMcpBlock(block)
+    }))
+}
+
+export function mergeGrokSettingsConfig(existingContent: string, settingsContent: string): string {
+  return [grokSettingsConfig(settingsContent).trim(), grokUserMcpConfig(existingContent).trim()]
+    .filter(Boolean).join('\n\n').concat('\n')
+}
+
+export function mergeGrokUserMcpConfig(existingContent: string, mcpContent: string): string {
+  return [grokSettingsConfig(existingContent).trim(), grokUserMcpConfig(mcpContent).trim()]
+    .filter(Boolean).join('\n\n').concat('\n')
 }
 
 export function mergeGrokConfigWithManagedMcp(content: string, managedMcpToml: string): string {
@@ -93,6 +134,18 @@ async function copyGlobalDirectory(source: string, target: string): Promise<void
     dereference: true,
     errorOnExist: false,
     force: false,
+    preserveTimestamps: true,
+  })
+}
+
+async function syncGlobalSkillsDirectory(sourceHome: string, rootDir: string): Promise<void> {
+  const source = join(sourceHome, 'skills')
+  if (!existsSync(source)) return
+  await cp(source, join(rootDir, 'skills'), {
+    recursive: true,
+    dereference: true,
+    errorOnExist: false,
+    force: true,
     preserveTimestamps: true,
   })
 }
@@ -168,6 +221,7 @@ export function scopedGrokIdentityPrompt(provider: string, model: string): strin
 }
 
 export async function prepareScopedGrokRuntime(input: {
+  sourceHome?: string
   rootDir: string
   provider: string
   model: string
@@ -181,6 +235,7 @@ export async function prepareScopedGrokRuntime(input: {
   managedMcpToml: string
 }): Promise<GrokRuntimeFiles> {
   await mkdir(input.rootDir, { recursive: true, mode: 0o700 })
+  if (input.sourceHome) await syncGlobalSkillsDirectory(input.sourceHome, input.rootDir)
   const configPath = join(input.rootDir, 'config.toml')
   const promptFile = join(input.rootDir, 'AGENTS.md')
   const config = [

--- a/packages/server/src/modules/coding-agents/services/grok/config.ts
+++ b/packages/server/src/modules/coding-agents/services/grok/config.ts
@@ -101,6 +101,13 @@ export function grokUserMcpConfig(content: string): string {
   return value ? `${value}\n` : ''
 }
 
+export function grokMcpConfig(content: string): string {
+  const value = joinGrokConfigBlocks(
+    grokConfigBlocks(content).filter(block => Boolean(mcpServerName(block[0] || ''))),
+  )
+  return value ? `${value}\n` : ''
+}
+
 export function stripManagedGrokMcp(content: string): string {
   return joinGrokConfigBlocks(grokConfigBlocks(content)
     .filter((block) => {
@@ -138,16 +145,16 @@ async function copyGlobalDirectory(source: string, target: string): Promise<void
   })
 }
 
-async function syncGlobalSkillsDirectory(sourceHome: string, rootDir: string): Promise<void> {
-  const source = join(sourceHome, 'skills')
+async function syncSkillsDirectory(source: string, target: string): Promise<void> {
   if (!existsSync(source)) return
-  await cp(source, join(rootDir, 'skills'), {
-    recursive: true,
-    dereference: true,
-    errorOnExist: false,
-    force: true,
-    preserveTimestamps: true,
+  await cp(source, target, {
+    recursive: true, dereference: true, errorOnExist: false, force: true, preserveTimestamps: true,
   })
+}
+
+async function syncGlobalSkillsDirectories(sourceHome: string, rootDir: string): Promise<void> {
+  await syncSkillsDirectory(join(sourceHome, 'skills'), join(rootDir, 'skills'))
+  await syncSkillsDirectory(join(sourceHome, '..', '.agents', 'skills'), join(rootDir, 'skills'))
 }
 
 function shouldCopyGlobalFile(name: string): boolean {
@@ -176,6 +183,7 @@ export async function prepareGlobalGrokRuntime(input: {
       }
     }
   }
+  await syncGlobalSkillsDirectories(input.sourceHome, input.rootDir)
 
   const configPath = join(input.rootDir, 'config.toml')
   const promptFile = join(input.rootDir, 'AGENTS.md')
@@ -235,7 +243,7 @@ export async function prepareScopedGrokRuntime(input: {
   managedMcpToml: string
 }): Promise<GrokRuntimeFiles> {
   await mkdir(input.rootDir, { recursive: true, mode: 0o700 })
-  if (input.sourceHome) await syncGlobalSkillsDirectory(input.sourceHome, input.rootDir)
+  if (input.sourceHome) await syncGlobalSkillsDirectories(input.sourceHome, input.rootDir)
   const configPath = join(input.rootDir, 'config.toml')
   const promptFile = join(input.rootDir, 'AGENTS.md')
   const config = [

--- a/packages/server/src/modules/coding-agents/services/index.ts
+++ b/packages/server/src/modules/coding-agents/services/index.ts
@@ -19,7 +19,15 @@ import { getSystemPrompt } from '../../studio/public/runs/prompt'
 import { codingAgentRunManager } from './runtime/run-manager'
 import { PI_EXTENDED_THINKING_LEVEL_MAP, piModelSupportsThinking } from './pi/thinking'
 import { GROK_API_KEY_ENV, GROK_CODING_AGENT_DEFINITION, GROK_PROVIDER_ID } from './grok/definition'
-import { prepareGlobalGrokRuntime, prepareScopedGrokRuntime } from './grok/config'
+import {
+  grokSettingsConfig,
+  grokUserMcpConfig,
+  mergeGrokConfigWithManagedMcp,
+  mergeGrokSettingsConfig,
+  mergeGrokUserMcpConfig,
+  prepareGlobalGrokRuntime,
+  prepareScopedGrokRuntime,
+} from './grok/config'
 import { getSession, updateSession, type HermesSessionRow } from '../../studio/public/sessions'
 import type { SessionState } from '../../studio/contracts/runs/session'
 import { normalizeWindowsCommandPath, windowsCmdShimExecution, windowsCommandNeedsShell, type WindowsCommandExecution } from '../../studio/public/windows-command'
@@ -355,6 +363,8 @@ const CONFIG_FILE_DEFINITIONS: Record<CodingAgentId, Array<Omit<CodingAgentConfi
   grok: [
     { key: 'auth', path: '~/.grok/auth.json', scopedPath: 'auth.json', language: 'json' },
     { key: 'config', path: '~/.grok/config.toml', scopedPath: 'config.toml', language: 'ini' },
+    { key: 'mcp', path: '~/.grok/config.toml', scopedPath: 'config.toml', language: 'ini' },
+    { key: 'settings', path: '~/.grok/config.toml', scopedPath: 'config.toml', language: 'ini' },
     { key: 'agents', path: '~/.grok/AGENTS.md', scopedPath: 'AGENTS.md', language: 'markdown' },
   ],
 }
@@ -2285,13 +2295,16 @@ export async function deleteCodingAgent(id: string): Promise<CodingAgentMutation
 }
 
 export async function readCodingAgentConfigFile(id: string, key: string, scope: CodingAgentConfigScope = {}): Promise<CodingAgentConfigFileContent> {
-  const definition = getLiveConfigFileDefinition(id, key)
+  const normalizedScope = normalizeConfigScope(scope)
+  const liveDefinition = getLiveConfigFileDefinition(id, key)
+  const definition = id === 'grok' && key === 'mcp' && normalizedScope.provider !== 'default'
+    ? getScopedConfigFileDefinition(id, key, normalizedScope)
+    : liveDefinition
   if (!definition) {
     const err = new Error('Unknown coding agent config file')
     ;(err as any).status = 404
     throw err
   }
-  const normalizedScope = normalizeConfigScope(scope)
 
   try {
     const info = await stat(definition.absolutePath)
@@ -2305,7 +2318,18 @@ export async function readCodingAgentConfigFile(id: string, key: string, scope: 
       ;(err as any).status = 413
       throw err
     }
-    const content = await readFile(definition.absolutePath, 'utf-8')
+    const sourceContent = await readFile(definition.absolutePath, 'utf-8')
+    const globalGrokConfig = id === 'grok' && key === 'mcp' && liveDefinition
+      ? await safeReadFile(liveDefinition.absolutePath) || ''
+      : ''
+    const content = id === 'grok' && key === 'mcp'
+      ? mergeGrokConfigWithManagedMcp(
+          grokUserMcpConfig(`${globalGrokConfig}\n${sourceContent}`),
+          codexMcpConfigToml(normalizedScope.profile),
+        )
+      : id === 'grok' && key === 'settings'
+        ? grokSettingsConfig(sourceContent)
+        : sourceContent
     return {
       ...definition,
       ...normalizedScope,
@@ -2316,9 +2340,11 @@ export async function readCodingAgentConfigFile(id: string, key: string, scope: 
     }
   } catch (err: any) {
     if (err?.code !== 'ENOENT') throw err
-    const defaultContent = id === 'pi'
-      ? piLiveConfigDefault(key, normalizedScope.profile) || ''
-      : ''
+    const defaultContent = id === 'grok' && key === 'mcp'
+      ? mergeGrokConfigWithManagedMcp('', codexMcpConfigToml(normalizedScope.profile))
+      : id === 'pi'
+        ? piLiveConfigDefault(key, normalizedScope.profile) || ''
+        : ''
     return {
       ...definition,
       ...normalizedScope,
@@ -2331,15 +2357,23 @@ export async function readCodingAgentConfigFile(id: string, key: string, scope: 
 }
 
 export async function writeCodingAgentConfigFile(id: string, key: string, content: string, scope: CodingAgentConfigScope = {}): Promise<CodingAgentConfigFileContent> {
-  const definition = getLiveConfigFileDefinition(id, key)
+  const normalizedScope = normalizeConfigScope(scope)
+  const definition = id === 'grok' && key === 'mcp' && normalizedScope.provider !== 'default'
+    ? getScopedConfigFileDefinition(id, key, normalizedScope)
+    : getLiveConfigFileDefinition(id, key)
   if (!definition) {
     const err = new Error('Unknown coding agent config file')
     ;(err as any).status = 404
     throw err
   }
-  const normalizedScope = normalizeConfigScope(scope)
-
-  const buffer = Buffer.from(content || '', 'utf-8')
+  let persistedContent = content || ''
+  if (id === 'grok' && (key === 'mcp' || key === 'settings')) {
+    const existingContent = await safeReadFile(definition.absolutePath) || ''
+    persistedContent = key === 'mcp'
+      ? mergeGrokUserMcpConfig(existingContent, persistedContent)
+      : mergeGrokSettingsConfig(existingContent, persistedContent)
+  }
+  const buffer = Buffer.from(persistedContent, 'utf-8')
   if (buffer.length > MAX_CONFIG_FILE_SIZE) {
     const err = new Error('Config file content is too large')
     ;(err as any).status = 413
@@ -2357,7 +2391,14 @@ export async function writeCodingAgentConfigFile(id: string, key: string, conten
     ...definition,
     ...normalizedScope,
     rootDir: dirname(definition.absolutePath),
-    content,
+    content: id === 'grok' && key === 'mcp'
+      ? mergeGrokConfigWithManagedMcp(
+          grokUserMcpConfig(persistedContent),
+          codexMcpConfigToml(normalizedScope.profile),
+        )
+      : id === 'grok' && key === 'settings'
+        ? grokSettingsConfig(persistedContent)
+        : content,
     exists: true,
     size: buffer.length,
   }
@@ -2763,7 +2804,11 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
       : null
     const capabilities = getModelRuntimeCapabilities({ profile: scope.profile, provider, model })
     const baseConfigRoot = getScopedConfigRoot(tool.id, scope)
+    const globalGrokHome = process.env.GROK_HOME?.trim() || join(getGlobalConfigHome(), '.grok')
+    const globalInstructions = await safeReadFile(join(globalGrokHome, 'AGENTS.md')) || ''
+    const scopedInstructions = await safeReadFile(join(baseConfigRoot, 'AGENTS.md')) || ''
     const prepared = await prepareScopedGrokRuntime({
+      sourceHome: globalGrokHome,
       rootDir,
       provider,
       model,
@@ -2773,7 +2818,9 @@ export async function prepareCodingAgentLaunch(id: string, input: CodingAgentLau
       outputLimit: capabilities.outputLimit,
       reasoningEffort,
       systemPrompt: scopedSystemPrompt,
-      userInstructions: await safeReadFile(join(baseConfigRoot, 'AGENTS.md')) || '',
+      userInstructions: [globalInstructions.trim(), scopedInstructions.trim()]
+        .filter((value, index, values) => value && values.indexOf(value) === index)
+        .join('\n\n'),
       managedMcpToml: codexMcpConfigToml(
         scope.profile,
         await safeReadFile(getLiveConfigFileDefinition(tool.id, 'config')?.absolutePath || ''),

--- a/packages/server/src/modules/coding-agents/services/index.ts
+++ b/packages/server/src/modules/coding-agents/services/index.ts
@@ -21,6 +21,7 @@ import { PI_EXTENDED_THINKING_LEVEL_MAP, piModelSupportsThinking } from './pi/th
 import { GROK_API_KEY_ENV, GROK_CODING_AGENT_DEFINITION, GROK_PROVIDER_ID } from './grok/definition'
 import {
   grokSettingsConfig,
+  grokMcpConfig,
   grokUserMcpConfig,
   mergeGrokConfigWithManagedMcp,
   mergeGrokSettingsConfig,
@@ -28,7 +29,7 @@ import {
   prepareGlobalGrokRuntime,
   prepareScopedGrokRuntime,
 } from './grok/config'
-import { getSession, updateSession, type HermesSessionRow } from '../../studio/public/sessions'
+import { getSession, listSessions, updateSession, type HermesSessionRow } from '../../studio/public/sessions'
 import type { SessionState } from '../../studio/contracts/runs/session'
 import { normalizeWindowsCommandPath, windowsCmdShimExecution, windowsCommandNeedsShell, type WindowsCommandExecution } from '../../studio/public/windows-command'
 import { updateAgentStatus } from '../../studio/public/agent-status-registry'
@@ -256,6 +257,8 @@ export interface CodingAgentConfigScope {
   provider?: string
 }
 
+export type CodingAgentConfigRequestScope = CodingAgentConfigScope & { sessionId?: string }
+
 export interface CodingAgentConfigFileContent extends CodingAgentConfigFileDefinition {
   content: string
   exists: boolean
@@ -263,6 +266,9 @@ export interface CodingAgentConfigFileContent extends CodingAgentConfigFileDefin
   profile: string
   provider: string
   rootDir: string
+  writable?: boolean
+  source?: 'global' | 'runtime'
+  sessionId?: string
 }
 
 export interface CodingAgentLaunchInput extends CodingAgentConfigScope {
@@ -2294,12 +2300,54 @@ export async function deleteCodingAgent(id: string): Promise<CodingAgentMutation
   }
 }
 
-export async function readCodingAgentConfigFile(id: string, key: string, scope: CodingAgentConfigScope = {}): Promise<CodingAgentConfigFileContent> {
+function resolveGrokRuntimeConfig(
+  id: string,
+  key: string,
+  scope: CodingAgentConfigRequestScope,
+): { definition: CodingAgentConfigFileDefinition; session: HermesSessionRow; rootDir: string } | null {
+  if (id !== 'grok' || !scope.sessionId || !['mcp', 'settings', 'agents'].includes(key)) return null
+  const requestedProfile = normalizeScopeSegment(scope.profile, 'default', 'profile')
+  const requestedProvider = scope.provider
+    ? normalizeScopeSegment(scope.provider, 'default', 'provider')
+    : ''
+  const candidates = scope.sessionId === 'latest'
+    ? listSessions(requestedProfile).filter(session => (
+        session.agent === 'grok' &&
+        session.agent_mode === 'scoped' &&
+        Boolean(session.agent_session_id) &&
+        (!requestedProvider || normalizeScopeSegment(session.provider, 'default', 'provider') === requestedProvider)
+      )).sort((a, b) => b.last_active - a.last_active)
+    : [getSession(scope.sessionId)].filter((session): session is HermesSessionRow => Boolean(
+        session &&
+        session.profile === requestedProfile &&
+        session.agent === 'grok' &&
+        session.agent_mode === 'scoped' &&
+        session.agent_session_id,
+      ))
+  const session = candidates[0]
+  if (!session) return null
+  const runtimeScope = normalizeConfigScope({ profile: session.profile, provider: session.provider })
+  const rootDir = getScopedRuntimeConfigRoot('grok', runtimeScope, {
+    sessionId: session.id,
+    agentSessionId: session.agent_session_id,
+  })
+  const runtimeKey = key === 'agents' ? 'agents' : 'config'
+  const base = getScopedConfigFileDefinition('grok', runtimeKey, runtimeScope, rootDir)
+  if (!base) return null
+  return {
+    session,
+    rootDir,
+    definition: { ...base, key },
+  }
+}
+
+export async function readCodingAgentConfigFile(id: string, key: string, scope: CodingAgentConfigRequestScope = {}): Promise<CodingAgentConfigFileContent> {
   const normalizedScope = normalizeConfigScope(scope)
+  const runtime = resolveGrokRuntimeConfig(id, key, scope)
   const liveDefinition = getLiveConfigFileDefinition(id, key)
-  const definition = id === 'grok' && key === 'mcp' && normalizedScope.provider !== 'default'
+  const definition = runtime?.definition || (id === 'grok' && key === 'mcp' && normalizedScope.provider !== 'default'
     ? getScopedConfigFileDefinition(id, key, normalizedScope)
-    : liveDefinition
+    : liveDefinition)
   if (!definition) {
     const err = new Error('Unknown coding agent config file')
     ;(err as any).status = 404
@@ -2319,11 +2367,13 @@ export async function readCodingAgentConfigFile(id: string, key: string, scope: 
       throw err
     }
     const sourceContent = await readFile(definition.absolutePath, 'utf-8')
-    const globalGrokConfig = id === 'grok' && key === 'mcp' && liveDefinition
+    const globalGrokConfig = id === 'grok' && key === 'mcp' && liveDefinition && !runtime
       ? await safeReadFile(liveDefinition.absolutePath) || ''
       : ''
     const content = id === 'grok' && key === 'mcp'
-      ? mergeGrokConfigWithManagedMcp(
+      ? runtime
+        ? grokMcpConfig(sourceContent)
+        : mergeGrokConfigWithManagedMcp(
           grokUserMcpConfig(`${globalGrokConfig}\n${sourceContent}`),
           codexMcpConfigToml(normalizedScope.profile),
         )
@@ -2337,6 +2387,9 @@ export async function readCodingAgentConfigFile(id: string, key: string, scope: 
       content,
       exists: true,
       size: info.size,
+      writable: !runtime,
+      source: runtime ? 'runtime' : 'global',
+      sessionId: runtime?.session.id,
     }
   } catch (err: any) {
     if (err?.code !== 'ENOENT') throw err
@@ -2352,6 +2405,9 @@ export async function readCodingAgentConfigFile(id: string, key: string, scope: 
       content: defaultContent,
       exists: false,
       size: Buffer.byteLength(defaultContent),
+      writable: !runtime,
+      source: runtime ? 'runtime' : 'global',
+      sessionId: runtime?.session.id,
     }
   }
 }

--- a/packages/server/src/modules/hermes/controllers/skills.ts
+++ b/packages/server/src/modules/hermes/controllers/skills.ts
@@ -49,6 +49,10 @@ function codexSystemSkillsDir(): string {
   return join(homedir(), '.codex', 'skills', '.system')
 }
 
+function sharedAgentSkillsDir(): string {
+  return join(homedir(), '.agents', 'skills')
+}
+
 function requestTargetSkillsDir(ctx: any): string {
   const target = requestSkillTarget(ctx)
   return target === 'hermes' ? requestSkillsDir(ctx) : globalSkillsDir(target)
@@ -67,6 +71,9 @@ async function resolveSkillDirForTarget(ctx: any, category: string, skillName: s
 
   if (target === 'codex') {
     return findSkillDirInRoot(codexSystemSkillsDir(), category, skillName)
+  }
+  if (target === 'grok') {
+    return findSkillDirInRoot(sharedAgentSkillsDir(), category, skillName)
   }
 
   return null
@@ -527,6 +534,14 @@ export async function list(ctx: any) {
           'builtin',
         )
         categories = mergeExternalCategories(categories, systemCategories)
+      } else if (target === 'grok') {
+        const sharedDir = sharedAgentSkillsDir()
+        extraDirs.push(sharedDir)
+        const sharedCategories = withSkillSource(
+          await scanSkillsDirIfExists(sharedDir, new Map(), new Set(), [], new Map()),
+          'external',
+        )
+        categories = mergeExternalCategories(categories, sharedCategories)
       }
       ctx.body = {
         categories,

--- a/tests/client/coding-agent-config-navigation.test.ts
+++ b/tests/client/coding-agent-config-navigation.test.ts
@@ -42,7 +42,7 @@ describe('coding Agent configuration navigation', () => {
     expect(view).toContain("'claude-code': { memory: 'memory', mcp: 'mcp', settings: 'settings' }")
     expect(view).toContain("codex: { memory: 'agents', mcp: 'config', settings: 'config' }")
     expect(view).toContain("pi: { memory: 'agents', mcp: 'mcp', settings: 'settings' }")
-    expect(view).toContain("grok: { memory: 'agents', mcp: 'config', settings: 'config' }")
+    expect(view).toContain("grok: { memory: 'agents', mcp: 'mcp', settings: 'settings' }")
     expect(skills).toContain('target?: SkillTarget')
   })
 })

--- a/tests/client/coding-agent-config-navigation.test.ts
+++ b/tests/client/coding-agent-config-navigation.test.ts
@@ -43,6 +43,8 @@ describe('coding Agent configuration navigation', () => {
     expect(view).toContain("codex: { memory: 'agents', mcp: 'config', settings: 'config' }")
     expect(view).toContain("pi: { memory: 'agents', mcp: 'mcp', settings: 'settings' }")
     expect(view).toContain("grok: { memory: 'agents', mcp: 'mcp', settings: 'settings' }")
+    expect(view).toContain("{ sessionId: 'latest' }")
+    expect(view).toContain(':readonly="configFile?.writable === false"')
     expect(skills).toContain('target?: SkillTarget')
   })
 })

--- a/tests/server/agent-runner/grok/grok-runtime.test.ts
+++ b/tests/server/agent-runner/grok/grok-runtime.test.ts
@@ -4,6 +4,10 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
+  grokSettingsConfig,
+  grokUserMcpConfig,
+  mergeGrokSettingsConfig,
+  mergeGrokUserMcpConfig,
   prepareGlobalGrokRuntime,
   prepareScopedGrokRuntime,
   stripManagedGrokMcp,
@@ -93,6 +97,31 @@ describe('Grok runtime isolation', () => {
     expect(updatedPrompt).toContain('Updated workflow instructions.')
   })
 
+  it('copies global Grok skills into scoped runtimes', async () => {
+    const root = makeRoot()
+    const sourceHome = join(root, 'user-grok')
+    const rootDir = join(root, 'runtime')
+    await mkdir(join(sourceHome, 'skills', 'review'), { recursive: true })
+    writeFileSync(join(sourceHome, 'skills', 'review', 'SKILL.md'), 'Review skill.\n')
+
+    await prepareScopedGrokRuntime({
+      sourceHome,
+      rootDir,
+      provider: 'custom-provider',
+      model: 'custom-model',
+      displayName: 'Custom Model',
+      proxyBaseUrl: 'http://127.0.0.1:8647/v1',
+      contextWindow: 128_000,
+      outputLimit: 8192,
+      reasoningEffort: '',
+      systemPrompt: 'Studio instructions.',
+      userInstructions: 'User instructions.',
+      managedMcpToml: '',
+    })
+
+    expect(readFileSync(join(rootDir, 'skills', 'review', 'SKILL.md'), 'utf-8')).toBe('Review skill.\n')
+  })
+
   it('removes only Studio-managed MCP blocks', () => {
     const config = [
       '[mcp_servers.user-tools]',
@@ -104,6 +133,27 @@ describe('Grok runtime isolation', () => {
 
     expect(stripManagedGrokMcp(config)).toContain('[mcp_servers.user-tools]')
     expect(stripManagedGrokMcp(config)).not.toContain('hermes-studio-api')
+  })
+
+  it('separates Grok settings and user MCP without persisting managed MCP', () => {
+    const config = [
+      '[cli]',
+      'installer = "npm"',
+      '',
+      '[mcp_servers.user-tools]',
+      'command = "user-mcp"',
+      '',
+      '[mcp_servers.hermes-studio-api]',
+      'command = "studio-mcp"',
+    ].join('\n')
+
+    expect(grokSettingsConfig(config)).toContain('[cli]')
+    expect(grokSettingsConfig(config)).not.toContain('mcp_servers')
+    expect(grokUserMcpConfig(config)).toContain('user-tools')
+    expect(grokUserMcpConfig(config)).not.toContain('hermes-studio-api')
+    expect(mergeGrokUserMcpConfig(config, '[mcp_servers.next]\ncommand = "next"')).toContain('[cli]')
+    expect(mergeGrokUserMcpConfig(config, '[mcp_servers.next]\ncommand = "next"')).not.toContain('user-tools')
+    expect(mergeGrokSettingsConfig(config, '[cli]\ninstaller = "brew"')).toContain('user-tools')
   })
 })
 

--- a/tests/server/agent-runner/grok/grok-runtime.test.ts
+++ b/tests/server/agent-runner/grok/grok-runtime.test.ts
@@ -102,7 +102,9 @@ describe('Grok runtime isolation', () => {
     const sourceHome = join(root, 'user-grok')
     const rootDir = join(root, 'runtime')
     await mkdir(join(sourceHome, 'skills', 'review'), { recursive: true })
+    await mkdir(join(root, '.agents', 'skills', 'shared'), { recursive: true })
     writeFileSync(join(sourceHome, 'skills', 'review', 'SKILL.md'), 'Review skill.\n')
+    writeFileSync(join(root, '.agents', 'skills', 'shared', 'SKILL.md'), 'Shared skill.\n')
 
     await prepareScopedGrokRuntime({
       sourceHome,
@@ -120,6 +122,7 @@ describe('Grok runtime isolation', () => {
     })
 
     expect(readFileSync(join(rootDir, 'skills', 'review', 'SKILL.md'), 'utf-8')).toBe('Review skill.\n')
+    expect(readFileSync(join(rootDir, 'skills', 'shared', 'SKILL.md'), 'utf-8')).toBe('Shared skill.\n')
   })
 
   it('removes only Studio-managed MCP blocks', () => {


### PR DESCRIPTION
## Summary

- show the latest scoped Grok runtime configuration by default for MCP, memory, and settings
- keep generated runtime files read-only and allow switching to editable global configuration
- separate Grok MCP blocks from ordinary settings
- merge shared `~/.agents/skills` into the Grok skills view and runtime
- avoid writing Studio-managed MCP entries back to the user global configuration

## Scope

This PR changes Grok only. Claude, Codex, and Pi have a similar global/runtime display mismatch, but are intentionally left unchanged.

## Tests

- `tests/server/agent-runner/grok/grok-runtime.test.ts`
- `tests/client/coding-agent-config-navigation.test.ts`
- `tests/client/skills-api-paths.test.ts`
- 14 tests passed

## Test package

Validated with the LPK built from main + merged PR #2857 + these changes.