### PR TITLE
fix: show published Agent images to shared group guests

### DIFF
--- a/docs/chat-chain-changes/2026-09-05-shared-group-markdown-images.md
+++ b/docs/chat-chain-changes/2026-09-05-shared-group-markdown-images.md
@@ -1,0 +1,8 @@
+# Shared group Markdown images
+
+- Area: group attachment reads and group message image rendering.
+- Problem: composer images use room attachments, but local Agents can return Markdown with an absolute image path. Invite viewers tried the protected filesystem API, while the room attachment fallback only recognized structured image blocks.
+- Change: group Markdown images use room/invite attachment URLs. The server recognizes image tokens in a saved local Agent assistant message and uses the existing bounded room attachment materialization. Historical messages are supported without rewriting the database. Images load after the final message is saved so a streaming render cannot cache an early 404.
+- Access boundary: only image destinations in the requesting room's messages grant access. Human text, code samples, HTML and ordinary file links do not. A remote Agent's path belongs to its own machine and does not authorize reading the room host's filesystem; that Agent must publish the artifact through its existing transfer flow. Existing attachment size/type/quota limits remain in force.
+- Clients: Studio share pages require this change. App remote groups also need the companion image-resource routing change; local App groups and single chat keep their existing routing. The cloud already forwards room attachment downloads and needs no change.
+- Validation: focused server/renderer tests, an invite-view browser regression, ordinary chat/group browser tests, and a read-only probe using the affected room's actual historical message and image bytes.

