### PR TITLE
fix: support split Runtime MCP modules in Agent Bridge

### DIFF
--- a/docs/chat-chain-changes/2026-09-05-bridge-mcp-split-imports.md
+++ b/docs/chat-chain-changes/2026-09-05-bridge-mcp-split-imports.md
@@ -1,0 +1,15 @@
+---
+date: 2026-09-05
+pr: pending
+feature: Agent Bridge MCP Runtime import compatibility
+impact: Restore MCP management and shutdown on split-module runtimes and avoid deprecated discovery aliases during chat startup.
+---
+
+Prefer the Runtime's `mcp_tool_loop` and `mcp_tool_discovery` modules, while
+retaining fallback imports for older runtimes where those modules are absent.
+Keep shared server state in `mcp_tool`. Do not fall back when a split module
+exists but fails to import a dependency. Missing MCP runtimes retain the
+existing config-only listing behavior.
+
+No configuration migration or Runtime source patch is required. Running bridge
+workers must be restarted after deployment to load the updated Python code.

--- a/packages/server/src/modules/hermes/services/bridge/python/bridge_runtime.py
+++ b/packages/server/src/modules/hermes/services/bridge/python/bridge_runtime.py
@@ -835,7 +835,12 @@ def _load_enabled_toolsets() -> list[str] | None:
 def _discover_bridge_mcp_tools() -> list[str]:
     _ensure_agent_imports()
     try:
-        from tools.mcp_tool import discover_mcp_tools
+        try:
+            from tools.mcp_tool_discovery import discover_mcp_tools
+        except ModuleNotFoundError as exc:
+            if exc.name != "tools.mcp_tool_discovery":
+                raise
+            from tools.mcp_tool import discover_mcp_tools
 
         tools = discover_mcp_tools()
         return list(tools) if isinstance(tools, list) else []

--- a/packages/server/src/modules/hermes/services/bridge/python/bridge_server.py
+++ b/packages/server/src/modules/hermes/services/bridge/python/bridge_server.py
@@ -365,7 +365,13 @@ class BridgeServer:
 
     def _shutdown_all_mcp_servers(self) -> int:
         try:
-            from tools.mcp_tool import _run_on_mcp_loop, _servers, _lock
+            from tools.mcp_tool import _servers, _lock
+            try:
+                from tools.mcp_tool_loop import _run_on_mcp_loop
+            except ModuleNotFoundError as exc:
+                if exc.name != "tools.mcp_tool_loop":
+                    raise
+                from tools.mcp_tool import _run_on_mcp_loop
         except ImportError:
             return 0
         with _lock:
@@ -375,7 +381,19 @@ class BridgeServer:
     def _handle_mcp_action(self, action: str, req: dict[str, Any], profile: str | None = None) -> dict[str, Any]:
         """Handle MCP management actions in worker process."""
         try:
-            from tools.mcp_tool import discover_mcp_tools, register_mcp_servers, _run_on_mcp_loop, _servers, _lock
+            from tools.mcp_tool import _servers, _lock
+            try:
+                from tools.mcp_tool_loop import _run_on_mcp_loop
+            except ModuleNotFoundError as exc:
+                if exc.name != "tools.mcp_tool_loop":
+                    raise
+                from tools.mcp_tool import _run_on_mcp_loop
+            try:
+                from tools.mcp_tool_discovery import discover_mcp_tools, register_mcp_servers
+            except ModuleNotFoundError as exc:
+                if exc.name != "tools.mcp_tool_discovery":
+                    raise
+                from tools.mcp_tool import discover_mcp_tools, register_mcp_servers
         except ImportError:
             # Older/minimal Hermes runtimes may not ship the live MCP module.
             # Keep config listing usable so Studio clients can render the MCP

