### PR TITLE
[codex] restore production app relay endpoints

### DIFF
--- a/packages/server/src/modules/studio/public/config.ts
+++ b/packages/server/src/modules/studio/public/config.ts
@@ -86,7 +86,7 @@ const remoteRelay = {
   url: process.env.HERMES_REMOTE_RELAY_URL?.trim() || 'https://api.hermes-studio.ai',
 }
 const appRelay = {
-  url: process.env.HERMES_APP_RELAY_URL?.trim() || 'https://testapi.hermes-studio.ai',
+  url: process.env.HERMES_APP_RELAY_URL?.trim() || 'https://api.hermes-studio.ai',
   entitlementRequired: isAppEntitlementRequired(),
 }
 

--- a/packages/server/src/modules/studio/services/app-relay/route.ts
+++ b/packages/server/src/modules/studio/services/app-relay/route.ts
@@ -4,7 +4,7 @@ import { readAppConfig, writeAppConfig } from '../config/app-config'
 export type AppRelayRoute = 'official' | 'cloudflare'
 
 export const DEFAULT_APP_RELAY_ROUTE: AppRelayRoute = 'official'
-export const CLOUDFLARE_APP_RELAY_URL = 'https://testapi.hermes-studio.ai'
+export const CLOUDFLARE_APP_RELAY_URL = 'https://cn.hermes-studio.ai'
 
 export function isAppRelayRoute(value: unknown): value is AppRelayRoute {
   return value === 'official' || value === 'cloudflare'

--- a/tests/server/app-relay-controller.test.ts
+++ b/tests/server/app-relay-controller.test.ts
@@ -73,7 +73,7 @@ describe('app relay controller', () => {
         pairingExpiresAt: 12345,
         expiresAt: 12345,
         route: 'official',
-        relayUrl: 'https://testapi.hermes-studio.ai',
+        relayUrl: 'https://api.hermes-studio.ai',
       },
     })
   })

--- a/tests/server/app-relay-route.test.ts
+++ b/tests/server/app-relay-route.test.ts
@@ -24,7 +24,7 @@ describe('App Relay route configuration', () => {
     )
 
     expect(await getAppRelayRoute()).toBe('official')
-    expect(appRelayUrlForRoute('official')).toBe('https://testapi.hermes-studio.ai')
+    expect(appRelayUrlForRoute('official')).toBe('https://api.hermes-studio.ai')
   })
 
   it('persists and maps the Cloudflare route', async () => {
@@ -34,6 +34,6 @@ describe('App Relay route configuration', () => {
 
     await setAppRelayRoute('cloudflare')
     expect(writeAppConfig).toHaveBeenCalledWith({ appRelayRoute: 'cloudflare' })
-    expect(appRelayUrlForRoute('cloudflare')).toBe('https://testapi.hermes-studio.ai')
+    expect(appRelayUrlForRoute('cloudflare')).toBe('https://cn.hermes-studio.ai')
   })
 })


### PR DESCRIPTION
## Summary
- restore the official App relay endpoint to `https://api.hermes-studio.ai`
- restore the Cloudflare App relay endpoint to `https://cn.hermes-studio.ai`
- update relay route and controller test expectations

## Impact
Studio device connections use production relay services by default again. Environment overrides remain supported through `HERMES_APP_RELAY_URL`.

## Validation
- `npm run test -- tests/server/app-relay-route.test.ts tests/server/app-relay-controller.test.ts`
- `npm run harness:check`
- `npm run build`