### PR TITLE
fix(chat): use quote icon for message references

### DIFF
--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -1288,8 +1288,8 @@ onBeforeUnmount(() => {
               :title="t('chat.referenceMessage')"
             >
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M9 17l-5-5 5-5" />
-                <path d="M20 18v-2a4 4 0 0 0-4-4H4" />
+                <path d="M8 9H5a2 2 0 0 0-2 2v2a2 2 0 0 0 2 2h3v1a3 3 0 0 1-3 3" />
+                <path d="M19 9h-3a2 2 0 0 0-2 2v2a2 2 0 0 0 2 2h3v1a3 3 0 0 1-3 3" />
               </svg>
             </button>
             <button

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -868,8 +868,8 @@ onBeforeUnmount(() => {
                     @click="referenceBubbleContent"
                 >
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M9 17l-5-5 5-5" />
-                        <path d="M20 18v-2a4 4 0 0 0-4-4H4" />
+                        <path d="M8 9H5a2 2 0 0 0-2 2v2a2 2 0 0 0 2 2h3v1a3 3 0 0 1-3 3" />
+                        <path d="M19 9h-3a2 2 0 0 0-2 2v2a2 2 0 0 0 2 2h3v1a3 3 0 0 1-3 3" />
                     </svg>
                 </button>
                 <span v-if="!embedded" class="message-time">{{ timeStr }}</span>

--- a/tests/client/group-message-item-highlight.test.ts
+++ b/tests/client/group-message-item-highlight.test.ts
@@ -106,6 +106,10 @@ describe('GroupMessageItem tool details', () => {
       global: { stubs: { MarkdownRenderer: true, ProfileAvatar: true } },
     })
 
+    expect(wrapper.get('.reference-bubble-btn svg').findAll('path').map(path => path.attributes('d'))).toEqual([
+      'M8 9H5a2 2 0 0 0-2 2v2a2 2 0 0 0 2 2h3v1a3 3 0 0 1-3 3',
+      'M19 9h-3a2 2 0 0 0-2 2v2a2 2 0 0 0 2 2h3v1a3 3 0 0 1-3 3',
+    ])
     await wrapper.get('.reference-bubble-btn').trigger('click')
 
     expect(store.activeMessageReference).toMatchObject({

--- a/tests/client/message-item-highlight.test.ts
+++ b/tests/client/message-item-highlight.test.ts
@@ -121,6 +121,10 @@ describe('MessageItem tool details', () => {
       global: { stubs: { MarkdownRenderer: true } },
     })
 
+    expect(wrapper.get('.reference-bubble-btn svg').findAll('path').map(path => path.attributes('d'))).toEqual([
+      'M8 9H5a2 2 0 0 0-2 2v2a2 2 0 0 0 2 2h3v1a3 3 0 0 1-3 3',
+      'M19 9h-3a2 2 0 0 0-2 2v2a2 2 0 0 0 2 2h3v1a3 3 0 0 1-3 3',
+    ])
     await wrapper.get('.reference-bubble-btn').trigger('click')
 
     expect(chatStore.activeMessageReference).toMatchObject({


### PR DESCRIPTION
## Summary
- replace the ambiguous reply-style reference action with a quote-marks icon
- keep single-chat and group-chat reference actions visually consistent
- preserve the existing tooltip, hit area, layout, and reference behavior
- add focused component assertions for the selected icon in both chat surfaces

## Visual

<img width="1200" height="620" alt="pr-before-after" src="https://github.com/user-attachments/assets/612fc941-3ed7-4094-b4fb-abbf1989bca8" />

## Validation
- `NODE_ENV=test npm run test -- tests/client/message-item-highlight.test.ts tests/client/group-message-item-highlight.test.ts` — 28 passed
- `mise x node@25.4.0 -- npm run harness:check` — passed
- `mise x node@25.4.0 -- npm run build` — passed
