### PR TITLE
fix(group-chat): preserve remote Agent events and restore summary state

### DIFF
--- a/packages/server/src/modules/studio/controllers/group-chat-agent-link.ts
+++ b/packages/server/src/modules/studio/controllers/group-chat-agent-link.ts
@@ -312,7 +312,7 @@ export async function connectLocalAgent(ctx: Context): Promise<void> {
     const cloudOrigin = normalizeCloudOrigin(body.cloudOrigin)
     const targetOrigin = normalizeGroupAgentTargetOrigin(body.targetOrigin)
     const pairingTicket = String(body.pairingTicket || '').trim()
-    const agent = normalizeRemoteGroupAgentDescriptor(body.agent)
+    const agent = normalizeRemoteGroupAgentDescriptor(body.agent, 'connection request')
     assertAgentAvailable(agent.agent)
     if (!pairingTicket) throw new Error('pairingTicket is required')
     const manager = getGroupAgentOutboundRelayManager(() => server.getChatRunService())

--- a/packages/server/src/modules/studio/services/app-relay/client.ts
+++ b/packages/server/src/modules/studio/services/app-relay/client.ts
@@ -617,15 +617,18 @@ export class AppRelayClient {
     localSocket.on('connect_error', (err: Error) => this.emitSocketEvent(bridge, 'connect_error', { message: err.message }))
     localSocket.on('disconnect', (reason: string) => this.emitSocketEvent(bridge, 'disconnect', { reason }))
     localSocket.onAny((event: string, ...args: unknown[]) => {
+      // Agent relay events carry one payload. Socket.IO recovery appends an
+      // offset argument which belongs to this local connection, not the relay.
+      const payload = namespace === '/group-chat-agent-relay' ? args[0] : args.length <= 1 ? args[0] : args
       if (namespace === '/group-chat-agent-relay' && typeof args.at(-1) === 'function') {
         const ack = args.pop() as (response: unknown) => void
         if (!this.socket?.connected) { ack({ error: 'Agent relay is disconnected' }); return }
         this.socket.timeout(330_000).emit('app.socket.event', {
-          id, namespace, event, payload: args.length <= 1 ? args[0] : args,
+          id, namespace, event, payload,
         }, (error: Error | null, response: unknown) => ack(error ? { error: 'Agent response timed out' } : response))
         return
       }
-      this.handleLocalSocketEvent(bridge, event, args.length <= 1 ? args[0] : args)
+      this.handleLocalSocketEvent(bridge, event, payload)
     })
     return { id, ok: true, namespace, stream: bridge.stream }
   }

--- a/packages/server/src/modules/studio/services/group-chat/agent-relay-store.ts
+++ b/packages/server/src/modules/studio/services/group-chat/agent-relay-store.ts
@@ -30,8 +30,13 @@ function boundedText(value: unknown, maxLength: number, field: string, required 
   return text
 }
 
-export function normalizeRemoteGroupAgentDescriptor(value: unknown): RemoteGroupAgentDescriptor {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('Invalid remote Agent')
+export function normalizeRemoteGroupAgentDescriptor(
+  value: unknown,
+  source?: 'connection request' | 'relay confirmation',
+): RemoteGroupAgentDescriptor {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Invalid remote Agent${source ? ` in ${source}` : ''}`)
+  }
   const input = value as Record<string, unknown>
   const agent = String(input.agent || 'hermes').trim() as RemoteGroupAgentDescriptor['agent']
   if (!REMOTE_AGENT_TYPES.has(agent)) throw new Error('Invalid remote Agent type')

--- a/packages/server/src/modules/studio/services/group-chat/agent-relay.ts
+++ b/packages/server/src/modules/studio/services/group-chat/agent-relay.ts
@@ -1591,7 +1591,7 @@ class OutboundRelayConnection {
           const roomId = boundedRelayText(data.roomId || this.link.roomId || '', 160, 'room id')
           const roomName = boundedRelayText(data.roomName || this.link.roomName || roomId, 120, 'room name')
           const inviteCode = boundedRelayText(data.inviteCode || this.link.inviteCode || '', 160, 'invite code')
-          const relayAgent = normalizeRemoteGroupAgentDescriptor(data.agent)
+          const relayAgent = normalizeRemoteGroupAgentDescriptor(data.agent, 'relay confirmation')
           if (
             !UUID_PATTERN.test(connectorId)
             || !/^[a-zA-Z0-9_-]{40,128}$/.test(credential)

--- a/packages/server/src/modules/studio/sockets/group-chat.ts
+++ b/packages/server/src/modules/studio/sockets/group-chat.ts
@@ -4346,6 +4346,7 @@ export class GroupChatServer {
             historyTruncated,
             typingUsers: this.getTypingUsers(roomId),
             contextStatuses: this.getContextStatuses(roomId),
+            roomSummary: this.roomSummaryService.getState(roomId),
             executionQueue: this.executionQueueSnapshot(roomId),
             pendingApprovals: this.pendingApprovalSnapshots(roomId, socket),
             pendingClarifies: this.canSocketManageRoom(socket, roomId) ? this.pendingClarifySnapshots(roomId) : [],

--- a/tests/server/app-relay-agent-transport.test.ts
+++ b/tests/server/app-relay-agent-transport.test.ts
@@ -1,0 +1,56 @@
+import { createServer } from 'node:http'
+import { Server, type Socket } from 'socket.io'
+import { expect, it, vi } from 'vitest'
+import { startAppRelayClient, stopAppRelayClient } from '../../packages/server/src/modules/studio/services/app-relay/client'
+
+vi.mock('../../packages/server/src/modules/studio/public/system-info', () => ({
+  createDeviceSignature: async () => 'test-signature',
+}))
+
+it('keeps Agent payloads intact across a real Socket.IO connection with recovery enabled', async () => {
+  const targetHttp = createServer()
+  const cloudHttp = createServer()
+  const target = new Server(targetHttp, { connectionStateRecovery: {} })
+  const cloud = new Server(cloudHttp)
+  const agent = { agent: 'hermes', profile: 'default', name: 'Remote Agent' }
+  const ready = { connectorId: 'connector-1', agent }
+  const run = { runId: 'run-1', room: { id: 'room-1' } }
+  const forwarded: Array<{ event: string; payload: unknown }> = []
+  let relaySocket: Socket | undefined
+  target.of('/group-chat-agent-relay').on('connection', socket => {
+    relaySocket = socket
+    socket.emit('relay.ready', ready)
+    socket.emit('run.request', run)
+  })
+  let host: Socket | undefined
+  cloud.of('/app-relay').on('connection', socket => {
+    host = socket
+    socket.on('app.socket.event', (event, ack) => {
+      forwarded.push(event)
+      if (event.event === 'approval.respond') ack?.({ ok: true })
+    })
+  })
+  const listen = async (server: ReturnType<typeof createServer>) => {
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+    return `http://127.0.0.1:${(server.address() as { port: number }).port}`
+  }
+  try {
+    const targetOrigin = await listen(targetHttp)
+    const cloudOrigin = await listen(cloudHttp)
+    startAppRelayClient({ relayUrl: cloudOrigin, machineId: 'hwui_machine_1234567890', publicKey: 'test-key', localBaseUrl: targetOrigin })
+    await vi.waitFor(() => expect(host?.connected).toBe(true))
+    const opened = await new Promise(resolve => host!.emit('app.socket.open', {
+      id: 'agent-bridge', namespace: '/group-chat-agent-relay', stream: true,
+    }, resolve))
+    expect(opened).toMatchObject({ ok: true })
+    await vi.waitFor(() => expect(forwarded).toContainEqual(expect.objectContaining({ event: 'run.request', payload: run })))
+    expect(forwarded).toContainEqual(expect.objectContaining({ event: 'relay.ready', payload: ready }))
+    const approvalAck = vi.fn()
+    relaySocket!.emit('approval.respond', { decision: 'allow' }, approvalAck)
+    await vi.waitFor(() => expect(approvalAck).toHaveBeenCalledWith({ ok: true }))
+    expect(forwarded).toContainEqual(expect.objectContaining({ event: 'approval.respond', payload: { decision: 'allow' } }))
+  } finally {
+    stopAppRelayClient()
+    await Promise.all([new Promise<void>(resolve => target.close(() => resolve())), new Promise<void>(resolve => cloud.close(() => resolve()))])
+  }
+})

