### PR TITLE
feat(chat): consolidate session actions into a menu

### DIFF
--- a/packages/client/src/components/hermes/chat/ChatPanel.vue
+++ b/packages/client/src/components/hermes/chat/ChatPanel.vue
@@ -52,6 +52,7 @@ import TerminalPanel from "./TerminalPanel.vue";
 import SubagentStreamPanel from "./SubagentStreamPanel.vue";
 import { buildVisibleSessionCategoryGroups, partitionRecentSessions } from "./session-category-groups";
 import { buildSessionCategoryMenuChildren, resolveRecentSessionCategoryLabel } from "./session-category-menu";
+import { buildActiveSessionMenuOptions, buildSessionContextMenuOptions } from "./session-menu-options";
 import PageSidebarNav from "@/components/layout/PageSidebarNav.vue";
 import { isStoredSuperAdmin } from "@/api/client";
 import { useDefaultWorkspace } from "@/composables/useDefaultWorkspace";
@@ -96,6 +97,14 @@ const { t } = useI18n();
 const isSuperAdmin = computed(() => isStoredSuperAdmin());
 
 const showOutline = ref(false);
+const ACTIVE_SESSION_MENU_ID = "active-session-actions-menu";
+const showActiveSessionMenu = ref(false);
+const activeSessionMenuTriggerRef = ref<InstanceType<typeof NButton> | null>(null);
+let activeSessionMenuInitialFocus: "first" | "last" = "first";
+let restoreActiveSessionMenuTriggerFocus = false;
+const activeSessionSupportsPersistence = computed(() =>
+  Boolean(chatStore.activeSession && !chatStore.activeSession.isLocalOnly),
+);
 const showRealtimeVoice = ref(false);
 const messageListRef = ref<InstanceType<typeof MessageList> | null>(null);
 const chatInputRef = ref<(InstanceType<typeof ChatInput> & {
@@ -168,21 +177,22 @@ function closeRealtimeVoice() {
   showRealtimeVoice.value = false;
 }
 
-function sessionHref(sessionId: string) {
+function sessionHref(sessionId: string, profile?: string | null) {
   return router.resolve({
     name: chatStore.runtimeMode === "global_agent" ? "hermes.globalAgentSession" : "hermes.session",
     params: { sessionId },
+    query: profile ? { profile } : undefined,
   }).href;
 }
 
-function openSessionInNewTab(sessionId: string) {
+function openSessionInNewTab(sessionId: string, profile = sessionProfile(sessionId)) {
   if (typeof window === "undefined") return;
   const bridge = desktopBridge();
   if (bridge?.isDesktop && bridge.openChatWindow) {
-    void bridge.openChatWindow(sessionId, sessionProfile(sessionId) || undefined);
+    void bridge.openChatWindow(sessionId, profile || undefined);
     return;
   }
-  window.open(sessionHref(sessionId), "_blank", "noopener,noreferrer");
+  window.open(sessionHref(sessionId, profile), "_blank", "noopener,noreferrer");
 }
 
 function handleOutlineNavigate(target: { messageId: string; anchorId: string }) {
@@ -1330,6 +1340,170 @@ async function copySessionId(id?: string) {
   }
 }
 
+const activeSessionMenuOptions = computed<DropdownOption[]>(() => buildActiveSessionMenuOptions({
+  outline: t("chat.outlineTitle"),
+  rename: t("chat.rename"),
+  open: t(desktopChatWindowAvailable
+    ? "chat.openSessionInNewWindow"
+    : "chat.openSessionInNewTab"),
+  copyId: t("chat.copySessionId"),
+}, {
+  canRename: activeSessionSupportsPersistence.value,
+  canOpen: activeSessionSupportsPersistence.value,
+}));
+
+function activeSessionMenuProps() {
+  return {
+    id: ACTIVE_SESSION_MENU_ID,
+    role: "menu",
+    "aria-label": t("chat.sessionActions"),
+  };
+}
+
+function activeSessionMenuNodeProps(option: DropdownOption) {
+  return {
+    id: `${ACTIVE_SESSION_MENU_ID}-${String(option.key || "item")}`,
+    role: "menuitem",
+    tabindex: -1,
+    "aria-disabled": option.disabled ? "true" as const : undefined,
+  };
+}
+
+function activeSessionMenuItems(): HTMLElement[] {
+  if (typeof document === "undefined") return [];
+  const menu = document.getElementById(ACTIVE_SESSION_MENU_ID);
+  if (!menu) return [];
+  return Array.from(menu.querySelectorAll<HTMLElement>('[role="menuitem"]'));
+}
+
+function focusActiveSessionMenuItem(position: number | "first" | "last") {
+  const items = activeSessionMenuItems();
+  if (items.length === 0) return;
+  const index = position === "first"
+    ? 0
+    : position === "last"
+      ? items.length - 1
+      : (position + items.length) % items.length;
+  items[index]?.focus({ preventScroll: true });
+}
+
+function focusActiveSessionMenuTrigger() {
+  const element = activeSessionMenuTriggerRef.value?.$el as HTMLElement | undefined;
+  element?.focus({ preventScroll: true });
+}
+
+function focusAdjacentToActiveSessionMenuTrigger(backwards: boolean) {
+  if (typeof document === "undefined") return;
+  const trigger = activeSessionMenuTriggerRef.value?.$el as HTMLElement | undefined;
+  if (!trigger) return;
+  const selector = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[contenteditable="true"]',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(',');
+  const candidates = Array.from(document.querySelectorAll<HTMLElement>(selector)).filter((element) => {
+    if (element.closest(`#${ACTIVE_SESSION_MENU_ID}`) || element.closest('[inert]')) return false;
+    if (element.tabIndex < 0 || element.getClientRects().length === 0) return false;
+    const style = window.getComputedStyle(element);
+    return style.display !== "none" && style.visibility !== "hidden";
+  });
+  const triggerIndex = candidates.indexOf(trigger);
+  if (triggerIndex < 0) return;
+  const target = candidates[triggerIndex + (backwards ? -1 : 1)];
+  target?.focus({ preventScroll: true });
+}
+
+function handleActiveSessionMenuTriggerKeydown(event: KeyboardEvent) {
+  if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+  event.preventDefault();
+  event.stopPropagation();
+  activeSessionMenuInitialFocus = event.key === "ArrowUp" ? "last" : "first";
+  showActiveSessionMenu.value = true;
+}
+
+function handleActiveSessionMenuKeydown(event: KeyboardEvent) {
+  const items = activeSessionMenuItems();
+  const current = (event.target as HTMLElement | null)?.closest<HTMLElement>('[role="menuitem"]');
+  const currentIndex = current ? items.indexOf(current) : -1;
+
+  if (event.key === "ArrowDown" || event.key === "ArrowUp" || event.key === "Home" || event.key === "End") {
+    event.preventDefault();
+    event.stopPropagation();
+    if (event.key === "Home") focusActiveSessionMenuItem("first");
+    else if (event.key === "End") focusActiveSessionMenuItem("last");
+    else if (event.key === "ArrowDown") focusActiveSessionMenuItem(currentIndex < 0 ? 0 : currentIndex + 1);
+    else focusActiveSessionMenuItem(currentIndex < 0 ? items.length - 1 : currentIndex - 1);
+    return;
+  }
+
+  if (event.key === "Enter" || event.key === " ") {
+    event.preventDefault();
+    event.stopPropagation();
+    current?.querySelector<HTMLElement>(".n-dropdown-option-body")?.click();
+    return;
+  }
+
+  if (event.key === "Escape") {
+    event.preventDefault();
+    event.stopPropagation();
+    restoreActiveSessionMenuTriggerFocus = true;
+    showActiveSessionMenu.value = false;
+  } else if (event.key === "Tab") {
+    event.preventDefault();
+    event.stopPropagation();
+    const backwards = event.shiftKey;
+    restoreActiveSessionMenuTriggerFocus = false;
+    showActiveSessionMenu.value = false;
+    void nextTick().then(() => focusAdjacentToActiveSessionMenuTrigger(backwards));
+  }
+}
+
+watch(showActiveSessionMenu, async (visible, wasVisible) => {
+  if (visible) {
+    restoreActiveSessionMenuTriggerFocus = false;
+    await nextTick();
+    focusActiveSessionMenuItem(activeSessionMenuInitialFocus);
+    activeSessionMenuInitialFocus = "first";
+    return;
+  }
+  if (!wasVisible || !restoreActiveSessionMenuTriggerFocus) return;
+  restoreActiveSessionMenuTriggerFocus = false;
+  await nextTick();
+  focusActiveSessionMenuTrigger();
+});
+
+function openRenameSession(sessionId: string) {
+  const session = chatStore.sessions.find((item) => item.id === sessionId)
+    || (chatStore.activeSession?.id === sessionId ? chatStore.activeSession : null);
+  renameSessionId.value = sessionId;
+  renameValue.value = session?.title || "";
+  showRenameModal.value = true;
+  nextTick(() => {
+    renameInputRef.value?.focus();
+  });
+}
+
+function handleActiveSessionMenuSelect(key: string) {
+  const sessionId = chatStore.activeSessionId;
+  if (!sessionId) return;
+  restoreActiveSessionMenuTriggerFocus = key !== "rename";
+  if (key === "outline") {
+    showOutline.value = !showOutline.value;
+  } else if (key === "rename") {
+    if (!activeSessionSupportsPersistence.value) return;
+    openRenameSession(sessionId);
+  } else if (key === "open-link") {
+    if (!activeSessionSupportsPersistence.value) return;
+    openSessionInNewTab(sessionId, chatStore.activeSession?.profile || null);
+  } else if (key === "copy-id") {
+    void copySessionId(sessionId);
+  }
+}
+
 async function handleDeleteSession(id: string) {
   const ok = await chatStore.deleteSession(id);
   if (!ok) {
@@ -1539,73 +1713,43 @@ async function handleDeleteCategoryConfirm() {
   }
 }
 
-const contextMenuOptions = computed(() => {
-  const options: DropdownOption[] = [{
-    label: t(contextSessionPinned.value ? "chat.unpin" : "chat.pin"),
-    key: "pin",
-  },
-  { label: t("chat.rename"), key: "rename" }]
+const canSetContextSessionModel = computed(() =>
+  contextSession.value?.source === "cli" ||
+  (contextSession.value?.source === "coding_agent" && contextSession.value?.codingAgentMode !== "global"),
+);
 
-  if (contextSession.value?.source !== "global_agent") {
-    options.push({ label: t("chat.archiveSession"), key: "archive" })
-  }
-
-  options.push({ label: t("chat.setWorkspace"), key: "workspace" })
-
-  if (
-    contextSession.value?.source === "cli" ||
-    (contextSession.value?.source === "coding_agent" && contextSession.value?.codingAgentMode !== "global")
-  ) {
-    options.push({ label: t("chat.setModel"), key: "model" })
-  }
-
-  options.push({
-    label: t("chat.moveToCategory"),
-    key: "category",
-    children: buildSessionCategoryMenuChildren({
-      categories: sessionCategories.value,
-      currentCategoryId: contextSession.value?.categoryId,
-      createCategoryLabel: t("chat.createCategory"),
-      uncategorizedLabel: t("chat.uncategorized"),
-      loadFailedLabel: t("chat.categoryLoadFailed"),
-      retryLabel: t("common.retry"),
-      loadFailed: sessionCategoriesLoadFailed.value,
-      loading: sessionCategoriesLoading.value,
-    }),
-  })
-
-  options.push({
-    label: t("chat.export"),
-    key: "export",
-    children: [
-      {
-        label: t("chat.exportFull"),
-        key: "export-full",
-        children: [
-          { label: "JSON", key: "export-full-json" },
-          { label: "TXT", key: "export-full-txt" },
-        ],
-      },
-      {
-        label: t("chat.exportCompressed"),
-        key: "export-compressed",
-        children: [
-          { label: "JSON", key: "export-compressed-json" },
-          { label: "TXT", key: "export-compressed-txt" },
-        ],
-      },
-    ],
-  })
-  options.push({
-    label: t(desktopChatWindowAvailable
+const contextMenuOptions = computed(() => buildSessionContextMenuOptions({
+  pinned: contextSessionPinned.value,
+  includeArchive: contextSession.value?.source !== "global_agent",
+  includeModel: canSetContextSessionModel.value,
+  categoryChildren: buildSessionCategoryMenuChildren({
+    categories: sessionCategories.value,
+    currentCategoryId: contextSession.value?.categoryId,
+    createCategoryLabel: t("chat.createCategory"),
+    uncategorizedLabel: t("chat.uncategorized"),
+    loadFailedLabel: t("chat.categoryLoadFailed"),
+    retryLabel: t("common.retry"),
+    loadFailed: sessionCategoriesLoadFailed.value,
+    loading: sessionCategoriesLoading.value,
+  }),
+  labels: {
+    pin: t("chat.pin"),
+    unpin: t("chat.unpin"),
+    rename: t("chat.rename"),
+    archive: t("chat.archiveSession"),
+    workspace: t("chat.setWorkspace"),
+    model: t("chat.setModel"),
+    category: t("chat.moveToCategory"),
+    export: t("chat.export"),
+    exportFull: t("chat.exportFull"),
+    exportCompressed: t("chat.exportCompressed"),
+    open: t(desktopChatWindowAvailable
       ? "chat.openSessionInNewWindow"
       : "chat.openSessionInNewTab"),
-    key: "open-link",
-  })
-  options.push({ label: t("chat.copySessionLink"), key: "copy-link" })
-  options.push({ label: t("chat.copySessionId"), key: "copy-id" })
-  return options
-});
+    copyLink: t("chat.copySessionLink"),
+    copyId: t("chat.copySessionId"),
+  },
+}));
 const contextMenuCategoriesKey = computed(() => [
   sessionCategoriesLoadFailed.value ? "failed" : "ready",
   sessionCategoriesLoading.value ? "loading" : "idle",
@@ -1681,7 +1825,7 @@ async function handleContextMenuSelect(key: string) {
   } else if (key === "copy-id") {
     copySessionId(contextSessionId.value);
   } else if (key === "open-link") {
-    openSessionInNewTab(contextSessionId.value);
+    openSessionInNewTab(contextSessionId.value, contextSession.value?.profile || null);
   } else if (key === "archive") {
     const archivedSession = contextSession.value;
     const ok = await chatStore.archiveSession(contextSessionId.value);
@@ -1716,15 +1860,7 @@ async function handleContextMenuSelect(key: string) {
   } else if (key === "model") {
     await openSessionModelModal(contextSessionId.value);
   } else if (key === "rename") {
-    const session = chatStore.sessions.find(
-      (s) => s.id === contextSessionId.value,
-    );
-    renameSessionId.value = contextSessionId.value;
-    renameValue.value = session?.title || "";
-    showRenameModal.value = true;
-    nextTick(() => {
-      renameInputRef.value?.focus();
-    });
+    openRenameSession(contextSessionId.value);
   }
 }
 
@@ -2306,7 +2442,7 @@ async function handleSessionModelCustomSubmit() {
               :to="sessionHref(s.id)"
               :intercept-modified-navigation="desktopChatWindowAvailable"
               @select="handleRecentSessionClick(s.id)"
-              @open-new="openSessionInNewTab(s.id)"
+              @open-new="openSessionInNewTab(s.id, s.profile || null)"
               @contextmenu="handleContextMenu($event, s.id)"
               @delete="handleDeleteSession(s.id)"
               @toggle-select="toggleSessionSelection(s)"
@@ -2352,7 +2488,7 @@ async function handleSessionModelCustomSubmit() {
             :to="sessionHref(s.id)"
             :intercept-modified-navigation="desktopChatWindowAvailable"
             @select="handleSessionClick(s.id)"
-            @open-new="openSessionInNewTab(s.id)"
+            @open-new="openSessionInNewTab(s.id, s.profile || null)"
             @contextmenu="handleContextMenu($event, s.id)"
             @delete="handleDeleteSession(s.id)"
             @toggle-select="toggleSessionSelection(s)"
@@ -2419,7 +2555,7 @@ async function handleSessionModelCustomSubmit() {
               :to="sessionHref(s.id)"
               :intercept-modified-navigation="desktopChatWindowAvailable"
               @select="handleSessionClick(s.id)"
-              @open-new="openSessionInNewTab(s.id)"
+              @open-new="openSessionInNewTab(s.id, s.profile || null)"
               @contextmenu="handleContextMenu($event, s.id)"
               @delete="handleDeleteSession(s.id)"
               @toggle-select="toggleSessionSelection(s)"
@@ -3022,6 +3158,9 @@ async function handleSessionModelCustomSubmit() {
                   :class="{ active: showToolPanel }"
                   quaternary
                   size="small"
+                  :aria-label="t('chat.sidePanel')"
+                  :aria-expanded="showToolPanel"
+                  aria-controls="chat-tool-panel"
                   @click="toggleToolPanel"
                   circle
                 >
@@ -3045,57 +3184,52 @@ async function handleSessionModelCustomSubmit() {
               </template>
               {{ desktopBrowserAvailable ? `${t("drawer.files")} / ${t("drawer.terminal")} / ${t("browser.title")}` : `${t("drawer.files")} / ${t("drawer.terminal")}` }}
             </NTooltip>
-            <NTooltip trigger="hover">
-              <template #trigger>
-                <NButton
-                  quaternary
-                  size="small"
-                  @click="showOutline = !showOutline"
-                  circle
-                >
-                  <template #icon>
-                    <svg
-                      width="14"
-                      height="14"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1.5"
-                    >
-                      <path d="M3 12h18M3 6h18M3 18h18" />
-                    </svg>
-                  </template>
-                </NButton>
-              </template>
-              {{ t("chat.outlineTitle") }}
-            </NTooltip>
-            <NTooltip trigger="hover">
-              <template #trigger>
-                <NButton
-                  quaternary
-                  size="small"
-                  @click="copySessionId()"
-                  circle
-                >
-                  <template #icon>
-                    <svg
-                      width="14"
-                      height="14"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1.5"
-                    >
-                      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-                      <path
-                        d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
-                      />
-                    </svg>
-                  </template>
-                </NButton>
-              </template>
-              {{ t("chat.copySessionId") }}
-            </NTooltip>
+            <NDropdown
+              v-model:show="showActiveSessionMenu"
+              trigger="click"
+              placement="bottom-end"
+              :keyboard="false"
+              :menu-props="activeSessionMenuProps"
+              :node-props="activeSessionMenuNodeProps"
+              :options="activeSessionMenuOptions"
+              :show-arrow="true"
+              @select="handleActiveSessionMenuSelect"
+              @keydown="handleActiveSessionMenuKeydown"
+            >
+              <NTooltip trigger="hover" :disabled="showActiveSessionMenu">
+                <template #trigger>
+                  <NButton
+                    ref="activeSessionMenuTriggerRef"
+                    class="header-session-menu-trigger"
+                    quaternary
+                    size="small"
+                    :disabled="!chatStore.activeSessionId"
+                    :aria-label="t('chat.sessionActions')"
+                    :aria-expanded="showActiveSessionMenu"
+                    aria-controls="active-session-actions-menu"
+                    aria-haspopup="menu"
+                    @keydown="handleActiveSessionMenuTriggerKeydown"
+                    circle
+                  >
+                    <template #icon>
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2.4"
+                        stroke-linecap="round"
+                        aria-hidden="true"
+                      >
+                        <path d="M5 12h.01M12 12h.01M19 12h.01" />
+                      </svg>
+                    </template>
+                  </NButton>
+                </template>
+                {{ t("chat.sessionActions") }}
+              </NTooltip>
+            </NDropdown>
           </template>
         </div>
       </header>
@@ -3140,7 +3274,10 @@ async function handleSessionModelCustomSubmit() {
           >
             <aside
               v-if="showToolPanel"
+              id="chat-tool-panel"
               class="chat-tool-panel"
+              role="region"
+              :aria-label="t('chat.sidePanel')"
               :style="toolPanelStyle"
             >
               <div
@@ -4015,6 +4152,11 @@ async function handleSessionModelCustomSubmit() {
   align-items: center;
   gap: 4px;
   flex-shrink: 0;
+}
+
+:global(#active-session-actions-menu [role="menuitem"]:focus-visible > .n-dropdown-option-body) {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: -2px;
 }
 
 .chat-mode-toggle {

--- a/packages/client/src/components/hermes/chat/session-menu-options.ts
+++ b/packages/client/src/components/hermes/chat/session-menu-options.ts
@@ -1,0 +1,208 @@
+import type { DropdownOption } from 'naive-ui'
+import { h, type VNode, type VNodeChild } from 'vue'
+
+export type SessionMenuIconName =
+  | 'outline'
+  | 'pin'
+  | 'rename'
+  | 'archive'
+  | 'workspace'
+  | 'model'
+  | 'category'
+  | 'export'
+  | 'open-new'
+  | 'link'
+  | 'copy'
+
+interface ActiveSessionMenuLabels {
+  outline: string
+  rename: string
+  open: string
+  copyId: string
+}
+
+interface ActiveSessionMenuAvailability {
+  canRename: boolean
+  canOpen: boolean
+}
+
+interface SessionContextMenuLabels {
+  pin: string
+  unpin: string
+  rename: string
+  archive: string
+  workspace: string
+  model: string
+  category: string
+  export: string
+  exportFull: string
+  exportCompressed: string
+  open: string
+  copyLink: string
+  copyId: string
+}
+
+interface BuildSessionContextMenuOptions {
+  pinned: boolean
+  includeArchive: boolean
+  includeModel: boolean
+  categoryChildren: DropdownOption[]
+  labels: SessionContextMenuLabels
+}
+
+function iconChildren(name: SessionMenuIconName): VNodeChild[] {
+  switch (name) {
+    case 'outline':
+      return [
+        h('circle', { cx: 5, cy: 6, r: 1 }),
+        h('circle', { cx: 5, cy: 12, r: 1 }),
+        h('circle', { cx: 5, cy: 18, r: 1 }),
+        h('path', { d: 'M9 6h10M9 12h10M9 18h10' }),
+      ]
+    case 'pin':
+      return [
+        h('path', { d: 'M8 4h8' }),
+        h('path', { d: 'M9 4v6l-2 4v2h10v-2l-2-4V4' }),
+        h('path', { d: 'M12 16v5' }),
+      ]
+    case 'rename':
+      return [
+        h('path', { d: 'M12 20h9' }),
+        h('path', { d: 'M16.5 3.5a2.12 2.12 0 0 1 3 3L8 18l-4 1 1-4z' }),
+      ]
+    case 'archive':
+      return [
+        h('rect', { x: 3, y: 4, width: 18, height: 5, rx: 1 }),
+        h('path', { d: 'M5 9v11h14V9M10 13h4' }),
+      ]
+    case 'workspace':
+      return [
+        h('path', { d: 'M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z' }),
+      ]
+    case 'model':
+      return [
+        h('path', { d: 'm12 3 1.4 4.1L17.5 9l-4.1 1.4L12 14.5l-1.4-4.1L6.5 9l4.1-1.4z' }),
+        h('path', { d: 'm18.5 15 .7 2.1 2.1.7-2.1.7-.7 2.1-.7-2.1-2.1-.7 2.1-.7z' }),
+      ]
+    case 'category':
+      return [
+        h('path', { d: 'M4 4h6l10 10-6 6L4 10z' }),
+        h('circle', { cx: 8.5, cy: 8.5, r: 1 }),
+      ]
+    case 'export':
+      return [
+        h('path', { d: 'M12 3v11' }),
+        h('path', { d: 'm8 10 4 4 4-4' }),
+        h('path', { d: 'M5 15v4h14v-4' }),
+      ]
+    case 'open-new':
+      return [
+        h('path', { d: 'M14 3h7v7M21 3l-9 9' }),
+        h('path', { d: 'M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6' }),
+      ]
+    case 'link':
+      return [
+        h('path', { d: 'M10 13a5 5 0 0 0 7.1.1l2-2a5 5 0 0 0-7.1-7.1l-1.1 1.1' }),
+        h('path', { d: 'M14 11a5 5 0 0 0-7.1-.1l-2 2A5 5 0 0 0 12 20l1.1-1.1' }),
+      ]
+    case 'copy':
+      return [
+        h('rect', { x: 9, y: 9, width: 12, height: 12, rx: 2 }),
+        h('path', { d: 'M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1' }),
+      ]
+  }
+}
+
+export function renderSessionMenuIcon(name: SessionMenuIconName): VNode {
+  return h('svg', {
+    class: 'session-menu-icon',
+    'data-session-menu-icon': name,
+    width: 16,
+    height: 16,
+    viewBox: '0 0 24 24',
+    fill: 'none',
+    stroke: 'currentColor',
+    'stroke-width': 1.7,
+    'stroke-linecap': 'round',
+    'stroke-linejoin': 'round',
+    'aria-hidden': 'true',
+  }, iconChildren(name))
+}
+
+function actionOption(
+  label: string,
+  key: string,
+  iconName: SessionMenuIconName,
+  extra: Partial<DropdownOption> = {},
+): DropdownOption {
+  return {
+    ...extra,
+    label,
+    key,
+    icon: () => renderSessionMenuIcon(iconName),
+  } as DropdownOption
+}
+
+export function buildActiveSessionMenuOptions(
+  labels: ActiveSessionMenuLabels,
+  availability: ActiveSessionMenuAvailability = { canRename: true, canOpen: true },
+): DropdownOption[] {
+  return [
+    actionOption(labels.outline, 'outline', 'outline'),
+    actionOption(labels.copyId, 'copy-id', 'copy'),
+    actionOption(labels.rename, 'rename', 'rename', { disabled: !availability.canRename }),
+    actionOption(labels.open, 'open-link', 'open-new', { disabled: !availability.canOpen }),
+  ]
+}
+
+export function buildSessionContextMenuOptions({
+  pinned,
+  includeArchive,
+  includeModel,
+  categoryChildren,
+  labels,
+}: BuildSessionContextMenuOptions): DropdownOption[] {
+  const options: DropdownOption[] = [
+    actionOption(pinned ? labels.unpin : labels.pin, 'pin', 'pin'),
+    actionOption(labels.rename, 'rename', 'rename'),
+  ]
+
+  if (includeArchive) {
+    options.push(actionOption(labels.archive, 'archive', 'archive'))
+  }
+
+  options.push(actionOption(labels.workspace, 'workspace', 'workspace'))
+
+  if (includeModel) {
+    options.push(actionOption(labels.model, 'model', 'model'))
+  }
+
+  options.push(actionOption(labels.category, 'category', 'category', {
+    children: categoryChildren,
+  }))
+  options.push(actionOption(labels.export, 'export', 'export', {
+    children: [
+      {
+        label: labels.exportFull,
+        key: 'export-full',
+        children: [
+          { label: 'JSON', key: 'export-full-json' },
+          { label: 'TXT', key: 'export-full-txt' },
+        ],
+      },
+      {
+        label: labels.exportCompressed,
+        key: 'export-compressed',
+        children: [
+          { label: 'JSON', key: 'export-compressed-json' },
+          { label: 'TXT', key: 'export-compressed-txt' },
+        ],
+      },
+    ],
+  }))
+  options.push(actionOption(labels.open, 'open-link', 'open-new'))
+  options.push(actionOption(labels.copyLink, 'copy-link', 'link'))
+  options.push(actionOption(labels.copyId, 'copy-id', 'copy'))
+
+  return options
+}

--- a/packages/client/src/i18n/locales/ar.ts
+++ b/packages/client/src/i18n/locales/ar.ts
@@ -1093,6 +1093,8 @@ export default {
     workspaceRecent: 'حديثة',
     defaultWorkspace: 'مساحة العمل الافتراضية',
     more: 'المزيد',
+    sidePanel: 'اللوحة الجانبية',
+    sessionActions: 'إجراءات الجلسة',
     setWorkspace: 'تعيين مساحة العمل',
     setWorkspaceTitle: 'تعيين مساحة عمل الجلسة',
     workspacePlaceholder: 'أدخل مسار المشروع، مثال: /home/user/project',

--- a/packages/client/src/i18n/locales/de.ts
+++ b/packages/client/src/i18n/locales/de.ts
@@ -1086,6 +1086,8 @@ export default {
     workspaceRecent: 'Zuletzt verwendet',
     defaultWorkspace: 'Standardarbeitsbereich',
     more: 'Mehr',
+    sidePanel: 'Seitenleiste',
+    sessionActions: 'Sitzungsaktionen',
     workspace: 'Arbeitsbereich',
     setWorkspaceTitle: 'Sitzungs-Workspace festlegen',
     setWorkspace: 'Workspace festlegen',

--- a/packages/client/src/i18n/locales/en.ts
+++ b/packages/client/src/i18n/locales/en.ts
@@ -1100,6 +1100,8 @@ export default {
     workspaceRecent: 'Recent',
     defaultWorkspace: 'Default Workspace',
     more: 'More',
+    sidePanel: 'Side panel',
+    sessionActions: 'Session actions',
     setWorkspace: 'Set Workspace',
     setWorkspaceTitle: 'Set Session Workspace',
     workspacePlaceholder: 'Enter project path, e.g. /home/user/project',

--- a/packages/client/src/i18n/locales/es.ts
+++ b/packages/client/src/i18n/locales/es.ts
@@ -1086,6 +1086,8 @@ export default {
     workspaceRecent: 'Reciente',
     defaultWorkspace: 'Espacio de trabajo predeterminado',
     more: 'Más',
+    sidePanel: 'Panel lateral',
+    sessionActions: 'Acciones de la sesión',
     workspace: 'Espacio de trabajo',
     setWorkspaceTitle: 'Definir workspace de sesión',
     setWorkspace: 'Definir workspace',

--- a/packages/client/src/i18n/locales/fr.ts
+++ b/packages/client/src/i18n/locales/fr.ts
@@ -1086,6 +1086,8 @@ export default {
     workspaceRecent: 'Récent',
     defaultWorkspace: 'Espace de travail par défaut',
     more: 'Plus',
+    sidePanel: 'Panneau latéral',
+    sessionActions: 'Actions de la session',
     workspace: 'Espace de travail',
     setWorkspaceTitle: 'Définir le workspace de session',
     setWorkspace: 'Définir le workspace',

--- a/packages/client/src/i18n/locales/ja.ts
+++ b/packages/client/src/i18n/locales/ja.ts
@@ -1086,6 +1086,8 @@ export default {
     workspaceRecent: '最近使用',
     defaultWorkspace: 'デフォルトワークスペース',
     more: 'もっと見る',
+    sidePanel: 'サイドパネル',
+    sessionActions: 'セッション操作',
     workspace: 'ワークスペース',
     setWorkspaceTitle: 'セッション Workspace を設定',
     setWorkspace: 'Workspace を設定',

--- a/packages/client/src/i18n/locales/ko.ts
+++ b/packages/client/src/i18n/locales/ko.ts
@@ -1086,6 +1086,8 @@ export default {
     workspaceRecent: '최근 사용',
     defaultWorkspace: '기본 작업 공간',
     more: '더보기',
+    sidePanel: '사이드 패널',
+    sessionActions: '세션 작업',
     workspace: '작업 공간',
     setWorkspaceTitle: '세션 Workspace 설정',
     setWorkspace: 'Workspace 설정',

--- a/packages/client/src/i18n/locales/pt.ts
+++ b/packages/client/src/i18n/locales/pt.ts
@@ -1086,6 +1086,8 @@ export default {
     workspaceRecent: 'Recente',
     defaultWorkspace: 'Área de trabalho padrão',
     more: 'Mais',
+    sidePanel: 'Painel lateral',
+    sessionActions: 'Ações da sessão',
     workspace: 'Área de trabalho',
     setWorkspaceTitle: 'Definir workspace da sessão',
     setWorkspace: 'Definir workspace',

--- a/packages/client/src/i18n/locales/ru.ts
+++ b/packages/client/src/i18n/locales/ru.ts
@@ -979,6 +979,8 @@ export default {
     workspaceRecent: 'Недавние',
     defaultWorkspace: 'Рабочая область по умолчанию',
     more: 'Ещё',
+    sidePanel: 'Боковая панель',
+    sessionActions: 'Действия с сеансом',
     workspaceSet: 'Рабочая область установлена',
     workspaceSetFailed: 'Ошибка установки рабочей области',
     setModel: 'Установить модель',

--- a/packages/client/src/i18n/locales/zh-TW.ts
+++ b/packages/client/src/i18n/locales/zh-TW.ts
@@ -1091,6 +1091,8 @@ export default {
     workspaceRecent: '最近使用',
     defaultWorkspace: '預設工作區',
     more: '更多',
+    sidePanel: '側邊面板',
+    sessionActions: '工作階段操作',
     setWorkspace: '設定工作區',
     setWorkspaceTitle: '設定工作階段工作區',
     workspacePlaceholder: '輸入專案路徑，例如 /home/user/project',

--- a/packages/client/src/i18n/locales/zh.ts
+++ b/packages/client/src/i18n/locales/zh.ts
@@ -1100,6 +1100,8 @@ export default {
     workspaceRecent: '最近使用',
     defaultWorkspace: '默认工作区',
     more: '更多',
+    sidePanel: '侧边面板',
+    sessionActions: '会话操作',
     setWorkspace: '设置工作区',
     setWorkspaceTitle: '设置会话工作区',
     workspacePlaceholder: '输入项目路径，例如 /home/user/project',

--- a/tests/client/chat-panel-session-actions.test.ts
+++ b/tests/client/chat-panel-session-actions.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'fs'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync('packages/client/src/components/hermes/chat/ChatPanel.vue', 'utf8')
+
+function headerActionsSource() {
+  const start = source.indexOf('<div class="header-actions">')
+  const end = source.indexOf('</header>', start)
+  return source.slice(start, end)
+}
+
+describe('ChatPanel session action menus', () => {
+  it('keeps the side-panel button and replaces the two adjacent actions with one accessible menu button', () => {
+    const header = headerActionsSource()
+
+    expect(header.match(/<NButton/g)).toHaveLength(2)
+    expect(header).toContain('class="header-tool-toggle"')
+    expect(header).toContain('@click="toggleToolPanel"')
+    expect(header).toContain(':aria-label="t(\'chat.sidePanel\')"')
+    expect(header).toContain(':aria-expanded="showToolPanel"')
+    expect(header).toContain('aria-controls="chat-tool-panel"')
+    expect(header).toContain('<NDropdown')
+    expect(header).toContain('v-model:show="showActiveSessionMenu"')
+    expect(header).toContain(':keyboard="false"')
+    expect(header).toContain(':menu-props="activeSessionMenuProps"')
+    expect(header).toContain(':node-props="activeSessionMenuNodeProps"')
+    expect(header).toContain(':options="activeSessionMenuOptions"')
+    expect(header).toContain('@select="handleActiveSessionMenuSelect"')
+    expect(header).toContain('class="header-session-menu-trigger"')
+    expect(header).toContain(':aria-label="t(\'chat.sessionActions\')"')
+    expect(header).toContain(':aria-expanded="showActiveSessionMenu"')
+    expect(header).toContain('aria-controls="active-session-actions-menu"')
+    expect(header).toContain('<NTooltip trigger="hover" :disabled="showActiveSessionMenu">')
+    expect(header).toContain('{{ t("chat.sessionActions") }}')
+    expect(header).not.toContain('{{ t("chat.more") }}')
+    expect(header).toContain('d="M5 12h.01M12 12h.01M19 12h.01"')
+    expect(header).not.toContain('@click="showOutline = !showOutline"')
+    expect(header).not.toContain('@click="copySessionId()"')
+  })
+
+  it('routes all four current-session menu actions through the existing behavior', () => {
+    expect(source).toContain('const activeSessionMenuOptions = computed<DropdownOption[]>(() => buildActiveSessionMenuOptions({')
+    expect(source).toContain('canRename: activeSessionSupportsPersistence.value')
+    expect(source).toContain('canOpen: activeSessionSupportsPersistence.value')
+    expect(source).toContain('function handleActiveSessionMenuSelect(key: string)')
+    expect(source).toContain('showOutline.value = !showOutline.value')
+    expect(source).toContain('openRenameSession(sessionId)')
+    expect(source).toContain('openSessionInNewTab(sessionId, chatStore.activeSession?.profile || null)')
+    expect(source).toContain('void copySessionId(sessionId)')
+    expect(source).toContain('window.open(sessionHref(sessionId, profile), "_blank", "noopener,noreferrer")')
+    expect(source).toContain('role: "menu"')
+    expect(source).toContain('role: "menuitem"')
+    expect(source).toContain('function handleActiveSessionMenuKeydown(event: KeyboardEvent)')
+    expect(source).toContain('function focusAdjacentToActiveSessionMenuTrigger(backwards: boolean)')
+    expect(source).toContain('id="chat-tool-panel"')
+    expect(source).toContain(':global(#active-session-actions-menu [role="menuitem"]:focus-visible > .n-dropdown-option-body)')
+  })
+
+  it('builds the sidebar context menu with the shared icon-bearing option helper', () => {
+    expect(source).toContain('buildSessionContextMenuOptions({')
+    expect(source).toContain('categoryChildren: buildSessionCategoryMenuChildren({')
+    expect(source).toContain('includeArchive: contextSession.value?.source !== "global_agent"')
+    expect(source).toContain('includeModel: canSetContextSessionModel.value')
+    expect(source).toContain('open: t(desktopChatWindowAvailable')
+  })
+})

--- a/tests/client/chat-panel-session-click.test.ts
+++ b/tests/client/chat-panel-session-click.test.ts
@@ -12,8 +12,10 @@ describe('ChatPanel session clicks', () => {
   it('opens desktop sessions in a native chat window while preserving the web tab fallback', () => {
     const source = readFileSync('packages/client/src/components/hermes/chat/ChatPanel.vue', 'utf8')
 
-    expect(source).toContain('bridge.openChatWindow(sessionId, sessionProfile(sessionId) || undefined)')
-    expect(source).toContain('window.open(sessionHref(sessionId), "_blank", "noopener,noreferrer")')
+    expect(source).toContain('function openSessionInNewTab(sessionId: string, profile = sessionProfile(sessionId))')
+    expect(source).toContain('bridge.openChatWindow(sessionId, profile || undefined)')
+    expect(source).toContain('window.open(sessionHref(sessionId, profile), "_blank", "noopener,noreferrer")')
+    expect(source).toContain('openSessionInNewTab(sessionId, chatStore.activeSession?.profile || null)')
     expect(source).toContain('v-if="currentMode === \'chat\' && !standalone"')
     expect(source).toContain('<header v-if="!standalone" class="chat-header">')
   })

--- a/tests/client/session-action-menu.test.ts
+++ b/tests/client/session-action-menu.test.ts
@@ -1,0 +1,193 @@
+import type { DropdownOption } from 'naive-ui'
+import type { VNode } from 'vue'
+import { describe, expect, it } from 'vitest'
+import {
+  buildActiveSessionMenuOptions,
+  buildSessionContextMenuOptions,
+  renderSessionMenuIcon,
+} from '@/components/hermes/chat/session-menu-options'
+
+function describeOptions(options: DropdownOption[]) {
+  return options.map((option) => {
+    const item = option as DropdownOption & {
+      icon?: () => VNode
+      label?: string
+      type?: string
+    }
+    const icon = item.icon?.()
+    return {
+      key: item.key,
+      label: item.label,
+      icon: icon?.props?.['data-session-menu-icon'],
+      hasChildren: Array.isArray(item.children),
+    }
+  })
+}
+
+describe('session action menu options', () => {
+  it('builds the compact current-session menu with an icon for every action', () => {
+    const options = buildActiveSessionMenuOptions({
+      outline: 'Conversation Outline',
+      rename: 'Rename',
+      open: 'Open in new window',
+      copyId: 'Copy Session ID',
+    })
+
+    expect(describeOptions(options)).toEqual([
+      { key: 'outline', label: 'Conversation Outline', icon: 'outline', hasChildren: false },
+      { key: 'copy-id', label: 'Copy Session ID', icon: 'copy', hasChildren: false },
+      { key: 'rename', label: 'Rename', icon: 'rename', hasChildren: false },
+      { key: 'open-link', label: 'Open in new window', icon: 'open-new', hasChildren: false },
+    ])
+
+    for (const option of options) {
+      const icon = (option as DropdownOption & { icon: () => VNode }).icon()
+      expect(icon.type).toBe('svg')
+      expect(icon.props).toMatchObject({
+        width: 16,
+        height: 16,
+        viewBox: '0 0 24 24',
+        'aria-hidden': 'true',
+      })
+    }
+  })
+
+  it('disables persistence-dependent header actions for an unsent local-only session', () => {
+    const options = buildActiveSessionMenuOptions({
+      outline: 'Conversation Outline',
+      rename: 'Rename',
+      open: 'Open in new window',
+      copyId: 'Copy Session ID',
+    }, {
+      canRename: false,
+      canOpen: false,
+    })
+
+    expect(options.map(option => ({ key: option.key, disabled: option.disabled ?? false }))).toEqual([
+      { key: 'outline', disabled: false },
+      { key: 'copy-id', disabled: false },
+      { key: 'rename', disabled: true },
+      { key: 'open-link', disabled: true },
+    ])
+  })
+
+  it('adds distinct icons to all ten top-level session context actions while preserving submenus', () => {
+    const categoryChildren: DropdownOption[] = [
+      { label: 'Work', key: 'category:1' },
+    ]
+    const options = buildSessionContextMenuOptions({
+      pinned: false,
+      includeArchive: true,
+      includeModel: true,
+      categoryChildren,
+      labels: {
+        pin: 'Pin',
+        unpin: 'Unpin',
+        rename: 'Rename',
+        archive: 'Archive',
+        workspace: 'Set Workspace',
+        model: 'Set Model',
+        category: 'Move to category',
+        export: 'Export',
+        exportFull: 'Full Export (JSON)',
+        exportCompressed: 'Compressed Export (TXT)',
+        open: 'Open in new window',
+        copyLink: 'Copy Session Link',
+        copyId: 'Copy Session ID',
+      },
+    })
+
+    expect(describeOptions(options)).toEqual([
+      { key: 'pin', label: 'Pin', icon: 'pin', hasChildren: false },
+      { key: 'rename', label: 'Rename', icon: 'rename', hasChildren: false },
+      { key: 'archive', label: 'Archive', icon: 'archive', hasChildren: false },
+      { key: 'workspace', label: 'Set Workspace', icon: 'workspace', hasChildren: false },
+      { key: 'model', label: 'Set Model', icon: 'model', hasChildren: false },
+      { key: 'category', label: 'Move to category', icon: 'category', hasChildren: true },
+      { key: 'export', label: 'Export', icon: 'export', hasChildren: true },
+      { key: 'open-link', label: 'Open in new window', icon: 'open-new', hasChildren: false },
+      { key: 'copy-link', label: 'Copy Session Link', icon: 'link', hasChildren: false },
+      { key: 'copy-id', label: 'Copy Session ID', icon: 'copy', hasChildren: false },
+    ])
+    expect(options.find(option => option.key === 'category')?.children).toBe(categoryChildren)
+    expect(options.find(option => option.key === 'export')?.children).toEqual([
+      {
+        label: 'Full Export (JSON)',
+        key: 'export-full',
+        children: [
+          { label: 'JSON', key: 'export-full-json' },
+          { label: 'TXT', key: 'export-full-txt' },
+        ],
+      },
+      {
+        label: 'Compressed Export (TXT)',
+        key: 'export-compressed',
+        children: [
+          { label: 'JSON', key: 'export-compressed-json' },
+          { label: 'TXT', key: 'export-compressed-txt' },
+        ],
+      },
+    ])
+  })
+
+  it('uses a clear, compact thumbtack glyph for Pin', () => {
+    const icon = renderSessionMenuIcon('pin')
+    const paths = (icon.children as VNode[]).map(child => child.props?.d)
+
+    expect(paths).toEqual([
+      'M8 4h8',
+      'M9 4v6l-2 4v2h10v-2l-2-4V4',
+      'M12 16v5',
+    ])
+  })
+
+  it('uses a downward download-style glyph for Export rather than an upload glyph', () => {
+    const icon = renderSessionMenuIcon('export')
+    const paths = (icon.children as VNode[]).map(child => child.props?.d)
+
+    expect(paths).toEqual([
+      'M12 3v11',
+      'm8 10 4 4 4-4',
+      'M5 15v4h14v-4',
+    ])
+  })
+
+  it('keeps the Set Model glyph lightweight and recognizable as AI rather than hardware', () => {
+    const icon = renderSessionMenuIcon('model')
+    const paths = (icon.children as VNode[]).map(child => child.props?.d)
+
+    expect(paths).toEqual([
+      'm12 3 1.4 4.1L17.5 9l-4.1 1.4L12 14.5l-1.4-4.1L6.5 9l4.1-1.4z',
+      'm18.5 15 .7 2.1 2.1.7-2.1.7-.7 2.1-.7-2.1-2.1-.7 2.1-.7z',
+    ])
+  })
+
+  it('uses the unpin label and keeps optional actions out when they are unavailable', () => {
+    const options = buildSessionContextMenuOptions({
+      pinned: true,
+      includeArchive: false,
+      includeModel: false,
+      categoryChildren: [],
+      labels: {
+        pin: 'Pin',
+        unpin: 'Unpin',
+        rename: 'Rename',
+        archive: 'Archive',
+        workspace: 'Set Workspace',
+        model: 'Set Model',
+        category: 'Move to category',
+        export: 'Export',
+        exportFull: 'Full Export (JSON)',
+        exportCompressed: 'Compressed Export (TXT)',
+        open: 'Open in new tab',
+        copyLink: 'Copy Session Link',
+        copyId: 'Copy Session ID',
+      },
+    })
+
+    expect(options[0]?.label).toBe('Unpin')
+    expect(options.map(option => option.key)).not.toContain('archive')
+    expect(options.map(option => option.key)).not.toContain('model')
+    expect(options.every(option => typeof (option as DropdownOption & { icon?: unknown }).icon === 'function')).toBe(true)
+  })
+})

--- a/tests/e2e/session-action-menu.spec.ts
+++ b/tests/e2e/session-action-menu.spec.ts
@@ -1,0 +1,276 @@
+import { expect, test, type Page } from '@playwright/test'
+import { authenticate, mockChatSocket, mockHermesApi, TEST_ACCESS_KEY } from './fixtures'
+
+const session = {
+  id: 'session-actions-1',
+  title: 'Session Menu Review',
+  source: 'cli',
+  model: 'test-model',
+  provider: 'test-provider',
+  profile: 'research',
+  workspace: '/tmp/session-menu-review',
+  started_at: 1_800_000_000,
+  ended_at: null,
+  last_active: 1_800_000_100,
+  message_count: 0,
+}
+
+interface SessionActionsHarness {
+  chatWindows: Array<{ sessionId: string; profile?: string }>
+  openedUrls: string[]
+  clipboard: { text: string }
+}
+
+async function openChat(page: Page, desktop: boolean) {
+  await page.addInitScript(({ installDesktopBridge }) => {
+    const sessionActionsState: SessionActionsHarness = {
+      chatWindows: [],
+      openedUrls: [],
+      clipboard: { text: '' },
+    }
+    ;(window as typeof window & {
+      __PW_SESSION_ACTIONS__?: SessionActionsHarness
+    }).__PW_SESSION_ACTIONS__ = sessionActionsState
+
+    if (installDesktopBridge) {
+      Object.defineProperty(window, 'hermesDesktop', {
+        configurable: true,
+        value: {
+          isDesktop: true,
+          platform: 'darwin',
+          windowKind: 'main',
+          openChatWindow: async (sessionId: string, profile?: string) => {
+            sessionActionsState.chatWindows.push({ sessionId, profile })
+          },
+        },
+      })
+    } else {
+      Object.defineProperty(window, 'open', {
+        configurable: true,
+        value: (url?: string | URL) => {
+          sessionActionsState.openedUrls.push(String(url || ''))
+          return null
+        },
+      })
+    }
+
+    Object.defineProperty(Navigator.prototype, 'clipboard', {
+      configurable: true,
+      get: () => ({
+        writeText: async (text: string) => {
+          sessionActionsState.clipboard.text = text
+        },
+      }),
+    })
+    ;(window as typeof window & { __PW_CHAT_SOCKET_RESUMES__?: Record<string, unknown> }).__PW_CHAT_SOCKET_RESUMES__ = {
+      'session-actions-1': {
+        session_id: 'session-actions-1',
+        messages: [],
+        isWorking: false,
+        messageLoadedCount: 0,
+        messageTotal: 0,
+      },
+    }
+  }, { installDesktopBridge: desktop })
+  await authenticate(page, TEST_ACCESS_KEY, 'research')
+  await mockChatSocket(page)
+  await mockHermesApi(page, { sessions: [session] })
+  await page.goto('/#/hermes/session/session-actions-1')
+  await expect(page.locator('.header-session-menu-trigger')).toBeEnabled()
+}
+
+async function openDesktopChat(page: Page) {
+  await openChat(page, true)
+}
+
+async function openBrowserChat(page: Page) {
+  await openChat(page, false)
+}
+
+function visibleOption(page: Page, label: string) {
+  const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return page.locator('.n-dropdown-option:visible').filter({ hasText: new RegExp(`^${escapedLabel}$`) })
+}
+
+test('consolidates current-session actions into one icon-bearing header menu', async ({ page }) => {
+  await openDesktopChat(page)
+
+  const headerActions = page.locator('.header-actions')
+  await expect(headerActions.getByRole('button')).toHaveCount(2)
+
+  const sidePanelButton = headerActions.getByRole('button', { name: 'Side panel' })
+  await expect(sidePanelButton).toHaveAttribute('aria-controls', 'chat-tool-panel')
+  await expect(sidePanelButton).toHaveAttribute('aria-expanded', 'false')
+  await sidePanelButton.click()
+  await expect(page.locator('#chat-tool-panel')).toBeVisible()
+  await expect(sidePanelButton).toHaveAttribute('aria-expanded', 'true')
+  await sidePanelButton.click()
+  await expect(page.locator('#chat-tool-panel')).toBeHidden()
+
+  const sessionActionsButton = headerActions.getByRole('button', { name: 'Session actions' })
+  await expect(sessionActionsButton).toHaveAttribute('aria-controls', 'active-session-actions-menu')
+  await expect(sessionActionsButton).toHaveAttribute('aria-expanded', 'false')
+
+  await sessionActionsButton.click()
+  await expect(sessionActionsButton).toHaveAttribute('aria-expanded', 'true')
+  const semanticMenu = page.getByRole('menu', { name: 'Session actions' })
+  await expect(semanticMenu).toBeVisible()
+  await expect(semanticMenu.getByRole('menuitem')).toHaveCount(4)
+
+  const expectedItems = [
+    ['Conversation Outline', 'outline'],
+    ['Copy Session ID', 'copy'],
+    ['Rename', 'rename'],
+    ['Open in new window', 'open-new'],
+  ] as const
+  await expect(page.locator('.n-dropdown-option:visible')).toHaveCount(expectedItems.length)
+  await expect(page.locator('.n-dropdown-option:visible .n-dropdown-option-body__label'))
+    .toHaveText(expectedItems.map(([label]) => label))
+  for (const [label, icon] of expectedItems) {
+    await expect(visibleOption(page, label).locator(`[data-session-menu-icon="${icon}"]`)).toBeVisible()
+  }
+
+  await visibleOption(page, 'Conversation Outline').click()
+  await expect(sessionActionsButton).toHaveAttribute('aria-expanded', 'false')
+  await expect(page.locator('.outline-panel')).toBeVisible()
+
+  await sessionActionsButton.click()
+  await visibleOption(page, 'Rename').click()
+  const renameDialog = page.getByRole('dialog').filter({ hasText: 'Rename Session' })
+  await expect(renameDialog.getByRole('textbox')).toHaveValue('Session Menu Review')
+  await renameDialog.getByRole('button', { name: 'Cancel' }).click()
+
+  await sessionActionsButton.click()
+  await visibleOption(page, 'Open in new window').click()
+  await expect.poll(() => page.evaluate(() => (
+    window as typeof window & { __PW_SESSION_ACTIONS__?: SessionActionsHarness }
+  ).__PW_SESSION_ACTIONS__?.chatWindows)).toEqual([
+    { sessionId: 'session-actions-1', profile: 'research' },
+  ])
+
+  await sessionActionsButton.click()
+  await visibleOption(page, 'Copy Session ID').click()
+  await expect.poll(() => page.evaluate(() => (
+    window as typeof window & { __PW_SESSION_ACTIONS__?: SessionActionsHarness }
+  ).__PW_SESSION_ACTIONS__?.clipboard.text)).toBe('session-actions-1')
+})
+
+test('supports announced keyboard focus inside the current-session menu', async ({ page }) => {
+  await openDesktopChat(page)
+
+  const trigger = page.getByRole('button', { name: 'Session actions' })
+  await trigger.focus()
+  await page.keyboard.press('ArrowDown')
+  const menu = page.getByRole('menu', { name: 'Session actions' })
+  const items = menu.getByRole('menuitem')
+  await expect(menu).toBeVisible()
+  await expect(items.nth(0)).toBeFocused()
+  await expect(items.nth(0).locator(':scope > .n-dropdown-option-body')).toHaveCSS('outline-style', 'solid')
+
+  await page.keyboard.press('Escape')
+  await expect(menu).toBeHidden()
+  await expect(trigger).toBeFocused()
+
+  await page.keyboard.press('ArrowUp')
+  await expect(menu).toBeVisible()
+  await expect(items.nth(3)).toBeFocused()
+  await page.keyboard.press('Escape')
+  await expect(trigger).toBeFocused()
+
+  await page.keyboard.press('ArrowDown')
+  await expect(items.nth(0)).toBeFocused()
+
+  await page.keyboard.press('ArrowDown')
+  await expect(items.nth(1)).toBeFocused()
+  await page.keyboard.press('Enter')
+  await expect(menu).toBeHidden()
+  await expect(trigger).toBeFocused()
+  await expect.poll(() => page.evaluate(() => (
+    window as typeof window & { __PW_SESSION_ACTIONS__?: SessionActionsHarness }
+  ).__PW_SESSION_ACTIONS__?.clipboard.text)).toBe('session-actions-1')
+
+  await page.keyboard.press('Tab')
+  await page.locator(':focus').evaluate(element => element.setAttribute('data-pw-native-forward-focus', 'true'))
+  await trigger.focus()
+  await page.keyboard.press('Shift+Tab')
+  await page.locator(':focus').evaluate(element => element.setAttribute('data-pw-native-backward-focus', 'true'))
+
+  await trigger.focus()
+  await page.keyboard.press('ArrowDown')
+  await page.keyboard.press('Tab')
+  await expect(page.locator('[data-pw-native-forward-focus="true"]')).toBeFocused()
+
+  await trigger.focus()
+  await page.keyboard.press('ArrowDown')
+  await page.keyboard.press('Shift+Tab')
+  await expect(page.locator('[data-pw-native-backward-focus="true"]')).toBeFocused()
+})
+
+test('opens the profiled session route in a browser tab when no desktop bridge exists', async ({ page }) => {
+  await openBrowserChat(page)
+
+  await page.getByRole('button', { name: 'Session actions' }).click()
+  await visibleOption(page, 'Open in new tab').click()
+  await expect.poll(() => page.evaluate(() => (
+    window as typeof window & { __PW_SESSION_ACTIONS__?: SessionActionsHarness }
+  ).__PW_SESSION_ACTIONS__?.openedUrls)).toEqual([
+    '#/hermes/session/session-actions-1?profile=research',
+  ])
+})
+
+test('keeps local-only session actions honest until the first message persists the chat', async ({ page }) => {
+  await openDesktopChat(page)
+
+  await page.getByRole('button', { name: 'New Chat', exact: true }).click()
+  await page.getByRole('button', { name: 'Create', exact: true }).click()
+  await expect(page).toHaveURL(/#\/hermes\/session\//)
+
+  await page.getByRole('button', { name: 'Session actions' }).click()
+  await expect(visibleOption(page, 'Conversation Outline').locator(':scope > .n-dropdown-option-body'))
+    .not.toHaveClass(/n-dropdown-option-body--disabled/)
+  await expect(visibleOption(page, 'Copy Session ID').locator(':scope > .n-dropdown-option-body'))
+    .not.toHaveClass(/n-dropdown-option-body--disabled/)
+  await expect(visibleOption(page, 'Rename').locator(':scope > .n-dropdown-option-body'))
+    .toHaveClass(/n-dropdown-option-body--disabled/)
+  await expect(visibleOption(page, 'Open in new window').locator(':scope > .n-dropdown-option-body'))
+    .toHaveClass(/n-dropdown-option-body--disabled/)
+  const renameMenuItem = page.getByRole('menuitem', { name: 'Rename' })
+  const openMenuItem = page.getByRole('menuitem', { name: 'Open in new window' })
+  await expect(renameMenuItem).toHaveAttribute('aria-disabled', 'true')
+  await expect(openMenuItem).toHaveAttribute('aria-disabled', 'true')
+
+  await page.keyboard.press('Home')
+  await page.keyboard.press('ArrowDown')
+  await page.keyboard.press('ArrowDown')
+  await expect(renameMenuItem).toBeFocused()
+  await page.keyboard.press('Enter')
+  await expect(page.getByRole('menu', { name: 'Session actions' })).toBeVisible()
+  await expect(page.getByRole('dialog').filter({ hasText: 'Rename Session' })).toHaveCount(0)
+})
+
+test('shows a matching icon for every sidebar session action and keeps submenu affordances', async ({ page }) => {
+  await openDesktopChat(page)
+
+  await page.locator('.session-item').first().click({ button: 'right' })
+  const expectedItems = [
+    ['Pin', 'pin'],
+    ['Rename', 'rename'],
+    ['Archive', 'archive'],
+    ['Set Workspace', 'workspace'],
+    ['Set Model', 'model'],
+    ['Move to category', 'category'],
+    ['Export', 'export'],
+    ['Open in new window', 'open-new'],
+    ['Copy Session Link', 'link'],
+    ['Copy Session ID', 'copy'],
+  ] as const
+  await expect(page.locator('.n-dropdown-option:visible')).toHaveCount(expectedItems.length)
+  for (const [label, icon] of expectedItems) {
+    await expect(visibleOption(page, label).locator(`[data-session-menu-icon="${icon}"]`)).toBeVisible()
+  }
+
+  await expect(visibleOption(page, 'Move to category').locator('.n-dropdown-option-body__suffix')).toBeVisible()
+  await expect(visibleOption(page, 'Export').locator('.n-dropdown-option-body__suffix')).toBeVisible()
+  await visibleOption(page, 'Move to category').hover()
+  await expect(visibleOption(page, 'Create new category')).toBeVisible()
+})


### PR DESCRIPTION
## Summary

- Keep the Side panel control and consolidate Conversation Outline, Copy Session ID, Rename, and Open in new window/tab into one Session actions menu.
- Add clear, consistent icons to every top-level session context action, including a simplified Pin thumbtack, while preserving category/export submenus.
- Preserve desktop/web behavior and session profile routing, and add localized labels plus full keyboard and ARIA menu support.

## Motivation

The chat header currently exposes separate controls for closely related session actions, while the session context menu relies on text-only items. Consolidating these actions reduces toolbar clutter and makes both menus easier to scan and operate with a mouse, keyboard, or assistive technology.

## Screenshots

### Header session actions menu

![Header session actions menu](https://github.com/user-attachments/assets/5f2e77a9-9e97-4278-a021-0b97ccd3085b)

### Session context menu

![Session context menu with action icons](https://github.com/user-attachments/assets/f80c9178-c9aa-4187-9fcd-8a134911bf11)

## Validation

- `NODE_ENV=test npm run test -- tests/client/session-action-menu.test.ts tests/client/chat-panel-session-actions.test.ts tests/client/session-category-menu.test.ts tests/client/chat-panel-session-click.test.ts tests/client/drawer-panel-resize.test.ts tests/client/i18n-coverage.test.ts` — 54 tests passed
- `NODE_ENV=test PLAYWRIGHT_PORT=4225 PLAYWRIGHT_CHANNEL=chrome npx playwright test tests/e2e/session-action-menu.spec.ts --project=chromium --workers=1` — 5 tests passed
- `npm run build`
- `npm run harness:check`

## Notes for reviewers

- Rename and Open are intentionally disabled for local-only sessions until the session has been persisted.
- Opening a session in a new window/tab carries the session's profile through both desktop and browser paths.
