### PR TITLE
fix: preserve session category collapse during refresh

### DIFF
--- a/docs/chat-chain-changes/2026-09-05-session-category-refresh-collapse.md
+++ b/docs/chat-chain-changes/2026-09-05-session-category-refresh-collapse.md
@@ -1,0 +1,11 @@
+# Preserve manual category collapse during session refresh
+
+The category reveal watcher now compares individual values instead of a newly
+allocated array on every session-list update. Polling and foreground refreshes,
+including refreshes that add visible categories, preserve manual collapse choices.
+Initial category loading, active-session navigation, and changes to the active
+session's category retain automatic reveal behavior. Recent shortcut suppression
+continues to preserve its category's collapse state.
+
+Browser regression coverage reproduces the polling failure and verifies foreground
+refresh with a new category, persisted collapse state, and ordinary navigation.

--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -680,21 +680,29 @@ function saveRecentCount() {
   showRecentCountModal.value = false;
 }
 
+const activeSessionCategoryKey = computed(() => {
+  const session = chatStore.sessions.find((item) => item.id === chatStore.activeSessionId);
+  return session?.categoryId == null ? "category-none" : `category-${session.categoryId}`;
+});
+
 watch(
-  () => [
-    sessionCategoriesLoaded.value,
-    categorizedSessions.value.map((group) => group.key).join("\u0000"),
-    chatStore.activeSessionId,
+  [
+    () => sessionCategoriesLoaded.value,
+    () => categorizedSessions.value.map((group) => group.key).join("\u0000"),
+    () => chatStore.activeSessionId,
+    activeSessionCategoryKey,
   ],
-  () => {
+  ([loaded, , sessionId, activeKey], [previousLoaded, , previousSessionId, previousActiveKey]) => {
     if (!sessionCategoriesLoaded.value || categorizedSessions.value.length === 0) return;
     const activeSession = chatStore.sessions.find((session) => session.id === chatStore.activeSessionId);
     if (categoryRevealSuppressedSessionId.value === activeSession?.id) return;
     setCategoryRevealSuppressedSessionId(null);
-    const activeKey = activeSession?.categoryId == null
-      ? "category-none"
-      : `category-${activeSession.categoryId}`;
-    if (collapsedCategories.value.has(activeKey)) {
+    // Only navigation or a changed category should reveal the active session.
+    // Background list refreshes must preserve manually collapsed groups.
+    const shouldReveal = loaded !== previousLoaded
+      || sessionId !== previousSessionId
+      || activeKey !== previousActiveKey;
+    if (shouldReveal && collapsedCategories.value.has(activeKey)) {
       collapsedCategories.value = new Set(
         [...collapsedCategories.value].filter((key) => key !== activeKey),
       );

--- a/tests/e2e/session-categories.spec.ts
+++ b/tests/e2e/session-categories.spec.ts
@@ -108,6 +108,57 @@ test('groups sessions by category and persists collapsed groups', async ({ page 
   await expect(recentHeader.locator('.session-group-count')).toHaveText('2')
 })
 
+test('keeps manually collapsed categories closed across polling and foreground refreshes', async ({ page }) => {
+  await authenticate(page, TEST_ACCESS_KEY, 'research')
+  await page.clock.install()
+  await page.addInitScript(() => {
+    (window as any).__PW_CHAT_SOCKET_RESUMES__ = Object.fromEntries(
+      ['work-session', 'notes-session'].map(sessionId => [sessionId, {
+        session_id: sessionId, messages: [], isWorking: false,
+      }]),
+    )
+  })
+  const sessions = [
+    sessionSummary('work-session', 'Project Alpha', 1, 200),
+    sessionSummary('notes-session', 'General Notes', null, 100),
+  ]
+  const api = await mockHermesApi(page, {
+    sessionCategories: [{ id: 1, name: 'Work' }, { id: 2, name: 'Other' }],
+    sessions,
+  })
+  await mockChatSocket(page)
+  await page.goto('/#/hermes/session/work-session')
+
+  const workHeader = page.locator('.session-group-header').filter({ hasText: 'Work' })
+  const workChevron = workHeader.locator('.group-chevron')
+  await expect(workChevron).not.toHaveClass(/collapsed/)
+  await workHeader.click()
+  await expect(workChevron).toHaveClass(/collapsed/)
+
+  await page.clock.runFor(100)
+  const listRequests = () => api.requests.filter(request => request.pathname === '/api/studio/sessions').length
+  const beforePoll = listRequests()
+  sessions[0].title = 'Project Alpha Updated'
+  await page.clock.fastForward(12_000)
+  await expect.poll(listRequests).toBeGreaterThan(beforePoll)
+  await expect(page.getByRole('link', { name: /Project Alpha Updated/ })).toHaveCount(1)
+  await expect(workChevron).toHaveClass(/collapsed/)
+
+  // A refresh that adds another visible category must also preserve the user's choice.
+  sessions.push(sessionSummary('other-session', 'Other Project', 2, 300))
+  await page.evaluate(() => document.dispatchEvent(new Event('visibilitychange')))
+  await expect(page.locator('.session-group-header').filter({ hasText: 'Other' })).toBeVisible()
+  await expect(workChevron).toHaveClass(/collapsed/)
+  await expect.poll(() => page.evaluate(() => localStorage.getItem('hermes_chat_collapsed_categories')))
+    .toContain('category-1')
+  await expect(page).toHaveURL(/\/hermes\/session\/work-session$/)
+
+  // Ordinary navigation still reveals the selected session's category.
+  await page.goto('/#/hermes/session/notes-session')
+  await page.goto('/#/hermes/session/work-session')
+  await expect(workChevron).not.toHaveClass(/collapsed/)
+})
+
 test('selects a recent session without expanding its collapsed category', async ({ page }) => {
   await authenticate(page, TEST_ACCESS_KEY, 'research')
   await mockHermesApi(page, {


### PR DESCRIPTION
## Summary

Manually collapsing the active session's category was undone by the next 12-second session-list refresh. The category reveal watcher treated each newly allocated source array as a change and reopened the category.

Watch individual values and reveal the active category only on initial category loading, session navigation, or a change to the active session's category. Polling and foreground refreshes preserve manual collapse choices, including when another category becomes visible. Recent shortcut behavior remains covered.

## Validation

- Reproduced the original failure with a browser regression test before the fix.
- `npm run test:e2e -- tests/e2e/session-categories.spec.ts --workers=2`
- `npm run test -- tests/client/chat-panel-session-click.test.ts tests/client/session-category-groups.test.ts tests/client/session-browser-prefs.test.ts`
- `npm run harness:check`
- `npm run build`
