### PR TITLE
fix: preview uploaded images before sending

### DIFF
--- a/packages/client/src/components/hermes/chat/ChatInput.vue
+++ b/packages/client/src/components/hermes/chat/ChatInput.vue
@@ -20,6 +20,7 @@ import { BRIDGE_SESSION_COMMAND_DEFINITIONS } from '@/utils/hermes/bridge-sessio
 import { clampChatInputHeight, isMobileChatInputViewport } from '@/utils/chat-input-height'
 import { normalizeComposerVoiceTranscript, useComposerVoiceInput } from '@/composables/useComposerVoiceInput'
 import { extractRepresentativeVideoFrames, isVideoFile } from '@/utils/video-frame-extraction'
+import ImagePreviewOverlay from './ImagePreviewOverlay.vue'
 
 const chatStore = useChatStore()
 const appStore = useAppStore()
@@ -120,6 +121,7 @@ const textareaRef = ref<HTMLTextAreaElement>()
 const commandDropdownRef = ref<HTMLDivElement>()
 const fileInputRef = ref<HTMLInputElement>()
 const attachments = ref<Attachment[]>([])
+const previewAttachment = ref<Attachment | null>(null)
 const pendingVideoFrameJobs = new Set<Promise<void>>()
 const isPreparingAttachments = ref(false)
 let sendAwaitingAttachments = false
@@ -1005,6 +1007,7 @@ async function handleSend() {
   chatStore.sendMessage(text, attachments.value.length > 0 ? attachments.value : undefined)
   inputText.value = ''
   saveDraftForActiveSession('')
+  previewAttachment.value = null
   attachments.value = []
   slashActive.value = false
 
@@ -1096,6 +1099,9 @@ function removeAttachment(id: string) {
     if (attachment.videoFrameFor === id) removedIds.add(attachment.id)
   }
   const removed = attachments.value.filter(attachment => removedIds.has(attachment.id))
+  if (previewAttachment.value && removedIds.has(previewAttachment.value.id)) {
+    previewAttachment.value = null
+  }
   for (const attachment of removed) URL.revokeObjectURL(attachment.url)
   attachments.value = attachments.value.filter(attachment => !removedIds.has(attachment.id))
 }