--- a/tests/server/app-relay-client.test.ts
+++ b/tests/server/app-relay-client.test.ts
@@ -110,6 +110,22 @@ describe('AppRelayClient', () => {
     await vi.waitFor(() => expect(denied).toHaveBeenCalledWith(expect.objectContaining({ ok: false })))
   })
 
+  it('forwards single Agent payloads without Socket.IO recovery offsets', async () => {
+    const { startAppRelayClient } = await import('../../packages/server/src/modules/studio/services/app-relay/client')
+    startAppRelayClient({ relayUrl: 'https://relay.example', machineId: 'hwui_machine_1234567890', publicKey: 'key', localBaseUrl: 'http://127.0.0.1:8648', fetchImpl: vi.fn() as any })
+    const remote = sockets[0]
+    remote.connected = true
+    remote.__handlers.get('app.socket.open')({ id: 'agent-recovery', namespace: '/group-chat-agent-relay', auth: {} }, vi.fn())
+    const local = sockets[1]
+    for (const event of ['relay.ready', 'run.request', 'run.interrupt', 'room.metadata', 'connector.revoked']) {
+      const payload = { agent: { name: 'Remote Agent' }, runId: 'run-1' }
+      local.__onAny(event, payload, 'recovery-offset')
+      expect(remote.emit).toHaveBeenLastCalledWith('app.socket.event', {
+        id: 'agent-recovery', namespace: '/group-chat-agent-relay', event, payload,
+      })
+    }
+  })
+
   it('forwards target-issued Agent request secrets and workspace hash preconditions', async () => {
     const { startAppRelayClient } = await import('../../packages/server/src/modules/studio/services/app-relay/client')
     const fetchImpl = vi.fn(async () => new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } }))

