### PR TITLE
fix: hide coding agent runtime storage paths

### DIFF
--- a/packages/client/src/views/hermes/CodingAgentConfigView.vue
+++ b/packages/client/src/views/hermes/CodingAgentConfigView.vue
@@ -140,7 +140,7 @@ watch([agentId, section, grokEffectiveView], loadConfigFile, { immediate: true }
       <template v-else-if="configKey">
         <div class="editor-toolbar">
           <div class="file-meta">
-            <code>{{ configFile?.absolutePath || configFile?.path }}</code>
+            <code>{{ configFile?.path }}</code>
             <NTag v-if="configFile?.source === 'runtime'" type="info" size="small" :bordered="false">
               {{ configFile.sessionId }}
             </NTag>

--- a/tests/client/coding-agent-config-navigation.test.ts
+++ b/tests/client/coding-agent-config-navigation.test.ts
@@ -45,6 +45,8 @@ describe('coding Agent configuration navigation', () => {
     expect(view).toContain("grok: { memory: 'agents', mcp: 'mcp', settings: 'settings' }")
     expect(view).toContain("{ sessionId: 'latest' }")
     expect(view).toContain(':readonly="configFile?.writable === false"')
+    expect(view).toContain('<code>{{ configFile?.path }}</code>')
+    expect(view).not.toContain('configFile?.absolutePath || configFile?.path')
     expect(skills).toContain('target?: SkillTarget')
   })
 })


### PR DESCRIPTION
## Summary

- display the logical coding-agent configuration path in the editor toolbar
- avoid exposing the internal scoped runtime storage directory for Grok
- keep the runtime session badge so users can still identify the effective session
- align the path presentation with Claude, Codex, and Pi

## Tests

- coding-agent configuration navigation tests
- Grok runtime tests
- skills API path tests
- 14 tests passed