### PR TITLE
fix(files): render Markdown in workspace previews

### DIFF
--- a/packages/client/src/components/hermes/files/WorkspaceFileDiff.vue
+++ b/packages/client/src/components/hermes/files/WorkspaceFileDiff.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
-import { NAlert, NButton, NSpin, useMessage } from 'naive-ui'
+import { computed, defineAsyncComponent, ref, watch } from 'vue'
+import { NAlert, NButton, NSpin, NTooltip, useMessage } from 'naive-ui'
 import { useI18n } from 'vue-i18n'
 import type { FileEntry, WorkspaceFileDiff } from '@/api/studio/files'
 import { fetchSessionWorkspaceFileDiff, readSessionWorkspaceFile } from '@/api/studio/sessions'
 import { fetchGroupWorkspaceFileDiff, readGroupWorkspaceFile } from '@/api/studio/group-chat'
-import { getLanguageFromPath, useFilesStore } from '@/stores/hermes/files'
+import { getLanguageFromPath, isMarkdownFile, useFilesStore } from '@/stores/hermes/files'
 import { handleCodeBlockCopyClick, renderHighlightedCodeBlock } from '@/components/hermes/chat/highlight'
+
+const MarkdownRenderer = defineAsyncComponent(async () => (await import('@/components/hermes/chat/MarkdownRenderer.vue')).default)
 
 const props = defineProps<{
   entry: FileEntry
@@ -116,8 +118,45 @@ watch(
         </span>
       </div>
       <div class="diff-actions">
-        <NButton size="small" secondary @click="editFile">{{ t('common.edit') }}</NButton>
-        <NButton size="small" quaternary @click="emit('close')">{{ t('files.closePreview') }}</NButton>
+        <NTooltip trigger="hover">
+          <template #trigger>
+            <NButton
+              class="diff-action-button"
+              size="small"
+              quaternary
+              circle
+              :aria-label="t('common.edit')"
+              @click="editFile"
+            >
+              <template #icon>
+                <svg data-icon="edit" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M12 20h9" />
+                  <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
+                </svg>
+              </template>
+            </NButton>
+          </template>
+          {{ t('common.edit') }}
+        </NTooltip>
+        <NTooltip trigger="hover">
+          <template #trigger>
+            <NButton
+              class="diff-action-button"
+              size="small"
+              quaternary
+              circle
+              :aria-label="t('files.closePreview')"
+              @click="emit('close')"
+            >
+              <template #icon>
+                <svg data-icon="close" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="m18 6-12 12M6 6l12 12" />
+                </svg>
+              </template>
+            </NButton>
+          </template>
+          {{ t('files.closePreview') }}
+        </NTooltip>
       </div>
     </header>
     <main class="diff-content">
@@ -132,6 +171,12 @@ watch(
         v-html="renderedPatch"
         @click="handleDiffClick"
       />
+      <div
+        v-else-if="fileContent !== null && isMarkdownFile(entry.name)"
+        class="workspace-markdown-preview"
+      >
+        <MarkdownRenderer :content="fileContent" />
+      </div>
       <div
         v-else-if="fileContent !== null"
         class="file-code"
@@ -195,6 +240,18 @@ watch(
 .diff-add { color: #2da44e; }
 .diff-del { color: #cf222e; }
 
+.diff-action-button {
+  :deep(svg) {
+    width: 16px;
+    height: 16px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.7;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+}
+
 .diff-content {
   flex: 1;
   min-width: 0;
@@ -206,6 +263,24 @@ watch(
   display: flex;
   justify-content: center;
   margin-top: 24px;
+}
+
+.workspace-markdown-preview {
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  box-sizing: border-box;
+  padding: 24px clamp(16px, 4vw, 48px);
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  :deep(.markdown-body) {
+    width: min(800px, 100%);
+    margin: 0 auto;
+  }
 }
 
 .diff-code,

--- a/tests/client/workspace-file-diff.test.ts
+++ b/tests/client/workspace-file-diff.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { defineComponent } from 'vue'
+
+const workspaceMocks = vi.hoisted(() => ({
+  fetchSessionWorkspaceFileDiff: vi.fn(),
+  readSessionWorkspaceFile: vi.fn(),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('naive-ui', () => ({
+  NAlert: defineComponent({ template: '<div><slot /></div>' }),
+  NButton: defineComponent({
+    inheritAttrs: false,
+    template: '<button type="button" v-bind="$attrs"><slot name="icon" /><slot /></button>',
+  }),
+  NSpin: defineComponent({ template: '<div class="spin" />' }),
+  NTooltip: defineComponent({ template: '<span><slot name="trigger" /><span class="tooltip"><slot /></span></span>' }),
+  useMessage: () => ({ success: vi.fn(), error: vi.fn() }),
+}))
+
+vi.mock('@/api/studio/sessions', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/api/studio/sessions')>()
+  return {
+    ...actual,
+    fetchSessionWorkspaceFileDiff: workspaceMocks.fetchSessionWorkspaceFileDiff,
+    readSessionWorkspaceFile: workspaceMocks.readSessionWorkspaceFile,
+  }
+})
+
+import WorkspaceFileDiff from '@/components/hermes/files/WorkspaceFileDiff.vue'
+
+const markdownEntry = {
+  name: 'notes.md',
+  path: 'notes.md',
+  isDir: false,
+  size: 64,
+  modTime: '2026-09-05T00:00:00.000Z',
+}
+
+describe('WorkspaceFileDiff', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    workspaceMocks.fetchSessionWorkspaceFileDiff.mockResolvedValue({
+      patch: '',
+      additions: 0,
+      deletions: 0,
+      binary: false,
+      truncated: false,
+    })
+    workspaceMocks.readSessionWorkspaceFile.mockResolvedValue({
+      path: markdownEntry.path,
+      content: '# Rendered heading\n\nThis is **bold** text.\n',
+    })
+  })
+
+  it('renders unchanged markdown workspace files instead of showing raw source', async () => {
+    const wrapper = mount(WorkspaceFileDiff, {
+      props: {
+        entry: markdownEntry,
+        workspace: '/tmp/workspace',
+        workspaceSessionId: 'session-1',
+      },
+    })
+
+    await flushPromises()
+    await vi.waitFor(() => {
+      expect(
+        wrapper.find('.workspace-markdown-preview .markdown-body h1').exists(),
+        wrapper.html(),
+      ).toBe(true)
+    })
+
+    expect(wrapper.find('.workspace-markdown-preview .markdown-body h1').text()).toBe('Rendered heading')
+    expect(wrapper.find('.workspace-markdown-preview strong').text()).toBe('bold')
+    expect(wrapper.find('.file-code').exists()).toBe(false)
+  })
+
+  it('uses accessible icon-only controls for editing and closing the preview', async () => {
+    const wrapper = mount(WorkspaceFileDiff, {
+      props: {
+        entry: markdownEntry,
+        workspace: '/tmp/workspace',
+        workspaceSessionId: 'session-1',
+      },
+    })
+
+    await flushPromises()
+
+    const editButton = wrapper.get('button[aria-label="common.edit"]')
+    const closeButton = wrapper.get('button[aria-label="files.closePreview"]')
+    expect(editButton.text()).toBe('')
+    expect(closeButton.text()).toBe('')
+    expect(editButton.find('svg[data-icon="edit"]').exists()).toBe(true)
+    expect(closeButton.find('svg[data-icon="close"]').exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- render unchanged `.md` and `.markdown` workspace files with the existing `MarkdownRenderer` instead of showing highlighted source
- keep unified diff rendering unchanged when a workspace file has a patch
- replace the preview header's Edit and Close text buttons with consistent icon-only controls while preserving tooltips, accessible labels, and behavior
- add focused component coverage for Markdown rendering and the icon affordances

## Motivation
Workspace Markdown files currently fall through to the generic code renderer when they do not have a Git patch. This exposes Markdown syntax instead of presenting the document as formatted content, even though Hermes Studio already has a shared, safe Markdown renderer.

The adjacent Edit and Close actions also occupy more header space than necessary and are visually inconsistent with the rest of the compact workspace toolbar.

## Visual

### Full workspace context

<img width="1600" height="1000" alt="workspace-markdown-preview-context" src="https://github.com/user-attachments/assets/1bc67c76-1607-46a2-bc88-878787e5b5e7" />

### Rendered preview and icon controls

<img width="771" height="907" alt="workspace-markdown-preview-panel" src="https://github.com/user-attachments/assets/c3f0c86b-4f3f-4baf-a02b-a837b802b7b5" />

## Validation
- `NODE_ENV=test mise exec node@25.4.0 -- npm run test -- tests/client/workspace-file-diff.test.ts tests/client/markdown-rendering.test.ts tests/client/file-preview-formats.test.ts tests/client/files-panel-attach.test.ts tests/client/drawer-panel-resize.test.ts` — 60 passed
- `NODE_ENV=test mise exec node@25.4.0 -- npm run harness:check` — passed
- `NODE_ENV=production mise exec node@25.4.0 -- npm run build` — passed
- isolated Chrome acceptance scenario — verified rendered Markdown, icon-only accessible controls, Edit/Close interactions, no page errors, and no unexpected API requests
- independent final code review — passed with no security or logic findings

## Notes for reviewers
- Markdown continues to use the shared renderer with raw HTML disabled.
- Files with a non-empty patch still take the existing diff-rendering path.
- No dependencies or locale strings were added.
