### PR TITLE
fix(chat): restore reply arrow for message references

### DIFF
--- a/docs/chat-chain-changes/2026-09-05-restore-reference-arrow.md
+++ b/docs/chat-chain-changes/2026-09-05-restore-reference-arrow.md
@@ -1,0 +1,11 @@
+---
+date: 2026-09-05
+pr: pending
+feature: Restore message reference arrow
+impact: Direct-chat and group-chat reference buttons use the familiar reply arrow again; reference behavior is unchanged.
+---
+
+Restore the SVG paths used before #2893 at user request. Keep the existing
+button dimensions, tooltip, click handler and reference payload intact. Update
+both component regression tests to assert the restored icon while retaining
+reference-click behavior coverage.

--- a/packages/client/src/components/hermes/chat/MessageItem.vue
+++ b/packages/client/src/components/hermes/chat/MessageItem.vue
@@ -1289,8 +1289,8 @@ onBeforeUnmount(() => {
               :title="t('chat.referenceMessage')"
             >
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M8 9H5a2 2 0 0 0-2 2v2a2 2 0 0 0 2 2h3v1a3 3 0 0 1-3 3" />
-                <path d="M19 9h-3a2 2 0 0 0-2 2v2a2 2 0 0 0 2 2h3v1a3 3 0 0 1-3 3" />
+                <path d="M9 17l-5-5 5-5" />
+                <path d="M20 18v-2a4 4 0 0 0-4-4H4" />
               </svg>
             </button>
             <button

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -869,8 +869,8 @@ onBeforeUnmount(() => {
                     @click="referenceBubbleContent"
                 >
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M8 9H5a2 2 0 0 0-2 2v2a2 2 0 0 0 2 2h3v1a3 3 0 0 1-3 3" />
-                        <path d="M19 9h-3a2 2 0 0 0-2 2v2a2 2 0 0 0 2 2h3v1a3 3 0 0 1-3 3" />
+                        <path d="M9 17l-5-5 5-5" />
+                        <path d="M20 18v-2a4 4 0 0 0-4-4H4" />
                     </svg>
                 </button>
                 <span v-if="!embedded" class="message-time">{{ timeStr }}</span>

--- a/tests/client/group-message-item-highlight.test.ts
+++ b/tests/client/group-message-item-highlight.test.ts
@@ -107,8 +107,8 @@ describe('GroupMessageItem tool details', () => {
     })
 
     expect(wrapper.get('.reference-bubble-btn svg').findAll('path').map(path => path.attributes('d'))).toEqual([
-      'M8 9H5a2 2 0 0 0-2 2v2a2 2 0 0 0 2 2h3v1a3 3 0 0 1-3 3',
-      'M19 9h-3a2 2 0 0 0-2 2v2a2 2 0 0 0 2 2h3v1a3 3 0 0 1-3 3',
+      'M9 17l-5-5 5-5',
+      'M20 18v-2a4 4 0 0 0-4-4H4',
     ])
     await wrapper.get('.reference-bubble-btn').trigger('click')
 

--- a/tests/client/message-item-highlight.test.ts
+++ b/tests/client/message-item-highlight.test.ts
@@ -122,8 +122,8 @@ describe('MessageItem tool details', () => {
     })
 
     expect(wrapper.get('.reference-bubble-btn svg').findAll('path').map(path => path.attributes('d'))).toEqual([
-      'M8 9H5a2 2 0 0 0-2 2v2a2 2 0 0 0 2 2h3v1a3 3 0 0 1-3 3',
-      'M19 9h-3a2 2 0 0 0-2 2v2a2 2 0 0 0 2 2h3v1a3 3 0 0 1-3 3',
+      'M9 17l-5-5 5-5',
+      'M20 18v-2a4 4 0 0 0-4-4H4',
     ])
     await wrapper.get('.reference-bubble-btn').trigger('click')
 


### PR DESCRIPTION
## Summary
- Restore the previous reply-arrow SVG on message reference buttons in both direct chat and group chat, as requested by the user after the quote-icon change in #2893.
- Keep button size, tooltip, click handler and reference payload unchanged.
- Update both component icon assertions while retaining existing reference behavior coverage; add the required chat-change fragment.

Refs #2893

## Validation
- `npm run test -- tests/client/message-item-highlight.test.ts tests/client/group-message-item-highlight.test.ts` — 28 passed.
- `PLAYWRIGHT_PORT=18723 npm run test:e2e -- tests/e2e/chat-streaming.spec.ts tests/e2e/group-chat-room-deeplink.spec.ts --workers=2` — 50 passed.
- `npm run harness:check` — passed.
- `npm run build` — passed (bundle-size warnings).
- `git diff --check` — passed.

No deployment, LPK installation or service restart is included.
