### PR TITLE
fix(chat): preview code-styled local file links

### DIFF
--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -82,6 +82,7 @@ const ConnectionsPanel = defineAsyncComponent(async () => (await import('@/compo
 const AgentManagerPanel = defineAsyncComponent(async () => (await import('@/views/hermes/AgentManagerView.vue')).default);
 const ModelsPanel = defineAsyncComponent(async () => (await import('@/views/hermes/ModelsView.vue')).default);
 const WorkspaceDiffPreview = defineAsyncComponent(async () => (await import('@/components/hermes/files/WorkspaceDiffPreview.vue')).default);
+const FilePreview = defineAsyncComponent(async () => (await import('@/components/hermes/files/FilePreview.vue')).default);
 const DesktopBrowserPanel = defineAsyncComponent(async () => (await import('./DesktopBrowserPanel.vue')).default);
 
 const chatStore = useChatStore();
@@ -105,9 +106,12 @@ const chatInputRef = ref<(InstanceType<typeof ChatInput> & {
 const chatContentWrapperRef = ref<HTMLElement | null>(null);
 const chatMainContentRef = ref<HTMLElement | null>(null);
 let sessionFadeAnimation: Animation | null = null;
+let workspacePreviewRequestSeq = 0;
+let workspacePreviewRequestPending = false;
 const chatDropCounter = ref(0);
 const isChatDropActive = ref(false);
 const showToolPanel = ref(false);
+const previewOnlyFileOpen = ref(false);
 const toolPanelTransitionReady = ref(false);
 const activeToolPanel = ref<"files" | "terminal" | "browser">("files");
 const desktopBrowserAvailable = hasDesktopBrowserBridge();
@@ -256,9 +260,12 @@ function closeToolPanelOverlay(): boolean {
     return false;
   }
   if (toolPanelStore.workspaceDiff && filesStore.editingFile) filesStore.closeEditor();
+  workspacePreviewRequestSeq += 1;
+  workspacePreviewRequestPending = false;
   filesStore.closePreview();
   toolPanelStore.closeWorkspaceDiff();
   selectedSubagent.value = null;
+  previewOnlyFileOpen.value = false;
   showToolPanel.value = false;
   return true;
 }
@@ -395,20 +402,33 @@ function workspacePreviewPath(filePath: string): string | null {
 }
 
 function handleWorkspaceFilePreviewRequest(event: Event) {
-  const customEvent = event as CustomEvent<{ path?: string; fileName?: string }>;
+  const customEvent = event as CustomEvent<{ path?: string; fileName?: string; previewOnly?: boolean }>;
   const sessionId = activePreviewSessionId.value;
   const filePath = typeof customEvent.detail?.path === "string" ? customEvent.detail.path : "";
   const previewPath = workspacePreviewPath(filePath);
   if (!sessionId || !previewPath) return;
 
   customEvent.preventDefault();
+  const requestSeq = ++workspacePreviewRequestSeq;
+  workspacePreviewRequestPending = true;
   const fileName = customEvent.detail?.fileName || previewPath.split("/").pop() || previewPath;
   filesStore.closePreview();
   toolPanelStore.closeWorkspaceDiff();
   selectedSubagent.value = null;
-  void filesStore.openSessionWorkspacePreview(sessionId, previewPath, fileName).catch((error) => {
-    message.error(error instanceof Error ? error.message : t("files.previewFailed"));
-  });
+  const previewOnly = customEvent.detail?.previewOnly === true;
+  previewOnlyFileOpen.value = previewOnly;
+  if (previewOnly) showToolPanel.value = true;
+  void filesStore.openSessionWorkspacePreview(sessionId, previewPath, fileName)
+    .then(() => {
+      if (requestSeq === workspacePreviewRequestSeq) workspacePreviewRequestPending = false;
+    })
+    .catch((error) => {
+      if (requestSeq !== workspacePreviewRequestSeq) return;
+      workspacePreviewRequestPending = false;
+      previewOnlyFileOpen.value = false;
+      if (previewOnly) showToolPanel.value = false;
+      message.error(error instanceof Error ? error.message : t("files.previewFailed"));
+    });
 }
 
 function handleOpenSubagentStreamRequest(event: Event) {
@@ -420,8 +440,11 @@ function handleOpenSubagentStreamRequest(event: Event) {
     return;
   }
   if (toolPanelStore.workspaceDiff && filesStore.editingFile) filesStore.closeEditor();
+  workspacePreviewRequestSeq += 1;
+  workspacePreviewRequestPending = false;
   filesStore.closePreview();
   toolPanelStore.closeWorkspaceDiff();
+  previewOnlyFileOpen.value = false;
   selectedSubagent.value = detail;
   showToolPanel.value = true;
 }
@@ -433,8 +456,11 @@ function handleOpenDesktopBrowserPanelRequest() {
     return;
   }
   if (toolPanelStore.workspaceDiff && filesStore.editingFile) filesStore.closeEditor();
+  workspacePreviewRequestSeq += 1;
+  workspacePreviewRequestPending = false;
   filesStore.closePreview();
   toolPanelStore.closeWorkspaceDiff();
+  previewOnlyFileOpen.value = false;
   selectedSubagent.value = null;
   activeToolPanel.value = "browser";
   showToolPanel.value = true;
@@ -459,11 +485,16 @@ onMounted(() => {
 watch(
   () => chatStore.activeSessionId,
   async (sessionId, previousSessionId) => {
-    if (!sessionId || !previousSessionId || sessionId === previousSessionId) return;
+    if (sessionId === previousSessionId || !previousSessionId) return;
 
-    if (filesStore.previewFile || toolPanelStore.workspaceDiff || selectedSubagent.value) {
+    if (filesStore.previewFile || toolPanelStore.workspaceDiff || selectedSubagent.value || previewOnlyFileOpen.value) {
       closeToolPanelOverlay();
+    } else {
+      workspacePreviewRequestSeq += 1;
+      workspacePreviewRequestPending = false;
+      filesStore.closePreview();
     }
+    if (!sessionId) return;
 
     await nextTick();
     // A session you just opened should be ready to type in. Without this the
@@ -498,7 +529,10 @@ onUnmounted(() => {
   window.removeEventListener("resize", handleToolPanelViewportResize);
   stopToolResize();
   sessionFadeAnimation?.cancel();
-  if (filesStore.previewFile?.workspaceSessionId) filesStore.closePreview();
+  workspacePreviewRequestSeq += 1;
+  if (workspacePreviewRequestPending || previewOnlyFileOpen.value || filesStore.previewFile?.workspaceSessionId) filesStore.closePreview();
+  workspacePreviewRequestPending = false;
+  previewOnlyFileOpen.value = false;
   toolPanelStore.closeWorkspaceDiff();
   sessionFadeAnimation = null;
 });
@@ -512,7 +546,11 @@ watch(
   () => toolPanelStore.workspaceDiff,
   (workspaceDiff) => {
     if (workspaceDiff) {
+      workspacePreviewRequestSeq += 1;
+      workspacePreviewRequestPending = false;
+      filesStore.closePreview();
       selectedSubagent.value = null;
+      previewOnlyFileOpen.value = false;
       showToolPanel.value = true;
     }
   },
@@ -3157,6 +3195,15 @@ async function handleSessionModelCustomSubmit() {
                   :stream="selectedSubagentStream"
                   @close="closeToolPanelOverlay"
                 />
+                <template v-else-if="previewOnlyFileOpen">
+                  <FilePreview
+                    v-if="filesStore.previewFile"
+                    :custom-close="closeToolPanelOverlay"
+                  />
+                  <div v-else class="chat-file-preview-loading">
+                    <NSpin size="small" />
+                  </div>
+                </template>
                 <template v-else>
                   <div class="chat-tool-tabs" role="tablist">
                     <button
@@ -4178,6 +4225,14 @@ async function handleSessionModelCustomSubmit() {
   min-height: 0;
   overflow: hidden;
   background: $bg-main-surface;
+}
+
+.chat-file-preview-loading {
+  flex: 1;
+  display: grid;
+  place-items: center;
+  min-width: 0;
+  min-height: 0;
 }
 
 .chat-tool-tabs {

--- a/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
+++ b/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
@@ -161,10 +161,10 @@ function localFilePathWithoutLocation(path: string): string {
   return locationMatch[1]
 }
 
-function requestWorkspaceFilePreview(path: string, fileName: string): boolean {
+function requestWorkspaceFilePreview(path: string, fileName: string, previewOnly = false): boolean {
   const event = new CustomEvent('hermes:preview-workspace-file', {
     cancelable: true,
-    detail: { path, fileName },
+    detail: { path, fileName, ...(previewOnly ? { previewOnly: true } : {}) },
   })
   window.dispatchEvent(event)
   return event.defaultPrevented
@@ -429,6 +429,16 @@ onBeforeUnmount(() => {
 })
 
 async function handleMarkdownClick(event: MouseEvent): Promise<void> {
+  const target = event.target as HTMLElement
+  const immediateLink = target.closest('a') as HTMLAnchorElement | null
+  const immediateHref = immediateLink?.getAttribute('href')
+  if (immediateHref && (isLocalFilePath(immediateHref) || immediateHref.startsWith('/api/studio/files/download?'))) {
+    // Native anchor navigation happens as soon as this async listener yields,
+    // so local-file links must be canceled before the first await.
+    event.preventDefault()
+    event.stopPropagation()
+  }
+
   const copyResult = await handleCodeBlockCopyClick(event)
   if (copyResult !== null) {
     if (copyResult) {
@@ -438,8 +448,6 @@ async function handleMarkdownClick(event: MouseEvent): Promise<void> {
     }
     return
   }
-
-  const target = event.target as HTMLElement
 
   // Handle image clicks for preview
   const img = target.closest('img') as HTMLImageElement | null
@@ -516,15 +524,24 @@ async function handleMarkdownClick(event: MouseEvent): Promise<void> {
     return
   }
 
-  // File path links: intercept and download
+  // Code-styled local file links intentionally remain ordinary Markdown links.
+  // Previewable files open as a single-file preview; unsupported files retain
+  // the existing download fallback.
   if (isLocalFilePath(href)) {
     event.preventDefault()
     event.stopPropagation()
     const linkText = link.textContent || ''
     const fileName = linkText.startsWith('File: ') ? linkText.slice(6).trim() : linkText.trim()
     const path = localFilePathWithoutLocation(href)
+    const downloadName = inferDownloadFileName(path, fileName || undefined)
+    if (isPreviewableFile(downloadName)) {
+      if (!requestWorkspaceFilePreview(path, downloadName, true)) {
+        message.error(t('files.previewFailed'))
+      }
+      return
+    }
     message.info(t('download.downloading'))
-    downloadFile(path, inferDownloadFileName(path, fileName || undefined)).catch((err: Error) => {
+    downloadFile(path, downloadName).catch((err: Error) => {
       message.error(err.message || t('download.downloadFailed'))
     })
   }

--- a/packages/client/src/stores/hermes/files.ts
+++ b/packages/client/src/stores/hermes/files.ts
@@ -59,6 +59,7 @@ export const useFilesStore = defineStore('files', () => {
   const sortBy = ref<'name' | 'size' | 'modTime'>('name')
   const sortOrder = ref<'asc' | 'desc'>('asc')
   let fetchRequestSeq = 0
+  let previewRequestSeq = 0
 
   const editingFile = ref<{
     path: string
@@ -82,6 +83,15 @@ export const useFilesStore = defineStore('files', () => {
     content?: string
     language?: string
   } | null>(null)
+
+  function beginPreviewRequest(): number {
+    return ++previewRequestSeq
+  }
+
+  function commitPreview(requestSeq: number, file: NonNullable<typeof previewFile.value>): void {
+    if (requestSeq !== previewRequestSeq) return
+    previewFile.value = file
+  }
 
   const pathSegments = computed(() => {
     if (!currentPath.value) return []
@@ -294,6 +304,7 @@ export const useFilesStore = defineStore('files', () => {
   ) {
     const type = getFilePreviewKind(fileName || filePath)
     if (!type) return
+    const requestSeq = beginPreviewRequest()
     const common = {
       path: filePath,
       name: fileName,
@@ -304,17 +315,17 @@ export const useFilesStore = defineStore('files', () => {
     }
     if (type === 'markdown' || type === 'text') {
       const result = await fetchSessionWorkspaceFileText(sessionId, filePath)
-      previewFile.value = type === 'markdown'
+      commitPreview(requestSeq, type === 'markdown'
         ? { ...common, size: result.size, content: result.content }
         : {
             ...common,
             size: result.size,
             content: result.content,
             language: getLanguageFromPath(filePath),
-          }
+          })
       return
     }
-    previewFile.value = common
+    commitPreview(requestSeq, common)
   }
 
   async function openGroupWorkspacePreview(
@@ -373,7 +384,10 @@ export const useFilesStore = defineStore('files', () => {
     return true
   }
 
-  function closePreview() { previewFile.value = null }
+  function closePreview() {
+    previewRequestSeq += 1
+    previewFile.value = null
+  }
 
   function selectDirectory(path: string) { currentPath.value = path }
 

--- a/tests/client/files-store.test.ts
+++ b/tests/client/files-store.test.ts
@@ -209,6 +209,38 @@ describe('files store', () => {
     })
   })
 
+  it('does not let an older session preview overwrite a newer file', async () => {
+    const olderPreview = deferred<{ content: string; size: number }>()
+    const newerPreview = deferred<{ content: string; size: number }>()
+    mockSessionsApi.fetchSessionWorkspaceFileText.mockImplementation((_sessionId: string, path: string) => {
+      return path === 'older.md' ? olderPreview.promise : newerPreview.promise
+    })
+    const store = useFilesStore()
+
+    const olderRequest = store.openSessionWorkspacePreview('session-1', 'older.md')
+    const newerRequest = store.openSessionWorkspacePreview('session-1', 'newer.md')
+    newerPreview.resolve({ content: '# Newer', size: 7 })
+    await newerRequest
+    expect(store.previewFile).toMatchObject({ path: 'newer.md', content: '# Newer' })
+
+    olderPreview.resolve({ content: '# Older', size: 7 })
+    await olderRequest
+    expect(store.previewFile).toMatchObject({ path: 'newer.md', content: '# Newer' })
+  })
+
+  it('does not reopen a pending session preview after it is closed', async () => {
+    const pendingPreview = deferred<{ content: string; size: number }>()
+    mockSessionsApi.fetchSessionWorkspaceFileText.mockReturnValue(pendingPreview.promise)
+    const store = useFilesStore()
+
+    const request = store.openSessionWorkspacePreview('session-1', 'pending.md')
+    store.closePreview()
+    pendingPreview.resolve({ content: '# Too late', size: 10 })
+    await request
+
+    expect(store.previewFile).toBeNull()
+  })
+
   it('opens image previews without reading file contents', async () => {
     const store = useFilesStore()
     const entry: FileEntry = {

--- a/tests/client/markdown-rendering.test.ts
+++ b/tests/client/markdown-rendering.test.ts
@@ -458,6 +458,58 @@ describe('MarkdownRenderer', () => {
     }
   })
 
+  it('keeps code-styled local file links as markdown while previewing them', async () => {
+    const previewRequests: Array<{ path: string; fileName: string; previewOnly?: boolean }> = []
+    const handlePreview = (event: Event) => {
+      const customEvent = event as CustomEvent<{ path: string; fileName: string; previewOnly?: boolean }>
+      previewRequests.push(customEvent.detail)
+      customEvent.preventDefault()
+    }
+    window.addEventListener('hermes:preview-workspace-file', handlePreview)
+    const wrapper = mount(MarkdownRenderer, {
+      props: {
+        content: '[`release-maintainer/SKILL.md`](</Users/zeeland/.hermes/skills/release-maintainer/SKILL.md>)',
+      },
+    })
+
+    try {
+      expect(wrapper.find('.markdown-file-card').exists()).toBe(false)
+      const link = wrapper.get('a')
+      expect(link.attributes('href')).toBe('/Users/zeeland/.hermes/skills/release-maintainer/SKILL.md')
+      expect(link.get('code').text()).toBe('release-maintainer/SKILL.md')
+      const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true })
+      link.element.dispatchEvent(clickEvent)
+      expect(clickEvent.defaultPrevented).toBe(true)
+      await vi.waitFor(() => {
+        expect(previewRequests).toEqual([{
+          path: '/Users/zeeland/.hermes/skills/release-maintainer/SKILL.md',
+          fileName: 'release-maintainer/SKILL.md',
+          previewOnly: true,
+        }])
+      })
+      expect(downloadApiMock.downloadFile).not.toHaveBeenCalled()
+    } finally {
+      wrapper.unmount()
+      window.removeEventListener('hermes:preview-workspace-file', handlePreview)
+    }
+  })
+
+  it('does not download a previewable code-styled link when no preview host accepts it', async () => {
+    const wrapper = mount(MarkdownRenderer, {
+      props: {
+        content: '[`release-maintainer/SKILL.md`](</tmp/release-maintainer/SKILL.md>)',
+      },
+    })
+    const link = wrapper.get('a')
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true })
+
+    link.element.dispatchEvent(clickEvent)
+    await vi.waitFor(() => expect(clickEvent.defaultPrevented).toBe(true))
+
+    expect(downloadApiMock.downloadFile).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
   it('removes line and column suffixes before previewing local workspace files', async () => {
     const previewRequests: Array<{ path: string; fileName: string }> = []
     const handlePreview = (event: Event) => {

--- a/tests/e2e/generated-file-preview.spec.ts
+++ b/tests/e2e/generated-file-preview.spec.ts
@@ -206,6 +206,103 @@ test('opens a Profile-generated package.json even when the session has no explic
   expect(api.unexpectedRequests).toEqual([])
 })
 
+test('opens the reported code-styled local file link in the side preview', async ({ page }) => {
+  const relativePath = 'release-maintainer/SKILL.md'
+  const absolutePath = `${sessionWorkspace}/${relativePath}`
+  await authenticate(page, TEST_ACCESS_KEY, 'research')
+  await page.addInitScript(({ id, label, path }) => {
+    ;(window as any).__PW_CHAT_SOCKET_RESUMES__ = {
+      [id]: {
+        session_id: id,
+        messages: [{
+          id: 1,
+          session_id: id,
+          role: 'assistant',
+          content: `Updated [\`${label}\`](<${path}>)`,
+          timestamp: 1_790_000_001,
+          tool_call_id: null,
+          tool_calls: null,
+          tool_name: null,
+          token_count: null,
+          finish_reason: null,
+          reasoning: null,
+        }],
+        isWorking: false,
+        events: [],
+      },
+    }
+  }, { id: sessionId, label: relativePath, path: absolutePath })
+
+  const api = await mockHermesApi(page, { sessions: [session] })
+  let previewRequestUrl = ''
+  let downloadRequests = 0
+  let releaseFirstPreview!: () => void
+  let releaseSecondPreview!: () => void
+  let markFirstPreviewStarted!: () => void
+  let markSecondPreviewStarted!: () => void
+  const firstPreviewGate = new Promise<void>(resolve => { releaseFirstPreview = resolve })
+  const secondPreviewGate = new Promise<void>(resolve => { releaseSecondPreview = resolve })
+  const firstPreviewStarted = new Promise<void>(resolve => { markFirstPreviewStarted = resolve })
+  const secondPreviewStarted = new Promise<void>(resolve => { markSecondPreviewStarted = resolve })
+  let previewRequestCount = 0
+  await page.route(`**/api/studio/sessions/${sessionId}/workspace-file/content**`, async route => {
+    previewRequestUrl = route.request().url()
+    if (previewRequestCount++ === 0) {
+      markFirstPreviewStarted()
+      await firstPreviewGate
+    } else {
+      markSecondPreviewStarted()
+      await secondPreviewGate
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/plain; charset=utf-8',
+      body: '# Release Maintainer\n\nOpened from the exact reported link shape.\n',
+    })
+  })
+  await page.route('**/api/studio/files/download**', async route => {
+    downloadRequests += 1
+    await route.fulfill({ status: 200, contentType: 'text/markdown', body: '# downloaded' })
+  })
+  await mockChatSocket(page)
+
+  await page.goto(`/#/hermes/session/${sessionId}`)
+  const fileLink = page.locator('.markdown-body a', { hasText: relativePath })
+  await expect(fileLink).toBeVisible({ timeout: 15_000 })
+  await expect(fileLink.locator('code')).toHaveText(relativePath)
+  await expect(page.locator('.markdown-file-card', { hasText: relativePath })).toHaveCount(0)
+  const toolPanel = page.locator('.chat-tool-panel')
+  await expect(toolPanel).toHaveCount(0)
+
+  await fileLink.click()
+  await firstPreviewStarted
+  await expect(toolPanel).toBeVisible()
+  await expect(toolPanel.locator('.chat-file-preview-loading')).toBeVisible()
+  await expect(toolPanel.locator('.files-tree-panel')).toHaveCount(0)
+  await expect(toolPanel.locator('.chat-tool-tabs')).toHaveCount(0)
+  releaseFirstPreview()
+  await expect(toolPanel.locator('.file-preview')).toBeVisible()
+  await toolPanel.getByRole('button', { name: 'Close', exact: true }).click()
+  await expect(toolPanel).toHaveCount(0)
+
+  await page.locator('.header-tool-toggle').click()
+  await expect(toolPanel.locator('.files-tree-panel')).toBeVisible()
+  await fileLink.click()
+  await secondPreviewStarted
+  await expect(toolPanel.locator('.chat-file-preview-loading')).toBeVisible()
+  await expect(toolPanel.locator('.files-tree-panel')).toHaveCount(0)
+  await expect(toolPanel.locator('.chat-tool-tabs')).toHaveCount(0)
+  releaseSecondPreview()
+  await expect(toolPanel.locator('.file-preview')).toBeVisible()
+  await expect(toolPanel.locator('.files-tree-panel')).toHaveCount(0)
+  await expect(toolPanel.locator('.chat-tool-tabs')).toHaveCount(0)
+  await expect(toolPanel.locator('.preview-filename')).toHaveText(relativePath)
+  await expect(toolPanel.locator('.preview-markdown')).toContainText('Opened from the exact reported link shape.')
+  expect(new URL(previewRequestUrl).searchParams.get('path')).toBe(relativePath)
+  expect(downloadRequests).toBe(0)
+  expect(api.unexpectedRequests).toEqual([])
+})
+
 test('HTML source mode remains scrollable while its scrollbar is hidden', async ({ page }) => {
   const htmlPath = `${sessionWorkspace}/long-preview.html`
   await authenticate(page, TEST_ACCESS_KEY, 'research')


### PR DESCRIPTION
## Summary
- preserve code-styled local file references as their original Markdown `<a><code>…</code></a>` output instead of converting them into attachment cards
- synchronously intercept previewable local-file clicks so native navigation/download cannot win the async click handler
- open a preview-only right panel immediately, using a loading state followed by `FilePreview` without the file tree, `No Data`, or tool tabs
- never auto-download a previewable link when no preview host accepts it; retain download fallback only for unsupported file types
- invalidate stale session-preview requests across rapid clicks, close, session changes, unmount, Browser, Subagent, and Diff transitions

## User impact
A local file reference keeps the same Markdown appearance it had before. Clicking it opens only that file's contents on the right; it does not become an attachment card, automatically download, or render an empty file tree.

## Validation
- `npm run test -- tests/client/files-store.test.ts tests/client/markdown-rendering.test.ts` — 54 passed after rebase
- `PLAYWRIGHT_CHANNEL=chrome npm run test:e2e -- tests/e2e/generated-file-preview.spec.ts --workers=1` — 5 passed after rebase
- E2E covers both an initially closed panel and an already-open FilesPanel during delayed loading
- `npm run harness:check` — passed after rebase
- `npm run build` — passed after rebase (Vue/type checks, client build, and server build)
- isolated Chrome visual smoke test — passed after rebase; temporary spec removed
- static added-line security scan — zero findings
- independent final and post-rebase reviews — passed with no security or logic findings
