### PR TITLE
Support cloud transport for remote group Agents

### DIFF
--- a/packages/server/src/modules/studio/controllers/group-chat-agent-link.ts
+++ b/packages/server/src/modules/studio/controllers/group-chat-agent-link.ts
@@ -1,4 +1,5 @@
 import type { Context } from 'koa'
+import { normalizeCloudAgentMachineId } from '../services/group-chat/cloud-agent-auth'
 import { listProfileNamesFromDisk } from '../public/profile-config'
 import { canManageGroupChatRoom } from '../services/group-chat/access'
 import {
@@ -317,6 +318,7 @@ export async function connectLocalAgent(ctx: Context): Promise<void> {
     const manager = getGroupAgentOutboundRelayManager(() => server.getChatRunService())
     const connected = await manager.connect({
       cloudOrigin,
+      cloudMachineId: normalizeCloudAgentMachineId(body.cloudMachineId),
       targetOrigin,
       pairingTicket,
       agent,

--- a/packages/server/src/modules/studio/services/app-relay/client.ts
+++ b/packages/server/src/modules/studio/services/app-relay/client.ts
@@ -36,8 +36,13 @@ const ALLOWED_REQUEST_HEADERS = new Set([
   'range',
   'x-hermes-profile',
   'x-request-id',
+  'x-group-agent-request-secret',
+  'x-expected-sha256',
 ])
-const ALLOWED_SOCKET_NAMESPACES = new Set(['/chat-run', '/group-chat', '/workflow'])
+const ALLOWED_SOCKET_NAMESPACES = new Set(['/chat-run', '/group-chat', '/workflow', '/group-chat-agent-relay'])
+const ALLOWED_GROUP_AGENT_CLIENT_EVENTS = new Set([
+  'run.accepted', 'run.completed', 'run.failed', 'agent.event', 'agent.config.update', 'attachment.read', 'connector.revoke',
+])
 const ALLOWED_CHAT_RUN_CLIENT_EVENTS = new Set([
   'run',
   'resume',
@@ -612,6 +617,14 @@ export class AppRelayClient {
     localSocket.on('connect_error', (err: Error) => this.emitSocketEvent(bridge, 'connect_error', { message: err.message }))
     localSocket.on('disconnect', (reason: string) => this.emitSocketEvent(bridge, 'disconnect', { reason }))
     localSocket.onAny((event: string, ...args: unknown[]) => {
+      if (namespace === '/group-chat-agent-relay' && typeof args.at(-1) === 'function') {
+        const ack = args.pop() as (response: unknown) => void
+        if (!this.socket?.connected) { ack({ error: 'Agent relay is disconnected' }); return }
+        this.socket.timeout(330_000).emit('app.socket.event', {
+          id, namespace, event, payload: args.length <= 1 ? args[0] : args,
+        }, (error: Error | null, response: unknown) => ack(error ? { error: 'Agent response timed out' } : response))
+        return
+      }
       this.handleLocalSocketEvent(bridge, event, args.length <= 1 ? args[0] : args)
     })
     return { id, ok: true, namespace, stream: bridge.stream }
@@ -1179,6 +1192,7 @@ function isMediaHttpRequest(request: AppRelayHttpRequest): boolean {
 }
 
 function isAllowedSocketEvent(namespace: string, event: string): boolean {
+  if (namespace === '/group-chat-agent-relay') return ALLOWED_GROUP_AGENT_CLIENT_EVENTS.has(event)
   if (namespace === '/chat-run') return ALLOWED_CHAT_RUN_CLIENT_EVENTS.has(event)
   if (namespace === '/group-chat') return ALLOWED_GROUP_CHAT_CLIENT_EVENTS.has(event)
   if (namespace === '/workflow') return ALLOWED_WORKFLOW_CLIENT_EVENTS.has(event)

--- a/packages/server/src/modules/studio/services/group-chat/agent-relay.ts
+++ b/packages/server/src/modules/studio/services/group-chat/agent-relay.ts
@@ -5,6 +5,7 @@ import { basename, dirname, extname, join, resolve } from 'node:path'
 import type { Server, Socket as ServerSocket } from 'socket.io'
 import { io, type Socket as ClientSocket } from 'socket.io-client'
 import { config } from '../../public/config'
+import { groupAgentSocketAuth, normalizeCloudAgentMachineId } from './cloud-agent-auth'
 import { logger } from '../../public/logging'
 import {
   createGroupPrimaryAgentBridge,
@@ -1533,6 +1534,7 @@ class OutboundRelayEventSink implements GroupAgentEventSink {
 
 type PersistedOutboundLink = {
   cloudOrigin: string
+  cloudMachineId?: string
   targetOrigin: string
   connectorId: string
   credential: string
@@ -1563,13 +1565,13 @@ class OutboundRelayConnection {
   async connect(): Promise<PersistedOutboundLink> {
     const reconnecting = Boolean(this.link.connectorId && this.link.credential)
     this.socket = io(`${this.link.cloudOrigin}/group-chat-agent-relay`, {
-      auth: {
+      auth: groupAgentSocketAuth({
         protocolVersion: GROUP_AGENT_RELAY_PROTOCOL_VERSION,
         targetOrigin: this.link.targetOrigin,
         ...(reconnecting
           ? { connectorId: this.link.connectorId, credential: this.link.credential }
           : { pairingTicket: this.pairingTicket }),
-      },
+      }, this.link.cloudMachineId),
       transports: ['websocket'],
       reconnection: true,
       reconnectionAttempts: Infinity,
@@ -1606,12 +1608,12 @@ class OutboundRelayConnection {
             ...(inviteCode ? { inviteCode } : {}),
             agent: this.link.agent,
           }
-          this.socket!.auth = {
+          this.socket!.auth = groupAgentSocketAuth({
             protocolVersion: GROUP_AGENT_RELAY_PROTOCOL_VERSION,
             targetOrigin: this.link.targetOrigin,
             connectorId,
             credential,
-          }
+          }, this.link.cloudMachineId)
           void this.manager.persist(this.link)
             .then(() => resolve(this.link))
             .catch(reject)
@@ -1816,7 +1818,9 @@ class OutboundRelayConnection {
           ...(request.workspaceApi
             ? {
                 remoteWorkspaceApi: {
-                  endpoint: `${this.link.cloudOrigin}/api/studio/group-chat/remote-workspace/v1`,
+                  endpoint: this.link.cloudMachineId
+                    ? `${this.link.cloudOrigin}/api/group-agent-relay/${this.link.cloudMachineId}/${this.link.connectorId}/workspace`
+                    : `${this.link.cloudOrigin}/api/studio/group-chat/remote-workspace/v1`,
                   token: request.workspaceApi.token,
                   access: request.workspaceApi.access,
                 },
@@ -1998,11 +2002,13 @@ export class GroupAgentOutboundRelayManager {
 
   async connect(input: {
     cloudOrigin: string
+    cloudMachineId?: string
     targetOrigin: string
     pairingTicket: string
     agent: RemoteGroupAgentDescriptor
   }): Promise<{ connectorId: string; roomId?: string; roomName?: string; inviteCode?: string }> {
     const cloudOrigin = normalizeOrigin(input.cloudOrigin)
+    const cloudMachineId = normalizeCloudAgentMachineId(input.cloudMachineId)
     const targetOrigin = normalizeOrigin(input.targetOrigin)
     const ticket = String(input.pairingTicket || '').trim()
     if (!ticket) throw new Error('pairingTicket is required')
@@ -2010,6 +2016,7 @@ export class GroupAgentOutboundRelayManager {
     const key = `pairing:${ticket.slice(0, 12)}`
     const connection = new OutboundRelayConnection(this, key, {
       cloudOrigin,
+      ...(cloudMachineId ? { cloudMachineId } : {}),
       targetOrigin,
       connectorId: '',
       credential: '',
@@ -2055,6 +2062,7 @@ export class GroupAgentOutboundRelayManager {
   async listConnections(): Promise<Array<{
     connectorId: string
     cloudOrigin: string
+    cloudMachineId?: string
     targetOrigin: string
     roomId?: string
     roomName?: string
@@ -2068,6 +2076,7 @@ export class GroupAgentOutboundRelayManager {
       return links.map(link => ({
         connectorId: link.connectorId,
         cloudOrigin: link.cloudOrigin,
+        ...(link.cloudMachineId ? { cloudMachineId: link.cloudMachineId } : {}),
         targetOrigin: link.targetOrigin,
         ...(link.roomId ? { roomId: link.roomId } : {}),
         ...(link.roomName ? { roomName: link.roomName } : {}),
@@ -2209,7 +2218,7 @@ export class GroupAgentOutboundRelayManager {
 
   private sameRoomLink(link: PersistedOutboundLink, seed: PersistedOutboundLink): boolean {
     if (!seed.roomId || !link.roomId) return link.connectorId === seed.connectorId
-    return link.cloudOrigin === seed.cloudOrigin && link.roomId === seed.roomId
+    return link.cloudOrigin === seed.cloudOrigin && link.cloudMachineId === seed.cloudMachineId && link.roomId === seed.roomId
   }
 
   private async withPersistenceLock<T>(task: () => Promise<T>): Promise<T> {
@@ -2281,6 +2290,7 @@ export class GroupAgentOutboundRelayManager {
           if (!UUID_PATTERN.test(connectorId) || !/^[a-zA-Z0-9_-]{40,128}$/.test(credential)) continue
           links.push({
             cloudOrigin: normalizeOrigin(link.cloudOrigin),
+            ...(link.cloudMachineId ? { cloudMachineId: normalizeCloudAgentMachineId(link.cloudMachineId) } : {}),
             targetOrigin: normalizeOrigin(link.targetOrigin),
             connectorId,
             credential,

--- a/packages/server/src/modules/studio/services/group-chat/cloud-agent-auth.ts
+++ b/packages/server/src/modules/studio/services/group-chat/cloud-agent-auth.ts
@@ -1,0 +1,23 @@
+import { randomUUID } from 'node:crypto'
+import { createDeviceSignature, getPublicSystemInfo } from '../../public/system-info'
+
+export function normalizeCloudAgentMachineId(value: unknown): string | undefined {
+  if (value == null || value === '') return undefined
+  if (typeof value !== 'string' || !/^hwui_[A-Za-z0-9_-]{16,64}$/.test(value)) throw new Error('Invalid cloud Agent target machine')
+  return value
+}
+
+// Re-sign on every reconnect; only the target Studio interprets pairing credentials.
+export function groupAgentSocketAuth(auth: Record<string, unknown>, machineId?: string) {
+  if (!machineId) return auth
+  return (callback: (auth: Record<string, unknown>) => void): void => {
+    void (async () => {
+      const machine = await getPublicSystemInfo()
+      const nonce = randomUUID()
+      const timestamp = Date.now()
+      const signature = await createDeviceSignature(nonce, timestamp)
+      callback({ ...auth, machineId, sourceMachineId: machine.device_id,
+        publicKey: machine.device_public_key, nonce, timestamp, signature, machine })
+    })().catch(() => callback({ machineId }))
+  }
+}

--- a/tests/server/app-relay-client.test.ts
+++ b/tests/server/app-relay-client.test.ts
@@ -85,6 +85,41 @@ describe('AppRelayClient', () => {
     expect(auth.timestamp).toEqual(expect.any(Number))
   })
 
+  it('bridges Agent events and preserves acknowledgements from the source Studio', async () => {
+    const { startAppRelayClient } = await import('../../packages/server/src/modules/studio/services/app-relay/client')
+    startAppRelayClient({ relayUrl: 'https://relay.example', machineId: 'hwui_machine_1234567890', publicKey: 'key', localBaseUrl: 'http://127.0.0.1:8648', fetchImpl: vi.fn() as any })
+    const remote = sockets[0]
+    remote.connected = true
+    const openAck = vi.fn()
+    remote.__handlers.get('app.socket.open')({ id: 'agent-bridge', namespace: '/group-chat-agent-relay', auth: { pairingTicket: 'target-ticket' } }, openAck)
+    const local = sockets[1]
+    expect(local.__url).toBe('http://127.0.0.1:8648/group-chat-agent-relay')
+    expect(local.__options.auth).toEqual({ pairingTicket: 'target-ticket' })
+    expect(openAck).toHaveBeenCalledWith(expect.objectContaining({ ok: true }))
+    local.emit.mockImplementation((_event: string, payload: unknown, ack?: Function) => { ack?.({ accepted: payload }); return local })
+    const eventAck = vi.fn()
+    remote.__handlers.get('app.socket.event')({ id: 'agent-bridge', event: 'agent.config.update', payload: { name: 'Updated' }, ack: true }, eventAck)
+    await vi.waitFor(() => expect(eventAck).toHaveBeenCalledWith(expect.objectContaining({ ok: true, payload: { accepted: { name: 'Updated' } } })))
+    remote.emit.mockImplementation((_event: string, _payload: unknown, ack?: Function) => { ack?.(null, { ok: true }); return remote })
+    const approvalAck = vi.fn()
+    local.__onAny('approval.respond', { decision: 'allow' }, approvalAck)
+    expect(remote.emit).toHaveBeenCalledWith('app.socket.event', { id: 'agent-bridge', namespace: '/group-chat-agent-relay', event: 'approval.respond', payload: { decision: 'allow' } }, expect.any(Function))
+    expect(approvalAck).toHaveBeenCalledWith({ ok: true })
+    const denied = vi.fn()
+    remote.__handlers.get('app.socket.event')({ id: 'agent-bridge', event: 'run', payload: {} }, denied)
+    await vi.waitFor(() => expect(denied).toHaveBeenCalledWith(expect.objectContaining({ ok: false })))
+  })
+
+  it('forwards target-issued Agent request secrets and workspace hash preconditions', async () => {
+    const { startAppRelayClient } = await import('../../packages/server/src/modules/studio/services/app-relay/client')
+    const fetchImpl = vi.fn(async () => new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } }))
+    startAppRelayClient({ relayUrl: 'https://relay.example', machineId: 'hwui_machine_1234567890', publicKey: 'key', localBaseUrl: 'http://127.0.0.1:8648', fetchImpl: fetchImpl as any })
+    const ack = vi.fn()
+    sockets[0].__handlers.get('app.http.request')({ id: 'agent-status', method: 'GET', path: '/api/studio/group-chat/invites/code/agent-links/request', headers: { 'x-group-agent-request-secret': 'request-secret', 'x-expected-sha256': 'hash' } }, ack)
+    await vi.waitFor(() => expect(ack).toHaveBeenCalled())
+    expect(Object.fromEntries((fetchImpl.mock.calls as any)[0][1].headers.entries())).toMatchObject({ 'x-group-agent-request-secret': 'request-secret', 'x-expected-sha256': 'hash' })
+  })
+
   it('marks development Web UI relay hosts as non-preemptive', async () => {
     const { shouldReplaceExistingAppRelayHost } = await import(
       '../../packages/server/src/modules/studio/services/app-relay/connection'

--- a/tests/server/group-chat-agent-relay-manager.test.ts
+++ b/tests/server/group-chat-agent-relay-manager.test.ts
@@ -301,6 +301,28 @@ describe('group Agent outbound Relay persistence', () => {
     manager.shutdown()
   })
 
+  it('persists and restores cloud routing without merging rooms on different machines', async () => {
+    const connectorIds = ['11111111-2222-4333-8444-555555555555', '66666666-7777-4888-8999-000000000000']
+    let index = 0
+    ioMock.mockImplementation(() => createReadyRelaySocket(connectorIds[index++ % 2], { credential: 'r'.repeat(48), roomId: 'same-room' }))
+    const { GroupAgentOutboundRelayManager } = await import('../../packages/server/src/modules/studio/services/group-chat/agent-relay')
+    const agent = { agent: 'hermes' as const, profile: 'default', provider: '', model: '', apiMode: '', reasoningEffort: '', name: 'Remote Agent', description: '', avatar: '' }
+    const manager = new GroupAgentOutboundRelayManager(() => null)
+    for (const suffix of ['one', 'two']) await manager.connect({ cloudOrigin: 'https://cloud.example',
+      cloudMachineId: `hwui_target_machine_${suffix}_1234567890`, targetOrigin: 'http://source.example', pairingTicket: `ticket-${suffix}`, agent })
+    expect(typeof ioMock.mock.calls[0][1].auth).toBe('function')
+    expect((await manager.listConnections()).map(link => link.cloudMachineId)).toEqual(['hwui_target_machine_one_1234567890', 'hwui_target_machine_two_1234567890'])
+    expect(await manager.renameRoom(connectorIds[0], 'First machine only')).toBe(1)
+    manager.shutdown()
+    const restored = new GroupAgentOutboundRelayManager(() => null)
+    await restored.restore()
+    await vi.waitFor(async () => expect((await restored.listConnections()).filter(link => link.connected)).toHaveLength(2))
+    expect(typeof ioMock.mock.calls[2][1].auth).toBe('function')
+    expect(await restored.leaveRoom(connectorIds[0])).toEqual({ removed: 1, notified: 1 })
+    expect(await restored.listConnections()).toEqual([expect.objectContaining({ connectorId: connectorIds[1], cloudMachineId: 'hwui_target_machine_two_1234567890' })])
+    restored.shutdown()
+  })
+
   it('ignores the legacy root-level connection file without migrating it', async () => {
     const { legacyLinksFile, linksFile, manager } = await restorePersistedConnection(
       'websocket connection unavailable',

--- a/tests/server/group-chat-cloud-agent-auth.test.ts
+++ b/tests/server/group-chat-cloud-agent-auth.test.ts
@@ -1,0 +1,22 @@
+import { expect, it, vi } from 'vitest'
+import { groupAgentSocketAuth, normalizeCloudAgentMachineId } from '../../packages/server/src/modules/studio/services/group-chat/cloud-agent-auth'
+import { createDeviceSignature } from '../../packages/server/src/modules/studio/public/system-info'
+vi.mock('../../packages/server/src/modules/studio/public/system-info', () => ({
+  getPublicSystemInfo: vi.fn(async () => ({ device_id: 'hwui_source_machine_1234567890', device_public_key: 'source-key' })),
+  createDeviceSignature: vi.fn(async (nonce: string) => `signature:${nonce}`),
+}))
+it('keeps direct connections unchanged and signs fresh cloud handshakes on reconnect', async () => {
+  const credentials = { connectorId: 'connector', credential: 'target-secret', targetOrigin: 'http://source.example' }
+  expect(groupAgentSocketAuth(credentials)).toBe(credentials)
+  const auth = groupAgentSocketAuth(credentials, 'hwui_target_machine_1234567890') as Function
+  const first: any = await new Promise(resolve => auth(resolve))
+  const next: any = await new Promise(resolve => auth(resolve))
+  expect(first).toMatchObject({ ...credentials, machineId: 'hwui_target_machine_1234567890', sourceMachineId: 'hwui_source_machine_1234567890', publicKey: 'source-key' })
+  expect(first.nonce).not.toBe(next.nonce)
+  expect(createDeviceSignature).toHaveBeenCalledWith(next.nonce, next.timestamp)
+  expect(next.signature).toBe(`signature:${next.nonce}`)
+})
+it('rejects malformed cloud routing instead of falling back to a direct connection', () => {
+  expect(normalizeCloudAgentMachineId(undefined)).toBeUndefined()
+  for (const value of ['http://host', 'hwui_x', {}, 12]) expect(() => normalizeCloudAgentMachineId(value)).toThrow()
+})


### PR DESCRIPTION
Remote group guests in the App need to connect Agents running on their own Studio through the official cloud relay. Studio now accepts an optional target machine ID, signs fresh source-machine handshakes, persists the cloud route for reconnects, and routes run-scoped workspace requests through the cloud. Direct connections retain the existing protocol.

The App Relay host forwards the Agent namespace and preserves acknowledgements in both directions, including tool approvals and clarifications. Pairing, room permissions and Agent execution continue to use the existing target Studio logic. Connections to equal room IDs on different target machines remain isolated.

Validation:
- `npm run harness:check` and `npm run build` passed.
- Focused cloud authentication, Agent persistence, App Relay, remote workspace, group baseline and approval tests: 86 passed.
- Group sharing and room deep-link Playwright regression: 36 passed.
- Companion App and cloud relay changes were tested and pushed separately. Cloud operation requires these Studio changes on both source and target machines.
