### PR TITLE
fix(runtime): use isolated extraction on Windows

### DIFF
--- a/packages/server/src/modules/hermes/services/runtime/runtime-archive.ts
+++ b/packages/server/src/modules/hermes/services/runtime/runtime-archive.ts
@@ -8,7 +8,7 @@ function appendError(current: string, chunk: Buffer | string): string {
   return `${current}${chunk.toString()}`.slice(0, MAX_ERROR_LENGTH)
 }
 
-function extractWithWindowsTar(archive: string, targetRoot: string): Promise<void> {
+function extractWithWindowsTar(archive: string, targetRoot: string): Promise<boolean> {
   return new Promise((resolvePromise, rejectPromise) => {
     const child = spawn('tar.exe', ['-xzf', archive, '-C', targetRoot], {
       stdio: ['ignore', 'ignore', 'pipe'],
@@ -19,11 +19,16 @@ function extractWithWindowsTar(archive: string, targetRoot: string): Promise<voi
       stderr = appendError(stderr, chunk)
     })
     child.once('error', error => {
+      // Only a missing executable can safely fall back: extraction has not started.
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        resolvePromise(false)
+        return
+      }
       rejectPromise(new Error(`Windows tar.exe failed to start: ${error.message}`, { cause: error }))
     })
     child.once('close', (code, signal) => {
       if (code === 0) {
-        resolvePromise()
+        resolvePromise(true)
         return
       }
       const detail = stderr.trim() || `exit code ${code ?? 'unknown'}${signal ? `, signal ${signal}` : ''}`
@@ -33,8 +38,7 @@ function extractWithWindowsTar(archive: string, targetRoot: string): Promise<voi
 }
 
 export async function extractTarGzipArchive(archive: string, targetRoot: string): Promise<void> {
-  if (process.platform === 'win32') {
-    await extractWithWindowsTar(archive, targetRoot)
+  if (process.platform === 'win32' && await extractWithWindowsTar(archive, targetRoot)) {
     return
   }
 

--- a/packages/server/src/modules/hermes/services/runtime/runtime-archive.ts
+++ b/packages/server/src/modules/hermes/services/runtime/runtime-archive.ts
@@ -1,0 +1,47 @@
+import { spawn } from 'node:child_process'
+import * as tar from 'tar'
+
+const MAX_ERROR_LENGTH = 16 * 1024
+
+function appendError(current: string, chunk: Buffer | string): string {
+  if (current.length >= MAX_ERROR_LENGTH) return current
+  return `${current}${chunk.toString()}`.slice(0, MAX_ERROR_LENGTH)
+}
+
+function extractWithWindowsTar(archive: string, targetRoot: string): Promise<void> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn('tar.exe', ['-xzf', archive, '-C', targetRoot], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+      windowsHide: true,
+    })
+    let stderr = ''
+    child.stderr?.on('data', chunk => {
+      stderr = appendError(stderr, chunk)
+    })
+    child.once('error', error => {
+      rejectPromise(new Error(`Windows tar.exe failed to start: ${error.message}`, { cause: error }))
+    })
+    child.once('close', (code, signal) => {
+      if (code === 0) {
+        resolvePromise()
+        return
+      }
+      const detail = stderr.trim() || `exit code ${code ?? 'unknown'}${signal ? `, signal ${signal}` : ''}`
+      rejectPromise(new Error(`Windows tar.exe failed to extract Runtime archive: ${detail}`))
+    })
+  })
+}
+
+export async function extractTarGzipArchive(archive: string, targetRoot: string): Promise<void> {
+  if (process.platform === 'win32') {
+    await extractWithWindowsTar(archive, targetRoot)
+    return
+  }
+
+  await tar.x({
+    file: archive,
+    cwd: targetRoot,
+    preserveOwner: false,
+    unlink: false,
+  })
+}

--- a/packages/server/src/modules/hermes/services/runtime/version-manager.ts
+++ b/packages/server/src/modules/hermes/services/runtime/version-manager.ts
@@ -3,7 +3,7 @@ import { accessSync, constants, createReadStream, createWriteStream, existsSync,
 import { get as httpGet } from 'http'
 import { get as httpsGet } from 'https'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'path'
-import * as tar from 'tar'
+import { extractTarGzipArchive } from './runtime-archive'
 import { config } from '../../../studio/public/config'
 import { getHermesAgentVersion, getHermesWebUiVersion } from '../../../studio/public/system-info'
 import { updateAgentStatus } from '../../../studio/public/agent-status-registry'
@@ -636,15 +636,6 @@ async function sha256File(file: string): Promise<string> {
   return hash.digest('hex')
 }
 
-async function extractTarGzip(archive: string, targetRoot: string): Promise<void> {
-  await tar.x({
-    file: archive,
-    cwd: targetRoot,
-    preserveOwner: false,
-    unlink: true,
-  })
-}
-
 export async function downloadRuntimeVersion(version: string, source: VersionDownloadSource, onProgress?: DownloadProgressHandler): Promise<InstalledRuntimeVersion> {
   const cleanVersion = version.trim()
   if (!cleanVersion) throw new Error('Runtime version is required')
@@ -669,23 +660,32 @@ export async function downloadRuntimeVersion(version: string, source: VersionDow
   removeRuntimePath(tempRoot)
   mkdirSync(tempRoot, { recursive: true })
 
+  let archiveVerified = false
+  let installSucceeded = false
   try {
-    await downloadFile(assetUrl, archive, onProgress)
-    onProgress?.({ stage: 'verify', message: 'runtimeVersions.jobStage.verifyRuntime', percent: 100 })
-    if (asset.sha256) {
-      const actual = await sha256File(archive)
-      if (actual !== asset.sha256) throw new Error(`Runtime checksum mismatch for ${assetName}`)
+    if (asset.sha256 && existsSync(archive) && await sha256File(archive) === asset.sha256) {
+      archiveVerified = true
+      onProgress?.({ stage: 'verify', message: 'runtimeVersions.jobStage.verifyRuntime', percent: 100 })
+    } else {
+      await downloadFile(assetUrl, archive, onProgress)
+      onProgress?.({ stage: 'verify', message: 'runtimeVersions.jobStage.verifyRuntime', percent: 100 })
+      if (asset.sha256) {
+        const actual = await sha256File(archive)
+        if (actual !== asset.sha256) throw new Error(`Runtime checksum mismatch for ${assetName}`)
+      }
+      archiveVerified = true
     }
     onProgress?.({ stage: 'extract', message: 'runtimeVersions.jobStage.extractRuntime' })
-    await extractTarGzip(archive, tempRoot)
+    await extractTarGzipArchive(archive, tempRoot)
     validateRuntimeDirectory(tempRoot, platform)
     validateRuntimeAgentFiles(tempRoot)
     onProgress?.({ stage: 'install', message: 'runtimeVersions.jobStage.installRuntime' })
     removeRuntimePath(targetRoot)
     mkdirSync(dirname(targetRoot), { recursive: true })
     await renameRuntimePath(tempRoot, targetRoot)
+    installSucceeded = true
   } finally {
-    cleanupRuntimePath(archive)
+    if (!archiveVerified || installSucceeded) cleanupRuntimePath(archive)
     cleanupRuntimePath(tempRoot)
   }
 
@@ -726,7 +726,7 @@ export async function downloadWebUiVersion(version: string, source: VersionDownl
       if (actual !== manifest.asset.sha256) throw new Error(`Web UI checksum mismatch for ${assetName}`)
     }
     onProgress?.({ stage: 'extract', message: 'runtimeVersions.jobStage.extractWebUi' })
-    await extractTarGzip(archive, tempRoot)
+    await extractTarGzipArchive(archive, tempRoot)
     const extractedRoot = join(tempRoot, 'webui')
     for (const required of ['package.json', 'bin/hermes-web-ui.mjs', 'dist/server/index.js']) {
       if (!existsSync(join(extractedRoot, required))) throw new Error(`Web UI archive is missing required file: ${required}`)

--- a/tests/server/runtime-archive-windows.test.ts
+++ b/tests/server/runtime-archive-windows.test.ts
@@ -1,0 +1,86 @@
+import { EventEmitter } from 'node:events'
+import { spawn } from 'node:child_process'
+import * as tar from 'tar'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { extractTarGzipArchive } from '../../packages/server/src/modules/hermes/services/runtime/runtime-archive'
+
+vi.mock('node:child_process', () => ({ spawn: vi.fn() }))
+vi.mock('tar', () => ({ x: vi.fn() }))
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+const archive = 'C:\\下载 目录\\runtime.tar.gz'
+const target = 'C:\\安装 目录\\runtime'
+
+describe('Windows runtime archive fallback', () => {
+  let child: EventEmitter & { stderr: EventEmitter }
+
+  beforeEach(() => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    vi.resetAllMocks()
+    child = Object.assign(new EventEmitter(), { stderr: new EventEmitter() })
+    vi.mocked(spawn).mockReturnValue(child as ReturnType<typeof spawn>)
+    vi.mocked(tar.x).mockResolvedValue(undefined as never)
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  })
+
+  it('uses native tar first and passes paths as separate arguments', async () => {
+    const pending = extractTarGzipArchive(archive, target)
+    expect(spawn).toHaveBeenCalledWith('tar.exe', ['-xzf', archive, '-C', target], {
+      stdio: ['ignore', 'ignore', 'pipe'], windowsHide: true,
+    })
+    child.emit('close', 0, null)
+    await pending
+    expect(tar.x).not.toHaveBeenCalled()
+  })
+
+  it('falls back once when tar.exe cannot be found, including its subsequent close event', async () => {
+    const pending = extractTarGzipArchive(archive, target)
+    child.emit('error', Object.assign(new Error('spawn tar.exe ENOENT'), { code: 'ENOENT' }))
+    child.emit('close', -4058, null)
+    await pending
+    expect(tar.x).toHaveBeenCalledExactlyOnceWith({
+      file: archive, cwd: target, preserveOwner: false, unlink: false,
+    })
+  })
+
+  it.each(['EACCES', 'EPERM'])('does not fall back on %s startup errors', async (code) => {
+    const pending = extractTarGzipArchive(archive, target)
+    child.emit('error', Object.assign(new Error(code), { code }))
+    await expect(pending).rejects.toThrow(`Windows tar.exe failed to start: ${code}`)
+    expect(tar.x).not.toHaveBeenCalled()
+  })
+
+  it('preserves native extraction errors without retrying over partial output', async () => {
+    const pending = extractTarGzipArchive(archive, target)
+    child.stderr.emit('data', Buffer.from('invalid archive'))
+    child.emit('close', 1, null)
+    await expect(pending).rejects.toThrow('failed to extract Runtime archive: invalid archive')
+    expect(tar.x).not.toHaveBeenCalled()
+  })
+
+  it('does not fall back when the native extractor is terminated', async () => {
+    const pending = extractTarGzipArchive(archive, target)
+    child.emit('close', null, 'SIGTERM')
+    await expect(pending).rejects.toThrow('signal SIGTERM')
+    expect(tar.x).not.toHaveBeenCalled()
+  })
+
+  it('propagates failures from the fallback extractor', async () => {
+    vi.mocked(tar.x).mockRejectedValue(new Error('node extraction failed'))
+    const pending = extractTarGzipArchive(archive, target)
+    child.emit('error', Object.assign(new Error('not found'), { code: 'ENOENT' }))
+    await expect(pending).rejects.toThrow('node extraction failed')
+  })
+
+  it('uses Node tar directly on non-Windows platforms', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+    await extractTarGzipArchive(archive, target)
+    expect(spawn).not.toHaveBeenCalled()
+    expect(tar.x).toHaveBeenCalledExactlyOnceWith({
+      file: archive, cwd: target, preserveOwner: false, unlink: false,
+    })
+  })
+})

--- a/tests/server/runtime-archive.test.ts
+++ b/tests/server/runtime-archive.test.ts
@@ -1,0 +1,33 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import * as tar from 'tar'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { extractTarGzipArchive } from '../../packages/server/src/modules/hermes/services/runtime/runtime-archive'
+
+describe('server runtime archive extraction', () => {
+  let tempRoot: string | null = null
+
+  afterEach(() => {
+    if (tempRoot) rmSync(tempRoot, { recursive: true, force: true })
+    tempRoot = null
+  })
+
+  it('extracts gzip tar archives without mutating the archive', async () => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'hermes-server-runtime-extract-'))
+    const source = join(tempRoot, 'source')
+    const target = join(tempRoot, 'target')
+    const archive = join(tempRoot, 'runtime.tar.gz')
+    mkdirSync(join(source, 'python', 'Scripts'), { recursive: true })
+    writeFileSync(join(source, 'python', 'Scripts', 'hermes.exe'), 'launcher', 'utf8')
+
+    await tar.c({ file: archive, cwd: source, gzip: true }, ['python'])
+    mkdirSync(target)
+
+    await extractTarGzipArchive(archive, target)
+
+    expect(readFileSync(join(target, 'python', 'Scripts', 'hermes.exe'), 'utf8')).toBe('launcher')
+    expect(readFileSync(archive).subarray(0, 2)).toEqual(Buffer.from([0x1f, 0x8b]))
+  })
+})


### PR DESCRIPTION
## Summary

- isolate Windows Runtime archive extraction in a `tar.exe` child process instead of running `tar.x()` inside the Web service process
- preserve a checksum-verified Runtime download after extraction or installation failure so retries do not download the same large archive again
- keep the Node `tar` implementation for non-Windows platforms and add extraction coverage

## Problem

On Windows, Runtime updates can fail or make Hermes Studio appear to crash while extracting a valid Runtime archive. The archive can be extracted successfully with the system `tar.exe`, but the Web service process may exit during in-process Node tar extraction or the subsequent activation sequence. The existing `finally` block also deleted the verified archive after any post-download failure, forcing every retry to download the full archive again.

## Changes

- use `tar.exe -xzf <archive> -C <temporary-directory>` on Windows with captured stderr and a non-zero exit error
- do not pass `unlink: true` to the portable Node extractor
- reuse an existing archive when its SHA-256 matches the manifest
- retain a verified archive when extraction, validation, or installation fails; remove it after successful installation
- add a server extraction test that verifies the archive remains intact

## Validation

- `git diff --check` passes
- The repository checkout does not contain installed `vitest`, `typescript`, or `tar` dependencies, so the automated test suite could not be run in this workspace.

Fixes the Windows Runtime update path in Hermes Studio 0.7.17.