--- a/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
+++ b/packages/client/src/components/hermes/chat/MarkdownRenderer.vue
@@ -63,6 +63,8 @@ const props = withDefaults(defineProps<{
     content: string
     mentionNames?: string[]
     headingIdPrefix?: string
+    resolveImageUrl?: (path: string) => string
+    deferImages?: boolean
 }>(), {
     mentionNames: () => [],
     headingIdPrefix: '',
@@ -187,6 +189,7 @@ function hasExtension(path: string, extensions: Set<string>): boolean {
 
 const renderedHtml = computed(() => {
   let html = md.render(repairNestedMarkdownFences(props.content))
+  if (props.deferImages) html = html.replace(/<img\b[^>]*>/gi, '')
 
   // Add IDs to headings for anchor links
   const prefix = props.headingIdPrefix ? `${props.headingIdPrefix}-` : ''
@@ -212,6 +215,11 @@ const renderedHtml = computed(() => {
   // Replace image src paths with download URLs
   html = html.replace(/\bsrc=(["'])([^"']+)\1/g, (match, quote, path) => {
     if (!isLocalFilePath(path)) return match
+    if (props.resolveImageUrl && !path.startsWith('//')) {
+      let decodedPath = md.utils.unescapeAll(path)
+      try { decodedPath = decodeURIComponent(decodedPath) } catch { /* Keep literal paths. */ }
+      return `src="${md.utils.escapeHtml(props.resolveImageUrl(normalizeLocalFilePath(decodedPath)))}"`
+    }
     const downloadUrl = getDownloadUrl(normalizeLocalFilePath(path))
     return `src=${quote}${downloadUrl}${quote}`
   })

--- a/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
+++ b/packages/client/src/components/hermes/group-chat/GroupMessageItem.vue
@@ -155,6 +155,12 @@ const thinkingExpanded = computed(() => {
     return false
 })
 const assistantBody = computed(() => parsedThinking.value.body || props.message.content || '')
+function resolveGroupImageUrl(path: string): string {
+    return getGroupChatAttachmentUrl({
+        roomId: props.message.roomId || groupChatStore.currentRoomId || '',
+        inviteCode: groupChatStore.inviteGuest ? groupChatStore.activeInviteCode || undefined : undefined,
+    }, path)
+}
 const contentBlocks = computed(() => {
     const content = props.message.content || ''
     const trimmed = content.trim()
@@ -815,10 +821,10 @@ onBeforeUnmount(() => {
                     </div>
                 </div>
                 <template v-if="parsedMessageReference">
-                    <MarkdownRenderer :content="referencedContentMarkdown" :mention-names="mentionNames" />
-                    <MarkdownRenderer v-if="parsedMessageReference.reply" :content="parsedMessageReference.reply" :mention-names="mentionNames" />
+                    <MarkdownRenderer :content="referencedContentMarkdown" :mention-names="mentionNames" :resolve-image-url="resolveGroupImageUrl" />
+                    <MarkdownRenderer v-if="parsedMessageReference.reply" :content="parsedMessageReference.reply" :mention-names="mentionNames" :resolve-image-url="resolveGroupImageUrl" />
                 </template>
-                <MarkdownRenderer v-else-if="renderedDisplayBody" :content="renderedDisplayBody" :mention-names="mentionNames" />
+                <MarkdownRenderer v-else-if="renderedDisplayBody" :content="renderedDisplayBody" :mention-names="mentionNames" :resolve-image-url="resolveGroupImageUrl" :defer-images="!!message.isStreaming" />
                 <ToolChangeCard
                     v-for="change in assistantWorkspaceChanges"
                     :key="change.change_id"

--- a/packages/server/src/modules/studio/services/group-chat/attachments.ts
+++ b/packages/server/src/modules/studio/services/group-chat/attachments.ts
@@ -1,7 +1,8 @@
 import { createHash, randomBytes } from 'node:crypto'
 import { constants as fsConstants, lstatSync } from 'node:fs'
 import { chmod, copyFile, lstat, mkdir, readdir, rm, stat } from 'node:fs/promises'
-import { basename, extname, resolve } from 'node:path'
+import { basename, extname, isAbsolute, resolve } from 'node:path'
+import MarkdownIt from 'markdown-it'
 import { config } from '../../public/config'
 import { isPathWithin } from '../files/path'
 
@@ -246,6 +247,28 @@ type PublishedAttachmentMessage = {
 
 type PublishedAttachmentAgent = {
     agentId?: string
+    executorType?: string
+}
+
+const publishedImageMarkdown = new MarkdownIt({ html: false, linkify: false })
+
+function publishedMarkdownImagePaths(content: unknown): string[] {
+    if (typeof content !== 'string' || !content.includes('![')) return []
+    const paths: string[] = []
+    const visit = (tokens: ReturnType<typeof publishedImageMarkdown.parse>) => {
+        for (const token of tokens) {
+            if (token.type === 'image') {
+                try {
+                    const path = decodeURIComponent(token.attrGet('src') || '')
+                    if (isAbsolute(path) && !path.startsWith('//') && !path.startsWith('/api/')
+                        && SAFE_PUBLISHED_IMAGE_EXTENSIONS.has(extname(path).toLowerCase())) paths.push(resolve(path))
+                } catch { /* Malformed image destinations do not grant file access. */ }
+            }
+            if (token.children) visit(token.children)
+        }
+    }
+    visit(publishedImageMarkdown.parse(content, {}))
+    return paths
 }
 
 const SAFE_PUBLISHED_IMAGE_EXTENSIONS = new Set(['.gif', '.jpeg', '.jpg', '.png', '.webp'])
@@ -271,11 +294,19 @@ export function findPublishedGroupChatAttachmentPath(
 ): string | null {
     if (!storedName || basename(storedName) !== storedName) return null
     const agentIds = new Set(agents.map(agent => String(agent.agentId || '')).filter(Boolean))
+    const localAgentIds = new Set(agents.filter(agent => agent.executorType !== 'remote')
+        .map(agent => String(agent.agentId || '')).filter(Boolean))
 
     for (const message of messages) {
         const isAgentMessage = (
             message.role === 'assistant' || message.role === 'tool' || message.role === 'agent_run'
         ) && agentIds.has(String(message.senderId || ''))
+        // A remote Agent's absolute path belongs to another machine and must
+        // never authorize reading a matching path on the room host.
+        if (message.role === 'assistant' && localAgentIds.has(String(message.senderId || ''))) {
+            const path = publishedMarkdownImagePaths(message.content).find(path => basename(path) === storedName)
+            if (path) return path
+        }
         for (const block of contentBlocks(message.content)) {
             if (block?.type !== 'image' || typeof block.path !== 'string') continue
             const publishedPath = resolve(block.path)

--- a/tests/client/markdown-rendering.test.ts
+++ b/tests/client/markdown-rendering.test.ts
@@ -79,6 +79,29 @@ vi.mock('@/api/studio/download', async (importOriginal) => {
 import MarkdownRenderer from '@/components/hermes/chat/MarkdownRenderer.vue'
 
 describe('MarkdownRenderer', () => {
+  it('waits for the final group message before requesting its published image', async () => {
+    const resolver = vi.fn(() => '/api/studio/group-chat/invites/ROOM1/attachments/answer.png')
+    const wrapper = mount(MarkdownRenderer, { props: {
+      content: '![answer](/workspace/answer.png)', deferImages: true, resolveImageUrl: resolver,
+    } })
+    expect(wrapper.find('img').exists()).toBe(false)
+    expect(resolver).not.toHaveBeenCalled()
+    await wrapper.setProps({ deferImages: false })
+    expect(wrapper.get('img').attributes('src')).toBe('/api/studio/group-chat/invites/ROOM1/attachments/answer.png')
+    wrapper.unmount()
+  })
+  it('uses the group image resolver for local images while leaving public images alone', () => {
+    const resolveImageUrl = vi.fn(path => `/api/studio/group-chat/invites/ROOM1/attachments/${encodeURIComponent(path.split('/').pop())}`)
+    const wrapper = mount(MarkdownRenderer, { props: {
+      content: '![图片](</workspace/马年 image.png>)\n\n![public](https://example.com/photo.png)', resolveImageUrl,
+    } })
+    const images = wrapper.findAll('img')
+    expect(images[0].attributes('src')).toBe('/api/studio/group-chat/invites/ROOM1/attachments/%E9%A9%AC%E5%B9%B4%20image.png')
+    expect(images[1].attributes('src')).toBe('https://example.com/photo.png')
+    expect(resolveImageUrl).toHaveBeenCalledWith('/workspace/马年 image.png')
+    expect(downloadApiMock.getDownloadUrl).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
   afterEach(() => {
     vi.useRealTimers()
   })

--- a/tests/e2e/group-chat-share.spec.ts
+++ b/tests/e2e/group-chat-share.spec.ts
@@ -19,7 +19,7 @@ const previewPng = Buffer.from(
   'base64',
 )
 
-async function mockInviteSocket(page: Page, joinFailure: { code: string, error: string } | null = null) {
+async function mockInviteSocket(page: Page, joinFailure: { code: string, error: string } | null = null, workerContent = 'How can I help?') {
   const joinFailureJson = JSON.stringify(joinFailure)
   await page.route('**/node_modules/.vite/deps/socket__io-client.js*', async (route) => {
     await route.fulfill({
@@ -76,7 +76,7 @@ export function io(url, options) {
             roomId: 'room-shared',
             senderId: 'agent-worker',
             senderName: 'Worker',
-            content: 'How can I help?',
+            content: ${JSON.stringify(workerContent)},
             timestamp: 2,
             role: 'assistant',
           }],
@@ -180,6 +180,19 @@ async function mockInviteApi(page: Page, valid = true, delayMs = 0) {
 }
 
 test.describe('invite-only group chat share page', () => {
+  test('loads an Agent Markdown image through the room invite without filesystem API access', async ({ page }) => {
+    await mockInviteSocket(page, null, 'Here is the image: ![result](/Users/owner/workspace/agent-result.png)')
+    const protectedRequests = await mockInviteApi(page)
+    await page.route('**/api/studio/group-chat/invites/ROOM1/attachments/agent-result.png*', route =>
+      route.fulfill({ status: 200, contentType: 'image/png', body: previewPng }))
+    await page.goto('/#/share/group-chat/ROOM1')
+    await page.locator('#group-chat-guest-name input').fill('Visitor')
+    await page.getByRole('button', { name: 'Enter room' }).click()
+    const picture = page.locator('.markdown-body img[alt="result"]')
+    await expect(picture).toHaveAttribute('src', /\/invites\/ROOM1\/attachments\/agent-result\.png$/)
+    await expect.poll(() => picture.evaluate((image: HTMLImageElement) => image.complete && image.naturalWidth > 0)).toBe(true)
+    expect(protectedRequests).toEqual([])
+  })
   test('joins one room without login, app sidebar, room list, or protected API calls', async ({ page }) => {
     await mockInviteSocket(page)
     const protectedRequests = await mockInviteApi(page, true, 300)

--- a/tests/server/group-chat-invite-attachments.test.ts
+++ b/tests/server/group-chat-invite-attachments.test.ts
@@ -41,7 +41,7 @@ describe('invite-scoped group chat attachments', () => {
         getRoom: (roomId: string) => [...rooms.values()].find(room => room.id === roomId) || null,
         getRoomsForProfiles: () => [],
         getMemberByAuthUserId: () => null,
-        getMessagesForContext: () => messages,
+        getMessagesForContext: (roomId: string) => messages.filter(message => !message.roomId || message.roomId === roomId),
         getRoomAgents: () => agents,
       }),
     })
@@ -287,6 +287,40 @@ describe('invite-scoped group chat attachments', () => {
     )
     expect(preview.status).toBe(200)
     expect(await preview.text()).toBe('legacy-image')
+  })
+
+  it('serves historical Agent Markdown images through the invite without granting cross-room access', async () => {
+    const imagePath = join(stateDir, '马年 image.png')
+    await writeFile(imagePath, 'published-markdown-image')
+    agents = [{ agentId: 'agent-1', executorType: 'server' }]
+    messages = [{ roomId: 'room-1', senderId: 'agent-1', role: 'assistant',
+      content: `图片在这里：\n\n![马年](<${imagePath}>)` }]
+    const file = encodeURIComponent(basename(imagePath))
+    const crossRoom = await fetch(`${baseUrl}/api/studio/group-chat/invites/ROOM2/attachments/${file}`)
+    expect(crossRoom.status).toBe(404)
+    const image = await fetch(`${baseUrl}/api/studio/group-chat/invites/ROOM1/attachments/${file}`)
+    expect(image.status).toBe(200)
+    expect(image.headers.get('content-type')).toBe('image/png')
+    expect(await image.text()).toBe('published-markdown-image')
+    await rm(imagePath)
+    expect(await (await fetch(`${baseUrl}/api/studio/group-chat/invites/ROOM1/attachments/${file}`)).text()).toBe('published-markdown-image')
+  })
+
+  it('does not publish paths from visitors, remote Agents, code samples or ordinary file links', async () => {
+    agents = [{ agentId: 'agent-1', executorType: 'server' }, { agentId: 'remote-1', executorType: 'remote' }]
+    for (const [name, senderId, role, content] of [
+      ['human', 'guest-1', 'user', (path: string) => `![private](${path})`],
+      ['remote', 'remote-1', 'assistant', (path: string) => `![private](${path})`],
+      ['code', 'agent-1', 'assistant', (path: string) => `\`\`\`md\n![private](${path})\n\`\`\``],
+      ['link', 'agent-1', 'assistant', (path: string) => `[private](${path})`],
+      ['html', 'agent-1', 'assistant', (path: string) => `<img src="${path}">`],
+    ] as const) {
+      const path = join(stateDir, `${name}.png`)
+      await writeFile(path, 'private-image')
+      messages.push({ roomId: 'room-1', senderId, role, content: content(path) })
+      const response = await fetch(`${baseUrl}/api/studio/group-chat/invites/ROOM1/attachments/${name}.png`)
+      expect(response.status, name).toBe(404)
+    }
   })
 
   it('rate-limits repeated public uploads per room', async () => {


### PR DESCRIPTION
Agent messages can publish images as Markdown absolute paths, while user uploads already use room attachments. Invite guests therefore cannot see Agent images such as `![image](/path/to/year-of-the-horse.png)`.

Resolve group Markdown images through room attachment routes and allow those routes to materialize image paths published by local Agents in the requested room, including existing history. Human messages, remote Agent paths, code examples and ordinary file links do not grant filesystem access. Streaming images wait until the final message is persisted. Existing attachment limits remain in effect.

App requires the companion `fix/remote-group-markdown-images` change. Cloud relay requires no change.

Validation:
- 65 focused server/client tests passed; 54 browser tests passed.
- Studio build and harness passed.
- Read-only development-data probe returned the actual published image with matching bytes.
- Full coverage run: 4,942 passed, 14 failed, 6 skipped. Thirteen failures are MCP autoinject fixtures rejected by the transient-path guard because this worktree is under /tmp; one runtime Skill-validation test also failed and its cause remains unverified. These failures are outside the changed image code. Kept draft pending full-suite resolution.