--- a/tests/server/group-chat-baseline.test.ts
+++ b/tests/server/group-chat-baseline.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../../packages/server/src/modules/studio/sockets/group-chat'
 import {
   GroupAgentRelayServer,
+  GroupAgentOutboundRelayManager,
   redactRelaySecrets,
   relayRoomWorkspace,
   validateRelayRunRequest,
@@ -124,6 +125,20 @@ describe('group chat baseline behavior', () => {
     expect(joined.members).toEqual(expect.arrayContaining([
       expect.objectContaining({ name: 'Alice', connectionStatus: 'online' }),
     ]))
+  })
+
+  it('includes the current summary state when entering or reconnecting to a room', async () => {
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-summary', 'Summary Room', 'SUMMARY1')
+    const summary = groupServer.getRoomSummaryService().getState('room-summary')
+    expect(storage.claimRoomSummaryRun('room-summary', summary, 'summary-run', Date.now() + 60_000)).toBe(true)
+    const guest = await connectGroupChatClient(port, 'summary-guest', 'Guest')
+    harness.sockets.push(guest)
+    const joined = await emitAck<any>(guest, 'join', { roomId: 'room-summary', inviteCode: 'SUMMARY1' })
+    expect(joined.roomSummary).toMatchObject({ roomId: 'room-summary', status: 'summarizing' })
+    storage.saveRoomSummary({ ...joined.roomSummary, status: 'success', summary: 'Updated summary', updatedAt: Date.now() })
+    const rejoined = await emitAck<any>(guest, 'join', { roomId: 'room-summary', inviteCode: 'SUMMARY1' })
+    expect(rejoined.roomSummary).toMatchObject({ status: 'success', summary: 'Updated summary' })
   })
 
   it('honors the requested initial history page size when joining', async () => {
@@ -554,6 +569,58 @@ describe('group chat baseline behavior', () => {
       'local relay failed',
     )).toMatchObject({ status: 'failed', failureReason: 'local relay failed' })
     expect(relayStore.claimGroupAgentPairingTicket(pairingTicket, 1_300)).toBeNull()
+  })
+
+  it('connects and edits an approved Agent through the real outbound and inbound relay sockets', async () => {
+    const relayStore = await import('../../packages/server/src/modules/studio/services/group-chat/agent-relay-store')
+    const storage = groupServer.getStorage()
+    storage.saveRoom('room-approved', 'Approved Room', 'APPROVED1')
+    storage.updateRoomGuestAgentPolicy('room-approved', {
+      allowGuestAgents: true,
+      maxGuestAgentsPerMember: 1,
+      allowRemoteWorkspaceAccess: false,
+    })
+    const agent = relayStore.normalizeRemoteGroupAgentDescriptor({
+      agent: 'hermes', profile: 'default', name: 'Approved Agent',
+    })
+    const created = relayStore.createGroupAgentPairingRequest({
+      roomId: 'room-approved', ownerMemberId: 'guest-approved', ownerName: 'Guest',
+      targetOrigin: 'http://127.0.0.1:8648', agent,
+    })
+    relayStore.decideGroupAgentPairingRequest(created.request.id, true, 1)
+    vi.spyOn(AgentClient.prototype, 'connect').mockResolvedValue()
+    vi.spyOn(AgentClient.prototype, 'joinRoom').mockResolvedValue({
+      roomId: 'room-approved', roomName: 'Approved Room', inviteCode: 'APPROVED1',
+      members: [], messages: [], rooms: ['room-approved'],
+    })
+    const relayServer = new GroupAgentRelayServer(groupServer.getIO(), groupServer)
+    const manager = new GroupAgentOutboundRelayManager(() => null)
+    const persist = vi.spyOn(manager, 'persist').mockResolvedValue()
+    try {
+      const connected = await manager.connect({
+        cloudOrigin: `http://127.0.0.1:${port}`, targetOrigin: 'http://127.0.0.1:8648',
+        pairingTicket: created.pairingTicket, agent,
+      })
+      expect(connected.roomId).toBe('room-approved')
+      expect(persist).toHaveBeenCalledWith(expect.objectContaining({ agent }))
+      expect(relayStore.getGroupAgentPairingRequest(created.request.id)?.status).toBe('consumed')
+      const updated = await manager.updateConnection(connected.connectorId, { ...agent, description: 'Updated remotely' })
+      expect(updated.agent.description).toBe('Updated remotely')
+      expect(storage.getRoomAgents('room-approved')[0].description).toBe('Updated remotely')
+    } finally {
+      manager.shutdown()
+      relayServer.shutdown()
+    }
+  })
+
+  it('identifies whether missing Agent data came from the connection request or relay confirmation', async () => {
+    const { normalizeRemoteGroupAgentDescriptor } = await import('../../packages/server/src/modules/studio/services/group-chat/agent-relay-store')
+    for (const value of [undefined, null, 'hermes', []]) {
+      expect(() => normalizeRemoteGroupAgentDescriptor(value, 'connection request'))
+        .toThrow('Invalid remote Agent in connection request')
+      expect(() => normalizeRemoteGroupAgentDescriptor(value, 'relay confirmation'))
+        .toThrow('Invalid remote Agent in relay confirmation')
+    }
   })
 
   it('releases a pairing claim after an origin mismatch and accepts the intended target once', async () => {

--- a/tests/server/group-chat-member-sync.test.ts
+++ b/tests/server/group-chat-member-sync.test.ts
@@ -28,6 +28,7 @@ vi.mock('../../packages/server/src/modules/studio/services/auth/token-auth', () 
 
 import { AgentClients, groupBridgeSessionId } from '../../packages/server/src/modules/studio/services/group-chat/agent-clients'
 import { GroupChatServer } from '../../packages/server/src/modules/studio/sockets/group-chat'
+import type { GroupRoomSummaryService } from '../../packages/server/src/modules/studio/services/group-chat/room-summary'
 import { canManageGroupChatRoom, isGroupChatRoomOwner } from '../../packages/server/src/modules/studio/services/group-chat/access'
 import { groupChatRoutes, setGroupChatServer } from '../../packages/server/src/modules/studio/routes/group-chat'
 import {
@@ -39,6 +40,22 @@ function routeHandler(path: string, method: string) {
   const layer = (groupChatRoutes as any).stack.find((item: any) => item.path === path && item.methods.includes(method))
   if (!layer) throw new Error(`Route not found: ${method} ${path}`)
   return layer.stack[0]
+}
+
+function createRoomSummaryServiceMock(): Pick<GroupRoomSummaryService, 'getState'> {
+  return {
+    getState: vi.fn((roomId: string) => ({
+      roomId,
+      summary: '',
+      summaryThroughMessageId: '',
+      summaryThroughMessageTimestamp: 0,
+      summarizedTurnCount: 0,
+      status: 'idle',
+      version: 0,
+      updatedAt: 0,
+      lastError: null,
+    })),
+  }
 }
 
 describe('Group Chat member/agent identity sync', () => {
@@ -1340,6 +1357,7 @@ describe('Group Chat member/agent identity sync', () => {
     server.userInfoMap = new Map([['agent-stable-1', { name: 'Worker', description: 'runtime agent' }]])
     server.typingState = new Map()
     server.contextStatusState = new Map()
+    server.roomSummaryService = createRoomSummaryServiceMock()
     server.storage = {
       getRoom: vi.fn(() => ({ id: 'room-1', name: 'Room', inviteCode: 'secret', ownerAuthUserId: 7 })),
       getRoomAgentByAgentId: vi.fn(() => ({ id: 'row-1', roomId: 'room-1', agentId: 'agent-stable-1', profile: 'default', name: 'Worker', description: '', invited: 0 })),
@@ -1360,6 +1378,8 @@ describe('Group Chat member/agent identity sync', () => {
 
     server.handleJoin(socket, { roomId: 'room-1' }, ack)
 
+    expect(server.roomSummaryService.getState).toHaveBeenCalledWith('room-1')
+    expect(ack.mock.calls[0][0].roomSummary).toMatchObject({ roomId: 'room-1', status: 'idle' })
     expect(server.storage.getRoomAgentByAgentId).toHaveBeenCalledWith('room-1', 'agent-stable-1')
     expect(server.storage.addRoomMember).not.toHaveBeenCalled()
     expect(socket.join).toHaveBeenCalledWith('room-1')
@@ -1376,6 +1396,7 @@ describe('Group Chat member/agent identity sync', () => {
     server.userInfoMap = new Map([['auth:42', { name: 'alice', description: '' }]])
     server.typingState = new Map()
     server.contextStatusState = new Map()
+    server.roomSummaryService = createRoomSummaryServiceMock()
     server.storage = {
       getRoom: vi.fn(() => ({ id: 'room-1', name: 'Room', inviteCode: 'secret', ownerAuthUserId: 7 })),
       getRoomAgentByAgentId: vi.fn(() => null),
@@ -1421,6 +1442,7 @@ describe('Group Chat member/agent identity sync', () => {
     server.userInfoMap = new Map([['auth:42', { name: 'alice', description: '' }]])
     server.typingState = new Map()
     server.contextStatusState = new Map()
+    server.roomSummaryService = createRoomSummaryServiceMock()
     server.storage = {
       getRoom: vi.fn(() => ({ id: 'room-1', name: 'Room', inviteCode: null, ownerAuthUserId: 42 })),
       getRoomAgentByAgentId: vi.fn(() => null),
@@ -1477,6 +1499,7 @@ describe('Group Chat member/agent identity sync', () => {
     server.userInfoMap = new Map([['auth:42', { name: 'alice', description: '' }]])
     server.typingState = new Map()
     server.contextStatusState = new Map()
+    server.roomSummaryService = createRoomSummaryServiceMock()
     server.nsp = { to: vi.fn(() => ({ emit })) }
     server.storage = {
       getRoom: vi.fn(() => ({ id: 'room-1', name: 'Room', inviteCode: null, ownerAuthUserId: 42 })),
@@ -1541,6 +1564,7 @@ describe('Group Chat member/agent identity sync', () => {
     server.userInfoMap = new Map([['auth:42', { name: 'alice', description: '' }]])
     server.typingState = new Map()
     server.contextStatusState = new Map()
+    server.roomSummaryService = createRoomSummaryServiceMock()
     server.nsp = { to: vi.fn(() => ({ emit })) }
     server.storage = {
       getRoom: vi.fn(() => ({ id: 'room-1', name: 'Room', inviteCode: null, ownerAuthUserId: 42 })),
@@ -1595,6 +1619,7 @@ describe('Group Chat member/agent identity sync', () => {
     server.userInfoMap = new Map([['auth:42', { name: 'alice-login', description: '' }]])
     server.typingState = new Map()
     server.contextStatusState = new Map()
+    server.roomSummaryService = createRoomSummaryServiceMock()
     server.storage = {
       getRoomAgentByAgentId: vi.fn(() => null),
       getMemberByUserId: vi.fn(() => null),
@@ -1898,6 +1923,7 @@ describe('Group Chat member/agent identity sync', () => {
     server.userInfoMap = new Map([['auth:42', { name: '郑工', description: '' }]])
     server.typingState = new Map()
     server.contextStatusState = new Map()
+    server.roomSummaryService = createRoomSummaryServiceMock()
     server.storage = {
       getRoom: vi.fn(() => ({ id: 'room-1', name: 'Family Room', inviteCode: 'secret' })),
       getRoomAgentByAgentId: vi.fn(() => null),
@@ -1949,6 +1975,7 @@ describe('Group Chat member/agent identity sync', () => {
     server.userInfoMap = new Map([['auth:42', { name: 'default-name', description: '' }]])
     server.typingState = new Map()
     server.contextStatusState = new Map()
+    server.roomSummaryService = createRoomSummaryServiceMock()
     server.storage = {
       getRoom: vi.fn(() => ({ id: 'room-2', name: 'Work Room', inviteCode: 'work123' })),
       getRoomAgentByAgentId: vi.fn(() => null),
@@ -2000,6 +2027,7 @@ describe('Group Chat member/agent identity sync', () => {
     }]])
     server.typingState = new Map()
     server.contextStatusState = new Map()
+    server.roomSummaryService = createRoomSummaryServiceMock()
     server.storage = {
       getRoom: vi.fn(() => ({ id: 'room-1', name: 'Room' })),
       getRoomAgentByAgentId: vi.fn(() => null),


### PR DESCRIPTION
## Summary

After an owner approves a remote Agent, Socket.IO connection recovery appends an offset to events. The Studio App relay forwarded `[payload, offset]` as the payload, causing `Invalid remote Agent` during the relay confirmation and corrupting subsequent run events. Forward the single Agent event payload while preserving acknowledgement callbacks, and distinguish missing configuration in the connection request from missing configuration in the relay confirmation.

Include the current room summary in the group-chat join acknowledgement so clients can restore an in-progress summary after entering a room or reconnecting. Mobile UI consumption is a separate App change; this PR contains only the Studio changes. Initialize the summary service in the prototype-based member-sync test fixtures so join tests exercise the expanded acknowledgement.

## Validation

- `NODE_ENV=test PORT=8648 npm run test:coverage`: 4,952 passed, 6 skipped. Explicit environment overrides avoid inheriting the running desktop app configuration.
- Focused relay and group-chat tests: 51 passed, including real Socket.IO recovery transport, approval acknowledgement forwarding, approved Agent connection/editing, and summary join snapshots.
- `npm run harness:check`
- `npm run build`
- `npm run test:e2e -- tests/e2e/group-chat-share.spec.ts tests/e2e/group-chat-room-deeplink.spec.ts`: 36 passed.