--- a/tests/server/agent-bridge-mcp-imports.test.ts
+++ b/tests/server/agent-bridge-mcp-imports.test.ts
@@ -1,0 +1,94 @@
+import { execFileSync } from 'child_process'
+import { describe, expect, it } from 'vitest'
+
+describe('agent bridge MCP runtime imports', () => {
+  it.each(['split', 'legacy'])('supports %s runtime management, cleanup and discovery', (layout) => {
+    const output = execFileSync(process.platform === 'win32' ? 'python' : 'python3', ['-c', String.raw`
+import importlib.util
+import json
+import sys
+import threading
+import types
+from pathlib import Path
+
+path = Path("packages/server/src/modules/hermes/services/bridge/python/hermes_bridge.py")
+spec = importlib.util.spec_from_file_location("hermes_bridge", path)
+bridge = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = bridge
+spec.loader.exec_module(bridge)
+
+# No installed Hermes runtime or live MCP servers are needed.
+for name in list(sys.modules):
+    if name == "tools" or name.startswith("tools."):
+        del sys.modules[name]
+tools = types.ModuleType("tools")
+tools.__path__ = []
+sys.modules["tools"] = tools
+core = types.ModuleType("tools.mcp_tool")
+core._servers = {}
+core._lock = threading.RLock()
+sys.modules[core.__name__] = core
+calls = []
+def discover():
+    calls.append("discover")
+    return ["mcp_probe_read"]
+def register():
+    calls.append("register")
+def run_on_loop(fn, timeout):
+    calls.append("loop")
+    return fn()
+
+if sys.argv[1] == "split":
+    loop = types.ModuleType("tools.mcp_tool_loop")
+    loop._run_on_mcp_loop = run_on_loop
+    sys.modules[loop.__name__] = loop
+    discovery = types.ModuleType("tools.mcp_tool_discovery")
+    discovery.discover_mcp_tools = discover
+    discovery.register_mcp_servers = register
+    sys.modules[discovery.__name__] = discovery
+    # Access to deprecated aliases must never be attempted on split runtimes.
+    def reject_alias(name):
+        if name in ("discover_mcp_tools", "register_mcp_servers", "_run_on_mcp_loop"):
+            raise AssertionError("deprecated core alias: " + name)
+        raise AttributeError(name)
+    core.__getattr__ = reject_alias
+else:
+    sys.modules["tools.mcp_tool_loop"] = None
+    sys.modules["tools.mcp_tool_discovery"] = None
+    core._run_on_mcp_loop = run_on_loop
+    core.discover_mcp_tools = discover
+    core.register_mcp_servers = register
+
+server = bridge.BridgeServer("tcp://127.0.0.1:0")
+server._read_mcp_config = lambda profile: {"mcp_servers": {}}
+listed = server._handle_mcp_action("mcp_list", {}, "default")
+# Verify that reload dispatch receives the resolved functions and shared state.
+def reload(req, profile, servers, lock, run, discover_fn, register_fn):
+    assert servers is core._servers and lock is core._lock
+    assert run is run_on_loop
+    register_fn()
+    return {"ok": True, "tools": discover_fn()}
+server._mcp_reload = reload
+reloaded = server._handle_mcp_action("mcp_reload", {}, "default")
+class Task:
+    def shutdown(self):
+        calls.append("shutdown")
+core._servers["probe"] = Task()
+stopped = server._shutdown_all_mcp_servers()
+import bridge_runtime
+bridge_runtime._ensure_agent_imports = lambda: None
+discovered = bridge_runtime._discover_bridge_mcp_tools()
+print(json.dumps({"listed": listed["ok"], "reloaded": reloaded,
+                  "stopped": stopped, "remaining": len(core._servers),
+                  "discovered": discovered, "calls": calls}))
+`, layout], { cwd: process.cwd(), encoding: 'utf-8', stdio: 'pipe' })
+    expect(JSON.parse(output)).toEqual({
+      listed: true,
+      reloaded: { ok: true, tools: ['mcp_probe_read'] },
+      stopped: 1,
+      remaining: 0,
+      discovered: ['mcp_probe_read'],
+      calls: ['register', 'discover', 'loop', 'shutdown', 'discover'],
+    })
+  })
+})

--- a/tests/server/agent-bridge-mcp-tools-filter.test.ts
+++ b/tests/server/agent-bridge-mcp-tools-filter.test.ts
@@ -33,6 +33,9 @@ bridge = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = bridge
 spec.loader.exec_module(bridge)
 
+# Explicitly simulate an absent optional runtime, even on development hosts
+# where Hermes has already been imported during bridge initialization.
+sys.modules["tools.mcp_tool"] = None
 server = bridge.BridgeServer("tcp://127.0.0.1:0")
 server._read_mcp_config = lambda profile: {
     "mcp_servers": {

--- a/tests/server/agent-bridge-profile-env.test.ts
+++ b/tests/server/agent-bridge-profile-env.test.ts
@@ -473,6 +473,7 @@ def discover_mcp_tools():
     return ["mcp_anysearch_search"]
 mcp_tool.discover_mcp_tools = discover_mcp_tools
 sys.modules["tools.mcp_tool"] = mcp_tool
+sys.modules["tools.mcp_tool_discovery"] = mcp_tool
 
 run_agent = types.ModuleType("run_agent")
 class FakeAgent:


### PR DESCRIPTION
## Summary
- Fix Hermes MCP management returning 503 on split-module runtimes: import `_run_on_mcp_loop` from `tools.mcp_tool_loop` for both management and shutdown.
- Import discovery/registration from `tools.mcp_tool_discovery`, including chat startup discovery, avoiding deprecated aliases scheduled for removal on 2026-09-14.
- Retain legacy imports only when the corresponding split module is absent. Keep shared registry state in `tools.mcp_tool` and preserve config-only listing when the optional runtime is unavailable.
- Add isolated split/legacy regression tests covering management dispatch, reload function wiring, shutdown and startup discovery; make existing missing-runtime/profile fixtures deterministic on machines with Hermes installed.

## Why
Studio 0.7.17 with Runtime 0.21.0 reports a healthy bridge but `/api/hermes/mcp/tools` returns 503. The old `_run_on_mcp_loop` import raises ImportError, which is misclassified as an unavailable MCP runtime. The shutdown path also silently skips cleanup. No MCP URL/configuration or Runtime source changes are needed.

## Validation
- `npm ci --ignore-scripts --no-audit --no-fund`
- Focused Vitest: `agent-bridge-mcp-imports`, `agent-bridge-mcp-tools-filter`, `agent-bridge-profile-env`, `bridge-mcp-action`: **19/19 passed**.
- `npm run harness:check`: passed.
- `npm run build`: passed.
- `git diff --check`: passed.
- Expanded `agent-bridge-*.test.ts` + `bridge-mcp-action`: **123 passed, 4 failed**. The same four failures reproduce on unchanged main `efd63a10` in this environment: one learn-command missing-runtime fixture and three manager Python-resolution tests. No unrelated fixes are included.

## Deployment / limitations
Restart bridge/profile workers after deploying the updated Python files. This PR does not alter or restart the live deployment. Tests use fake runtime modules and do not connect to real MCP providers; post-deployment MCP reload and connection checks remain necessary.
