### PR TITLE
fix(desktop): prevent managed MCP launches from reopening Studio

### DIFF
--- a/packages/server/src/modules/coding-agents/services/index.ts
+++ b/packages/server/src/modules/coding-agents/services/index.ts
@@ -1140,6 +1140,7 @@ function hermesMcpServerConfig(profile: string, serverName: string, toolset: str
   return {
     ...hermesMcpCommandConfig(toolset),
     env: {
+      ELECTRON_RUN_AS_NODE: '1',
       HERMES_WEB_UI_URL: `http://127.0.0.1:${process.env.PORT || '8648'}`,
       HERMES_WEB_UI_HOME: appHome,
       HERMES_WEBUI_STATE_DIR: appHome,

--- a/packages/server/src/modules/ekko/services/mcp.ts
+++ b/packages/server/src/modules/ekko/services/mcp.ts
@@ -119,6 +119,7 @@ function managedMcpServerConfig(
   return {
     ...managedCommandConfig(toolset),
     env: {
+      ELECTRON_RUN_AS_NODE: '1',
       HERMES_WEB_UI_URL: `http://127.0.0.1:${config.port}`,
       HERMES_WEB_UI_HOME: config.appHome,
       HERMES_WEBUI_STATE_DIR: config.appHome,

--- a/packages/server/src/modules/hermes/services/mcp/studio-autoinject.ts
+++ b/packages/server/src/modules/hermes/services/mcp/studio-autoinject.ts
@@ -169,6 +169,9 @@ function managedConfig(
   bundledScript: string | null,
 ): Record<string, unknown> {
   const env: Record<string, string> = {
+    // process.execPath can be Electron. Persist Node mode for external MCP
+    // clients (such as Gateway) that do not inherit the desktop server's env.
+    ELECTRON_RUN_AS_NODE: '1',
     HERMES_WEB_UI_URL: `http://127.0.0.1:${config.port}`,
     HERMES_WEB_UI_HOME: config.appHome,
     HERMES_WEBUI_STATE_DIR: config.appHome,
@@ -211,6 +214,7 @@ function sameConfig(existing: Record<string, any>, desired: Record<string, unkno
     (desired.timeout === undefined || existing.timeout === desired.timeout) &&
     existing.enabled !== false &&
     isRecord(existing.env) &&
+    existing.env.ELECTRON_RUN_AS_NODE === desiredEnv.ELECTRON_RUN_AS_NODE &&
     existing.env.HERMES_WEB_UI_URL === desiredEnv.HERMES_WEB_UI_URL &&
     existing.env.HERMES_WEB_UI_HOME === desiredEnv.HERMES_WEB_UI_HOME &&
     existing.env.HERMES_WEBUI_STATE_DIR === desiredEnv.HERMES_WEBUI_STATE_DIR &&

--- a/tests/server/coding-agents-launch.test.ts
+++ b/tests/server/coding-agents-launch.test.ts
@@ -1085,6 +1085,9 @@ describe('coding agent launch preparation', () => {
         HERMES_WEB_UI_MANAGED_MCP: '1',
       },
     })
+    for (const name of ['hermes-studio-api', 'hermes-studio-browser', 'hermes-studio-devices', 'hermes-studio-use']) {
+      expect(mcp.mcpServers[name].env.ELECTRON_RUN_AS_NODE).toBe('1')
+    }
     expect(mcp.mcpServers['hermes-studio-browser']).toMatchObject({
       command: process.execPath,
       args: [join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'browser'],
@@ -1640,7 +1643,8 @@ describe('coding agent launch preparation', () => {
     expect(config).toContain(`args = ["${join(process.cwd(), 'bin/hermes-studio-mcp.mjs')}", "api"]`)
     expect(config).toContain(`args = ["${join(process.cwd(), 'bin/hermes-studio-mcp.mjs')}", "devices"]`)
     expect(config).toContain(`args = ["${join(process.cwd(), 'bin/hermes-studio-mcp.mjs')}", "use"]`)
-    expect(config).toContain(`env = { HERMES_WEB_UI_URL = "http://127.0.0.1:8648", HERMES_WEB_UI_HOME = "${home}"`)
+    expect(config).toContain('ELECTRON_RUN_AS_NODE = "1"')
+    expect(config).toContain(`HERMES_WEB_UI_URL = "http://127.0.0.1:8648", HERMES_WEB_UI_HOME = "${home}"`)
     expect(config).toContain('HERMES_WEBUI_STATE_DIR = "')
     expect(config).toContain('HERMES_WEB_UI_PROFILE = "default"')
     expect(config).toContain('HERMES_MCP_SERVER_NAME = "hermes-studio-api"')

--- a/tests/server/ekko-agent-mcp.test.ts
+++ b/tests/server/ekko-agent-mcp.test.ts
@@ -43,6 +43,7 @@ describe('Ekko MCP server context', () => {
       command: process.execPath,
       args: [join(process.cwd(), 'bin/hermes-studio-mcp.mjs'), 'api'],
       env: {
+        ELECTRON_RUN_AS_NODE: '1',
         HERMES_WEB_UI_URL: 'http://127.0.0.1:8648',
         HERMES_WEB_UI_HOME: '/Users/test/.hermes-web-ui',
         HERMES_WEBUI_STATE_DIR: '/Users/test/.hermes-web-ui',
@@ -93,6 +94,23 @@ describe('Ekko MCP server context', () => {
     expect(servers?.['hermes-studio-browser']).toBeDefined()
     expect(servers?.['hermes-studio-devices']).toBeDefined()
     expect(servers?.['hermes-studio-use']).toBeDefined()
+  })
+
+  it('repairs persisted managed MCP launch environments without a bundled Node', async () => {
+    const { injectManagedEkkoMcpServers } = await import('../../packages/server/src/modules/ekko/services/mcp')
+    injectManagedEkkoMcpServers(setup)
+    const stale = structuredClone(setup.config.read())
+    for (const profile of Object.values(stale.mcp.profiles)) {
+      for (const server of Object.values(profile.servers)) delete server.env?.ELECTRON_RUN_AS_NODE
+    }
+    setup.config.replace(stale)
+    const result = injectManagedEkkoMcpServers(setup)
+    expect(result.targets.every(target => target.status === 'updated')).toBe(true)
+    for (const server of Object.values(setup.config.listMcpServers('work'))) {
+      expect(server.command).toBe(process.execPath)
+      expect(server.env?.ELECTRON_RUN_AS_NODE).toBe('1')
+    }
+    expect(injectManagedEkkoMcpServers(setup).targets.every(target => target.status === 'unchanged')).toBe(true)
   })
 
   it('preserves a disabled managed server while refreshing its injected definition', async () => {

--- a/tests/server/studio-mcp-autoinject.test.ts
+++ b/tests/server/studio-mcp-autoinject.test.ts
@@ -101,6 +101,7 @@ describe('studio MCP autoinject', () => {
   })
 
   afterEach(() => {
+    vi.unstubAllEnvs()
     delete process.env.HERMES_WEB_UI_MCP_BIN
     for (const root of fixtureRoots.splice(0).reverse()) rmSync(root, { recursive: true, force: true })
   })
@@ -117,6 +118,7 @@ describe('studio MCP autoinject', () => {
       command: process.execPath,
       args: [stableLauncher, 'api'],
       env: {
+        ELECTRON_RUN_AS_NODE: '1',
         HERMES_WEB_UI_URL: 'http://127.0.0.1:8648',
         HERMES_WEB_UI_HOME: '/Users/test/.hermes-web-ui',
         HERMES_WEBUI_STATE_DIR: '/Users/test/.hermes-web-ui',
@@ -167,6 +169,29 @@ describe('studio MCP autoinject', () => {
       'hermes-studio-use',
     ])
     expect(result.command).toBe(process.execPath)
+  })
+
+  it.each([undefined, '0'])('repairs managed MCP Node mode %s and then leaves the config unchanged', async (runAsNode) => {
+    vi.stubEnv('HERMES_DESKTOP', 'true')
+    vi.stubEnv('ELECTRON_RUN_AS_NODE', undefined)
+    const { injectBundledMcpServer } = await import('../../packages/server/src/modules/hermes/services/mcp/studio-autoinject')
+    await injectBundledMcpServer()
+    const updater = updateConfigYamlForProfileMock.mock.calls[0][1]
+    const initial = await updater({})
+    for (const server of Object.values(initial.data.mcp_servers) as any[]) {
+      expect(server.command).toBe(process.execPath)
+      expect(server.env.ELECTRON_RUN_AS_NODE).toBe('1')
+      if (runAsNode === undefined) delete server.env.ELECTRON_RUN_AS_NODE
+      else server.env.ELECTRON_RUN_AS_NODE = runAsNode
+    }
+    initial.data.mcp_servers['hermes-studio-api'].timeout = 42
+    const repaired = await updater(initial.data)
+    expect(repaired.result.status).toBe('updated')
+    for (const server of Object.values(repaired.data.mcp_servers) as any[]) {
+      expect(server.env.ELECTRON_RUN_AS_NODE).toBe('1')
+    }
+    expect(repaired.data.mcp_servers['hermes-studio-api'].timeout).toBe(42)
+    expect((await updater(repaired.data)).result.status).toBe('unchanged')
   })
 
   it('migrates an existing managed use server from the default MCP timeout', async () => {


### PR DESCRIPTION
## Summary
When no bundled Node is available, managed MCP commands fall back to `process.execPath`, which is the Electron executable in desktop builds. An external Gateway starting that command without `ELECTRON_RUN_AS_NODE=1` launches another GUI instance, restores the minimized Studio window through `second-instance`, and fails the MCP handshake. Gateway retries can repeat this while chat is idle.

- Persist `ELECTRON_RUN_AS_NODE=1` in managed Hermes, Ekko, and Coding Agent MCP environments. Independent Node remains preferred; Electron fallback runs the MCP script in Node mode.
- Include the flag in Hermes configuration comparison so existing managed entries with a missing or incorrect value are repaired during synchronization. Cover migration, timeout preservation, and idempotence in regression tests.

## Validation
- 147 tests passed across MCP injection, Coding Agent launch/configuration, MCP protocol, Gateway cleanup, and desktop lifecycle suites (`env -u PORT npm run test -- tests/server/studio-mcp-autoinject.test.ts tests/server/ekko-agent-mcp.test.ts tests/server/coding-agents-launch.test.ts tests/server/coding-agent-mcp-manager.test.ts tests/server/hermes-web-ui-mcp.test.ts tests/server/shutdown.test.ts tests/server/shutdown-background-order.test.ts tests/desktop/app-lifecycle.test.ts tests/server/gateway-respawn.test.ts`). `PORT` was unset to avoid the local desktop port overriding test defaults.
- `npm run harness:check` and `npm run build` passed.
- On macOS, the installed Hermes Studio 0.7.17 executable successfully ran the repository MCP script and completed `initialize` for all four toolsets with Node mode enabled and isolated state.
- Windows native execution was not tested locally.
