### PR TITLE
[Codex] use official npm registry for one-click install

### DIFF
--- a/packages/ekko-agent/skills/hermes-studio-installation/references/coding-agents.md
+++ b/packages/ekko-agent/skills/hermes-studio-installation/references/coding-agents.md
@@ -37,7 +37,7 @@ The Agents page install action effectively performs the following. The Pi adapte
 
 ```bash
 npm install -g @anthropic-ai/claude-code
-npm install -g @openai/codex
+npm install -g @openai/codex --registry=https://registry.npmjs.org
 npm install -g @earendil-works/pi-coding-agent@0.84.1
 npm install -g @xai-official/grok --registry=https://registry.npmjs.org
 studio_home="${HERMES_WEB_UI_HOME:-$HOME/.hermes-web-ui}"
@@ -74,14 +74,16 @@ Pi deliberately reports **not installed** when its CLI exists but that adapter e
 The Agents page **Check update** action behaves as follows:
 
 - Claude Code: compares the detected version with `npm view @anthropic-ai/claude-code version`.
-- Codex: compares the detected version with `npm view @openai/codex version`.
+- Codex: compares the detected version with `npm view @openai/codex version --registry=https://registry.npmjs.org`.
 - Pi: compares the detected version with Studio's pinned Pi version; it does not chase npm latest independently.
 - Grok: compares the detected version with `npm view @xai-official/grok version --registry=https://registry.npmjs.org`.
 
-Studio uses the official npm Registry only for Grok installation and update
-checks. This avoids stale third-party mirror metadata selecting a
-platform-incompatible historical release. It does not modify the user's npm
-configuration or the registry used for other coding Agents.
+Studio uses the official npm Registry only for Codex and Grok installation and
+update checks. Codex depends on platform-specific optional packages that may be
+missing from third-party mirrors even when the main package is present; Grok
+mirrors can also expose stale, platform-incompatible releases. Per-command
+registry arguments avoid modifying the user's npm configuration or the registry
+used for other coding Agents.
 
 When an update is available, the update action reruns the same install operation. Revalidate the executable path and version afterward. For Pi, revalidate the adapter too.
 

--- a/packages/server/src/modules/coding-agents/services/index.ts
+++ b/packages/server/src/modules/coding-agents/services/index.ts
@@ -54,7 +54,7 @@ const PI_MCP_ADAPTER_VERSION = '2.24.0'
 const PI_MCP_ADAPTER_PACKAGE = `pi-mcp-adapter@${PI_MCP_ADAPTER_VERSION}`
 const PI_CODING_AGENT_VERSION = '0.84.1'
 const PI_CODING_AGENT_PACKAGE = `@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}`
-const GROK_NPM_REGISTRY = 'https://registry.npmjs.org'
+const OFFICIAL_NPM_REGISTRY = 'https://registry.npmjs.org'
 const PI_PROVIDER_ID = 'hermes-studio'
 const PI_PROXY_TARGET_FILE = 'proxy-target.json'
 const PI_DYNAMIC_PROMPT_FILE = 'dynamic-system-prompt.md'
@@ -2018,8 +2018,8 @@ export function getCodingAgentDefinition(id: string): CodingAgentDefinition | nu
 }
 
 export function withCodingAgentRegistry(id: CodingAgentId, args: string[]): string[] {
-  return id === 'grok'
-    ? [...args, `--registry=${GROK_NPM_REGISTRY}`]
+  return id === 'codex' || id === 'grok'
+    ? [...args, `--registry=${OFFICIAL_NPM_REGISTRY}`]
     : [...args]
 }
 

--- a/tests/server/coding-agent-npm-registry.test.ts
+++ b/tests/server/coding-agent-npm-registry.test.ts
@@ -2,22 +2,25 @@ import { describe, expect, it } from 'vitest'
 import { withCodingAgentRegistry } from '../../packages/server/src/modules/coding-agents/services'
 
 describe('coding Agent npm registry policy', () => {
-  it('uses the official npm Registry for Grok package operations', () => {
-    expect(withCodingAgentRegistry('grok', ['install', '-g', '@xai-official/grok'])).toEqual([
+  it.each([
+    ['codex', '@openai/codex'],
+    ['grok', '@xai-official/grok'],
+  ] as const)('uses the official npm Registry for %s package operations', (agentId, packageName) => {
+    expect(withCodingAgentRegistry(agentId, ['install', '-g', packageName])).toEqual([
       'install',
       '-g',
-      '@xai-official/grok',
+      packageName,
       '--registry=https://registry.npmjs.org',
     ])
-    expect(withCodingAgentRegistry('grok', ['view', '@xai-official/grok', 'version'])).toEqual([
+    expect(withCodingAgentRegistry(agentId, ['view', packageName, 'version'])).toEqual([
       'view',
-      '@xai-official/grok',
+      packageName,
       'version',
       '--registry=https://registry.npmjs.org',
     ])
   })
 
-  it.each(['claude-code', 'codex', 'pi'] as const)(
+  it.each(['claude-code', 'pi'] as const)(
     'keeps the configured npm Registry for %s',
     (agentId) => {
       expect(withCodingAgentRegistry(agentId, ['install', '-g', 'package'])).toEqual([


### PR DESCRIPTION
## Summary
- route Codex install and update-check npm commands through the official npm Registry
- keep the user's configured Registry unchanged for Claude Code and Pi
- extend the focused Registry-policy regression test and installation reference

## Why
Codex publishes its platform binaries as optional alias packages such as `@openai/codex@<version>-linux-x64`. A third-party mirror can contain the main `@openai/codex` package while missing that platform variant. npm then exits successfully because the dependency is optional, but `codex --version` fails afterward with:

```text
Error: Missing optional dependency @openai/codex-linux-x64
```

Passing `--registry=https://registry.npmjs.org` only on Codex package operations ensures the matching platform package is available without modifying the user's npm configuration.

## User impact
The Agents page **Install now** and **Check update** actions for Codex no longer depend on incomplete third-party mirror metadata. Existing Codex configuration, authentication, and sessions are unaffected.

## Validation
- `npm ci --ignore-scripts --include=dev`
- `npm run test -- tests/server/coding-agent-npm-registry.test.ts` (4/4 passed)
- `npm run harness:check`
- `npm run build`
- `git diff --check`

## Scope
No image or LPK build, release, installation, deployment, or merge was performed.
