### PR TITLE
[codex] add Cmd/Ctrl+, settings shortcut

### DIFF
--- a/packages/client/src/composables/useKeyboard.ts
+++ b/packages/client/src/composables/useKeyboard.ts
@@ -23,6 +23,13 @@ export function useKeyboard() {
       return
     }
 
+    if (mod && e.key === ',') {
+      if (router.currentRoute.value.name === 'login') return
+      e.preventDefault()
+      router.push({ name: 'hermes.settings' })
+      return
+    }
+
     if (mod && e.key.toLowerCase() === 'k') {
       if (router.currentRoute.value.name === 'login') return
       e.preventDefault()

--- a/tests/client/session-search.test.ts
+++ b/tests/client/session-search.test.ts
@@ -208,4 +208,58 @@ describe('keyboard shortcut', () => {
 
     expect(useSessionSearch().sessionSearchOpen.value).toBe(true)
   })
+
+  it.each([
+    ['Cmd', { metaKey: true }],
+    ['Ctrl', { ctrlKey: true }],
+  ])('opens settings on %s+Comma', async (_label, modifiers) => {
+    const Dummy = defineComponent({
+      setup() {
+        useKeyboard()
+        return () => h('div')
+      },
+    })
+
+    const wrapper = mount(Dummy)
+
+    const event = new KeyboardEvent('keydown', {
+      key: ',',
+      ...modifiers,
+      bubbles: true,
+      cancelable: true,
+    })
+    window.dispatchEvent(event)
+    await nextTick()
+
+    expect(apiMocks.routerPushMock).toHaveBeenCalledWith({ name: 'hermes.settings' })
+    expect(event.defaultPrevented).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('does not open settings from the login page', async () => {
+    routerCurrentRoute.value = { name: 'login' }
+    const Dummy = defineComponent({
+      setup() {
+        useKeyboard()
+        return () => h('div')
+      },
+    })
+
+    const wrapper = mount(Dummy)
+
+    const event = new KeyboardEvent('keydown', {
+      key: ',',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    })
+    window.dispatchEvent(event)
+    await nextTick()
+
+    expect(apiMocks.routerPushMock).not.toHaveBeenCalledWith({ name: 'hermes.settings' })
+    expect(event.defaultPrevented).toBe(false)
+
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
## Summary
- Add a global `Cmd+,` / `Ctrl+,` shortcut that opens the existing Studio Settings route.
- Reuse the existing cross-platform modifier detection and ignore the shortcut on the login page.
- Add coverage for Command, Control, default-event prevention, and the login guard.

## Validation
- `npm run harness:check`
- `npm test -- --run tests/client/session-search.test.ts`
- `npm test` (585 test files passed; one environment-level Blob cross-realm assertion failed in `tests/client/use-speech-tts.test.ts:107`)
- `npm run build` (blocked by Mermaid type errors in the existing `packages/client/src/components/hermes/chat/MarkdownRenderer.vue` path)
- Browser QA with ego-browser: real `Command+,` and `Control+,` both navigated to `#/hermes/settings`; Settings rendered at desktop and 390px mobile widths with no Vite overlay.