### PR TITLE
fix: isolate group Agent connections and restore room membership

### DIFF
--- a/docs/chat-chain-changes/2026-09-05-group-agent-connection-recovery.md
+++ b/docs/chat-chain-changes/2026-09-05-group-agent-connection-recovery.md
@@ -1,0 +1,24 @@
+# Group Agent connection isolation and recovery
+
+Group Agent sockets now use their own Socket.IO manager. Previously the first
+Agent could share a cached manager with an App relay namespace on the same local
+server. Closing that relay with `disconnect(true)` disconnected the Agent too,
+with `io server disconnect`, which does not automatically reconnect. Additional
+Agents could remain online because repeated connections to the same namespace
+already received separate managers. Offline Agents are excluded from mention
+dispatch, so subsequent mentions produced no execution task.
+
+Room rejoin now runs on the namespace socket's `connect` event. The manager's
+`reconnect` event happens before namespace authentication completes, so the old
+handler attempted to join while `connected` was still false. Disconnect logs now
+include the Agent ID, reason, and whether automatic reconnect remains active.
+
+Real Socket.IO regression tests cover two local Agents plus a relay transport
+closure, and repeated transport reconnects with restored room membership. Both
+failure paths were reproduced before the fix. The reported room history showed
+unanswered mentions of the first local Agent; historical logs did not capture its
+exact disconnect reason, so the incident trigger cannot be proven retrospectively.
+
+This changes Studio group Agent connections only. Cloud relay, single-chat
+transport, credentials, and message persistence are unchanged. Existing running
+Studio processes need to load the update to use isolated connections.

--- a/packages/server/src/modules/studio/services/group-chat/agent-clients.ts
+++ b/packages/server/src/modules/studio/services/group-chat/agent-clients.ts
@@ -412,6 +412,9 @@ export class AgentClient implements GroupAgentExecutor {
         const token = await getToken()
 
         this.socket = io(`http://127.0.0.1:${actualPort}/group-chat`, {
+            // A relay namespace can close its entire transport. Do not let it
+            // share this Agent's connection and permanently disconnect it.
+            forceNew: true,
             auth: {
                 token: token || undefined,
                 userId: this.agentId,
@@ -1979,8 +1982,14 @@ export class AgentClient implements GroupAgentExecutor {
             this.handlers.onRoomUpdated?.(data)
         })
 
-        // Auto rejoin rooms on reconnect
-        s.io.on('reconnect', async () => {
+        s.on('disconnect', (reason) => {
+            logger.info({ agentId: this.agentId, reason, willReconnect: s.active }, '[AgentClient] group socket disconnected')
+        })
+
+        // Manager reconnect fires before this namespace is connected, when
+        // joinRoom still fails ensureConnected(). Rejoin after socket connect.
+        s.on('connect', async () => {
+            if (s !== this.socket || this.joinedRooms.size === 0) return
             if (this._reconnecting) return
             this._reconnecting = true
             logger.info(`[AgentClients] ${this.name} reconnecting, rejoining ${this.joinedRooms.size} rooms...`)

--- a/tests/server/group-chat-agent-reconnect.test.ts
+++ b/tests/server/group-chat-agent-reconnect.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { io, type Socket } from 'socket.io-client'
+import { createTestGroupChatServer, once } from './group-chat-test-helpers'
+import { AgentClient } from '../../packages/server/src/modules/studio/services/group-chat/agent-clients'
+
+describe('group Agent connection recovery', () => {
+  let harness: Awaited<ReturnType<typeof createTestGroupChatServer>>
+  let agent: AgentClient
+  let secondAgent: AgentClient | undefined
+  let socket: Socket
+
+  beforeEach(async () => {
+    harness = await createTestGroupChatServer()
+    const storage = harness.groupServer.getStorage()
+    storage.saveRoom('room-1', 'Room', 'INVITE1')
+    storage.addRoomAgent('room-1', 'agent-1', 'default', 'Worker', '', 0)
+    agent = new AgentClient({
+      agentId: 'agent-1', profile: 'default', name: 'Worker', description: '',
+      invited: 0, backgroundDelegationEnabled: false,
+    })
+    await agent.connect(harness.port)
+    await harness.groupServer.agentClients.addAgentToRoom('room-1', agent)
+    socket = (agent as any).socket
+  })
+
+  afterEach(async () => {
+    await agent?.disconnect()
+    await secondAgent?.disconnect()
+    secondAgent = undefined
+    harness?.cleanup()
+  })
+
+  it('keeps the local Agent online when a relay namespace closes its transport', async () => {
+    harness.groupServer.getStorage().addRoomAgent('room-1', 'agent-2', 'default', 'Second', '', 0)
+    secondAgent = new AgentClient({
+      agentId: 'agent-2', profile: 'default', name: 'Second', description: '',
+      invited: 0, backgroundDelegationEnabled: false,
+    })
+    await secondAgent.connect(harness.port)
+    await harness.groupServer.agentClients.addAgentToRoom('room-1', secondAgent)
+    const namespace = harness.groupServer.getIO().of('/group-chat-agent-relay')
+    const relay = io(`http://127.0.0.1:${harness.port}/group-chat-agent-relay`, {
+      transports: ['websocket'], reconnection: false,
+    })
+    harness.sockets.push(relay)
+    await once(relay, 'connect')
+    const closed = once(relay, 'disconnect')
+    namespace.sockets.get(relay.id!)!.disconnect(true)
+    await closed
+
+    expect(secondAgent.connected).toBe(true)
+    expect(agent.connected).toBe(true)
+    expect(harness.groupServer.agentClients.getConnectedAgents('room-1')).toContain(agent)
+    expect(harness.groupServer.getIO().of('/group-chat').sockets.get(socket.id!)?.rooms.has('room-1')).toBe(true)
+  })
+
+  it('rejoins after each transport reconnect once the group namespace is connected', async () => {
+    socket.io.reconnectionDelay(10)
+    socket.io.reconnectionDelayMax(20)
+    const namespace = harness.groupServer.getIO().of('/group-chat')
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const oldId = socket.id!
+      const connected = once(socket, 'connect')
+      namespace.sockets.get(oldId)!.conn.close()
+      await connected
+      expect(socket.id).not.toBe(oldId)
+      await vi.waitFor(() => {
+        expect(namespace.sockets.get(socket.id!)?.rooms.has('room-1')).toBe(true)
+      })
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Keep each Studio group Agent on its own Socket.IO manager. Previously, a relay namespace could share the first local Agent's transport; closing the relay with disconnect(true) also disconnected that Agent permanently, while a second local Agent remained online. Subsequent mentions skipped the offline executor and created no task.
- Rejoin rooms on the namespace socket's connect event. The manager reconnect event fires too early and previously failed the connected check, leaving recovered sockets outside their rooms.
- Log group Agent disconnect reason and reconnect eligibility. Changes are limited to Studio group Agent connections.

Both failure paths were reproduced with real Socket.IO connections before the fix. Regression coverage includes two local Agents with a relay closure and repeated transport reconnects. The reported development room has unanswered mentions of the first local Agent, but historical logs lack its disconnect reason, so the incident trigger cannot be proven retrospectively.

## Validation
- 87 focused server tests passed across connection recovery, baseline, member synchronization, execution queue, and relay manager suites. The strengthened two-Agent regression also passed separately.
- 36 group chat share/deep-link browser tests passed.
- npm run build passed.
- npm run harness:check passed.

Running Studio instances need to load this update. No cloud deployment or App change is required; single-chat connections are unchanged.