@@ -1108,6 +1114,11 @@ function formatSize(bytes: number): string {
 
 function isImage(type: string): boolean {
   return type.startsWith('image/')
+}
+
+function openAttachmentPreview(attachment: Attachment) {
+  if (!isImage(attachment.type)) return
+  previewAttachment.value = attachment
 }
 </script>
 
@@ -1122,7 +1133,14 @@ function isImage(type: string): boolean {
         :class="{ image: isImage(att.type), 'has-context': !!att.context }"
       >
         <template v-if="isImage(att.type)">
-          <img :src="att.url" :alt="att.name" class="attachment-thumb" />
+          <button
+            type="button"
+            class="attachment-thumb-button"
+            :aria-label="att.name"
+            @click="openAttachmentPreview(att)"
+          >
+            <img :src="att.url" :alt="att.name" class="attachment-thumb" />
+          </button>
         </template>
         <template v-else>
           <div class="attachment-file">
@@ -1140,6 +1158,12 @@ function isImage(type: string): boolean {
         </button>
       </div>
     </div>
+    <ImagePreviewOverlay
+      v-if="previewAttachment"
+      :src="previewAttachment.url"
+      :alt="previewAttachment.name"
+      @close="previewAttachment = null"
+    />
 
     <div v-if="activeMessageReference" class="message-reference-preview">
       <span class="message-reference-text">{{ messageReferencePreview }}</span>
@@ -2044,8 +2068,8 @@ function isImage(type: string): boolean {
   border: 1px solid $border-color;
 
   &.image {
-    width: 64px;
-    height: 64px;
+    width: 112px;
+    height: 72px;
   }
 
   &.image.has-context {
@@ -2055,9 +2079,26 @@ function isImage(type: string): boolean {
 }
 
 .attachment-thumb {
+  display: block;
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
+}
+
+.attachment-thumb-button {
+  display: block;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  background:
+    linear-gradient(45deg, rgba(127, 127, 127, 0.08) 25%, transparent 25%),
+    linear-gradient(-45deg, rgba(127, 127, 127, 0.08) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, rgba(127, 127, 127, 0.08) 75%),
+    linear-gradient(-45deg, transparent 75%, rgba(127, 127, 127, 0.08) 75%);
+  background-position: 0 0, 0 6px, 6px -6px, -6px 0;
+  background-size: 12px 12px;
+  cursor: zoom-in;
 }
 
 .attachment-preview.has-context .attachment-thumb {
@@ -2067,6 +2108,10 @@ function isImage(type: string): boolean {
   max-height: 220px;
   object-fit: contain;
   background: #fff;
+}
+
+.attachment-preview.has-context .attachment-thumb-button {
+  height: auto;
 }
 
 .attachment-context {

--- a/packages/client/src/components/hermes/chat/ImagePreviewOverlay.vue
+++ b/packages/client/src/components/hermes/chat/ImagePreviewOverlay.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted } from 'vue'
+
+defineProps<{
+  src: string
+  alt: string
+}>()
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+function handleKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape') emit('close')
+}
+
+onMounted(() => window.addEventListener('keydown', handleKeydown))
+onUnmounted(() => window.removeEventListener('keydown', handleKeydown))
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      class="image-preview-overlay"
+      role="dialog"
+      aria-modal="true"
+      :aria-label="alt"
+      @click.self="emit('close')"
+    >
+      <img :src="src" :alt="alt" class="image-preview-img" @click="emit('close')" />
+    </div>
+  </Teleport>
+</template>
+
+<style scoped lang="scss">
+.image-preview-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 5vh 5vw;
+  background: rgba(0, 0, 0, 0.85);
+  cursor: zoom-out;
+}
+
+.image-preview-img {
+  display: block;
+  max-width: 90vw;
+  max-height: 90vh;
+  object-fit: contain;
+  border-radius: 6px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+}
+</style>

--- a/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
+++ b/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
@@ -20,6 +20,7 @@ import {
 import { downloadFile, getDownloadUrl, inferDownloadFileName } from '@/api/studio/download'
 import { isPreviewableFile } from '@/utils/hermes/file-preview'
 import { openUrlInDesktopBrowser } from '@/utils/desktop-browser'
+import ImagePreviewOverlay from './ImagePreviewOverlay.vue'
 
 const LATEX_FENCE_LANGS = new Set(['latex', 'tex', 'math', 'katex'])
 function getFenceLanguage(info: string): string {
@@ -525,11 +526,12 @@ async function handleMarkdownClick(event: MouseEvent): Promise<void> {
 
 <template>
   <div ref="markdownBody" class="markdown-body" dir="auto" v-html="renderedHtml" @click="handleMarkdownClick"></div>
-  <Teleport to="body">
-    <div v-if="previewUrl" class="image-preview-overlay" @click.self="previewUrl = null">
-      <img :src="previewUrl" class="image-preview-img" @click="previewUrl = null" />
-    </div>
-  </Teleport>
+  <ImagePreviewOverlay
+    v-if="previewUrl"
+    :src="previewUrl"
+    alt=""
+    @close="previewUrl = null"
+  />
 </template>
 
 <style lang="scss">
@@ -802,25 +804,6 @@ async function handleMarkdownClick(event: MouseEvent): Promise<void> {
     align-items: center;
     justify-content: center;
   }
-}
-
-.image-preview-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 9999;
-  background: rgba(0, 0, 0, 0.85);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-}
-
-.image-preview-img {
-  max-width: 90vw;
-  max-height: 90vh;
-  object-fit: contain;
-  border-radius: 4px;
-  cursor: pointer;
 }
 
 </style>

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -33,6 +33,7 @@ import type { WorkspaceRunChangeSummary } from "@/api/studio/sessions";
 import { isServerTtsProvider } from "@/api/studio/tts";
 import type { ProfileAvatar as ProfileAvatarData } from "@/api/hermes/profiles";
 import ProfileAvatar from "@/components/hermes/profiles/ProfileAvatar.vue";
+import ImagePreviewOverlay from "./ImagePreviewOverlay.vue";
 
 const MarkdownRenderer = defineAsyncComponent(async () => (await import("./MarkdownRenderer.vue")).default);
 
@@ -1312,11 +1313,12 @@ onBeforeUnmount(() => {
       </div>
     </template>
   </div>
-  <Teleport to="body">
-    <div v-if="previewUrl" class="image-preview-overlay" @click.self="previewUrl = null">
-      <img :src="previewUrl" class="image-preview-img" @click="previewUrl = null" />
-    </div>
-  </Teleport>
+  <ImagePreviewOverlay
+    v-if="previewUrl"
+    :src="previewUrl"
+    alt=""
+    @close="previewUrl = null"
+  />
 </template>
 
 <style scoped lang="scss">
@@ -2118,24 +2120,6 @@ onBeforeUnmount(() => {
     opacity: 1;
     transform: scale(1);
   }
-}
-
-.image-preview-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 9999;
-  background: rgba(0, 0, 0, 0.85);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-}
-
-.image-preview-img {
-  max-width: 90vw;
-  max-height: 90vh;
-  object-fit: contain;
-  border-radius: 4px;
 }
 
 @media (max-width: $breakpoint-mobile) {

--- a/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupChatInput.vue
@@ -6,6 +6,7 @@ import { useGroupChatStore } from '@/stores/hermes/group-chat'
 import { useSettingsStore } from '@/stores/hermes/settings'
 import { useToolTraceVisibility } from '@/composables/useToolTraceVisibility'
 import { extractClipboardFiles } from '@/utils/clipboard-files'
+import ImagePreviewOverlay from '@/components/hermes/chat/ImagePreviewOverlay.vue'
 import { buildMentionOptions, type MentionOption } from './mention-options'
 import type { GroupChatMention } from '@/api/studio/group-chat'
 import type { Attachment } from '@/stores/hermes/chat'
@@ -48,6 +49,7 @@ const textareaRef = ref<HTMLTextAreaElement>()
 const dropdownRef = ref<HTMLDivElement>()
 const fileInputRef = ref<HTMLInputElement>()
 const attachments = ref<Attachment[]>([])
+const previewAttachment = ref<Attachment | null>(null)
 const isSending = ref(false)
 const pendingSendRoomId = ref<string | null>(null)
 const isDragging = ref(false)
@@ -239,6 +241,7 @@ const filteredMentionOptions = computed(() => buildMentionOptions(
 const canSend = computed(() => !!inputText.value.trim() || (props.allowAttachments && attachments.value.length > 0))
 
 function resetTransientComposerState() {
+    previewAttachment.value = null
     for (const attachment of attachments.value) URL.revokeObjectURL(attachment.url)
     attachments.value = []
     mentionActive.value = false
@@ -701,6 +704,7 @@ function removeAttachment(id: string) {
     if (isSending.value) return
     const idx = attachments.value.findIndex(a => a.id === id)
     if (idx !== -1) {
+        if (previewAttachment.value?.id === id) previewAttachment.value = null
         URL.revokeObjectURL(attachments.value[idx].url)
         attachments.value.splice(idx, 1)
     }
@@ -715,13 +719,26 @@ function formatSize(bytes: number): string {
 function isImage(type: string): boolean {
     return type.startsWith('image/')
 }
+
+function openAttachmentPreview(attachment: Attachment) {
+    if (!isImage(attachment.type)) return
+    previewAttachment.value = attachment
+}
 </script>
 
 <template>
     <div class="chat-input-area">
         <div v-if="attachments.length > 0" class="attachment-previews">
             <div v-for="att in attachments" :key="att.id" class="attachment-preview" :class="{ image: isImage(att.type) }">
-                <img v-if="isImage(att.type)" :src="att.url" :alt="att.name" class="attachment-thumb" />
+                <button
+                    v-if="isImage(att.type)"
+                    type="button"
+                    class="attachment-thumb-button"
+                    :aria-label="att.name"
+                    @click="openAttachmentPreview(att)"
+                >
+                    <img :src="att.url" :alt="att.name" class="attachment-thumb" />
+                </button>
                 <div v-else class="attachment-file">
                     <span class="file-name">{{ att.name }}</span>
                     <span class="file-size">{{ formatSize(att.size) }}</span>
@@ -731,6 +748,12 @@ function isImage(type: string): boolean {
                 </button>
             </div>
         </div>
+        <ImagePreviewOverlay
+            v-if="previewAttachment"
+            :src="previewAttachment.url"
+            :alt="previewAttachment.name"
+            @close="previewAttachment = null"
+        />
         <div v-if="activeMessageReference" class="message-reference-preview">
             <span class="message-reference-text">{{ messageReferencePreview }}</span>
             <button
@@ -960,15 +983,32 @@ function isImage(type: string): boolean {
     border: 1px solid $border-color;
 
     &.image {
-        width: 64px;
-        height: 64px;
+        width: 112px;
+        height: 72px;
     }
 }
 
 .attachment-thumb {
+    display: block;
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
+}
+
+.attachment-thumb-button {
+    display: block;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    border: 0;
+    background:
+        linear-gradient(45deg, rgba(127, 127, 127, 0.08) 25%, transparent 25%),
+        linear-gradient(-45deg, rgba(127, 127, 127, 0.08) 25%, transparent 25%),
+        linear-gradient(45deg, transparent 75%, rgba(127, 127, 127, 0.08) 75%),
+        linear-gradient(-45deg, transparent 75%, rgba(127, 127, 127, 0.08) 75%);
+    background-position: 0 0, 0 6px, 6px -6px, -6px 0;
+    background-size: 12px 12px;
+    cursor: zoom-in;
 }
 
 .attachment-file {

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -33,6 +33,7 @@ import { isServerTtsProvider } from '@/api/studio/tts'
 import { groupAgentAvatar, groupMessageAgent, parseStoredAvatar } from '@/utils/group-agent-avatar'
 import GroupAgentMessageAvatar from './GroupAgentMessageAvatar.vue'
 import GroupAgentRobotIcon from './GroupAgentRobotIcon.vue'
+import ImagePreviewOverlay from '@/components/hermes/chat/ImagePreviewOverlay.vue'
 
 const MarkdownRenderer = defineAsyncComponent(async () => (await import('../chat/MarkdownRenderer.vue')).default)
 
@@ -876,9 +877,12 @@ onBeforeUnmount(() => {
             </div>
         </div>
     </div>
-    <div v-if="previewUrl" class="image-preview-overlay" @click.self="previewUrl = null">
-        <img :src="previewUrl" class="image-preview-img" @click="previewUrl = null" />
-    </div>
+    <ImagePreviewOverlay
+        v-if="previewUrl"
+        :src="previewUrl"
+        alt=""
+        @close="previewUrl = null"
+    />
 </template>
 
 <style scoped lang="scss">
@@ -1399,26 +1403,6 @@ onBeforeUnmount(() => {
         font-size: 11px;
         color: $text-muted;
     }
-}
-
-.image-preview-overlay {
-    position: fixed;
-    inset: 0;
-    z-index: 9999;
-    background: rgba(0, 0, 0, 0.82);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 24px;
-}
-
-.image-preview-img {
-    max-width: min(96vw, 1400px);
-    max-height: 92vh;
-    object-fit: contain;
-    border-radius: 6px;
-    cursor: zoom-out;
-    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
 }
 
 .thinking-block {

--- a/tests/client/chat-input-draft.test.ts
+++ b/tests/client/chat-input-draft.test.ts
@@ -144,6 +144,31 @@ describe('ChatInput draft persistence', () => {
     expect(wrapper.get('.attachment-file').text()).toContain('notes.txt')
   })
 
+  it('shows the full uploaded image in a lightbox before sending', async () => {
+    const wrapper = mountForSession('session-image-preview')
+    const image = new File(['image'], 'wide-screenshot.png', { type: 'image/png' })
+    const input = wrapper.get('input[type="file"]')
+    Object.defineProperty(input.element, 'files', { configurable: true, value: [image] })
+
+    await input.trigger('change')
+    await nextTick()
+
+    const thumb = wrapper.get('.attachment-thumb')
+    expect(thumb.attributes('src')).toBe('blob:chat-attachment')
+    expect(wrapper.get('.attachment-thumb-button').attributes('aria-label')).toBe('wide-screenshot.png')
+
+    await wrapper.get('.attachment-thumb-button').trigger('click')
+    await nextTick()
+
+    const lightbox = document.body.querySelector('.image-preview-overlay')
+    expect(lightbox).not.toBeNull()
+    expect(lightbox?.querySelector('img')?.getAttribute('src')).toBe('blob:chat-attachment')
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await nextTick()
+    expect(document.body.querySelector('.image-preview-overlay')).toBeNull()
+  })
+
   it('sends extracted video frames to the model without showing them as separate attachments', async () => {
     const wrapper = mountForSession('session-video')
     const chatStore = useChatStore()

--- a/tests/client/group-chat-input-mentions.test.ts
+++ b/tests/client/group-chat-input-mentions.test.ts
@@ -59,6 +59,26 @@ describe('GroupChatInput mentions', () => {
     expect(wrapper.get('.attachment-file').text()).toContain('group-notes.txt')
   })
 
+  it('opens an uploaded image preview before sending', async () => {
+    const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
+    const settingsStore = useSettingsStore()
+    settingsStore.display = {}
+    const wrapper = mount(GroupChatInput, {
+      global: { plugins: [pinia], stubs: { Transition: false } },
+    })
+    const image = new File(['image'], 'group-screenshot.png', { type: 'image/png' })
+    const input = wrapper.get('input[type="file"]')
+    Object.defineProperty(input.element, 'files', { configurable: true, value: [image] })
+
+    await input.trigger('change')
+    await nextTick()
+    await wrapper.get('.attachment-thumb-button').trigger('click')
+    await nextTick()
+
+    expect(document.body.querySelector('.image-preview-overlay img')?.getAttribute('src'))
+      .toBe('blob:group-attachment')
+  })
+
   it('updates mention suggestions after the textarea has a custom height', async () => {
     const pinia = createTestingPinia({ stubActions: false, createSpy: vi.fn })
     const settingsStore = useSettingsStore()


### PR DESCRIPTION
## Summary

- show uploaded image thumbnails with the complete image instead of center-cropping wide screenshots
- allow clicking an image attachment to open a full-screen preview before sending
- support click-to-close and Escape-to-close
- apply the same behavior to normal chat and group chat composers

## Validation

- `npm exec vitest run tests/client/chat-input-draft.test.ts tests/client/group-chat-input-mentions.test.ts` (38 passed)
- `npm run build`
