### PR TITLE
chore(harness): require Node mode for Studio-managed MCP launches

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,6 +36,7 @@ npm run build
 - Do not reintroduce deprecated compatibility switches without a current caller.
 - Use structured APIs and parsers for structured data instead of ad hoc string edits when possible.
 - Add comments only where they explain non-obvious behavior or constraints.
+- Every Studio-injected managed MCP server must explicitly set `ELECTRON_RUN_AS_NODE: '1'` in its own launch `env`, including when an independent Node executable is selected. Never rely on parent environment inheritance or set this globally for the desktop GUI. See `docs/harness/validation.md` for the guardrail.
 
 ## Frontend Rules
 

--- a/docs/harness/validation.md
+++ b/docs/harness/validation.md
@@ -33,6 +33,20 @@ npm run build
 | GitHub workflow | `npm run harness:check` and `actionlint` when available |
 | Package manifests | `npm ci --ignore-scripts` and lockfile workflow expectations |
 
+## Managed MCP launch environment
+
+Every MCP definition injected by Studio (Hermes, Ekko, or Coding Agent) must
+include `ELECTRON_RUN_AS_NODE: '1'` in that MCP subprocess's `env`. Independent
+Node ignores the flag; the Electron executable fallback requires it to execute
+the MCP script instead of opening another desktop instance. External Gateway
+processes may not inherit the desktop server's environment.
+
+`npm run harness:check` inspects all three configuration factories. New managed
+MCP injection paths must be added to that check. Keep configuration comparison
+and migration aware of the flag so previously injected entries are repaired;
+do not overwrite user-owned MCP definitions or globally enable Node mode for
+the desktop app. Validate changes with the MCP injection and launch tests.
+
 ## CI Mapping
 
 - Build workflow: installs dependencies, runs coverage, and builds production

--- a/scripts/harness-check.mjs
+++ b/scripts/harness-check.mjs
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import path from 'node:path'
 import { checkServerModuleBoundaries } from './server-module-boundaries.mjs'
+import { hasManagedMcpNodeMode } from './managed-mcp-harness.mjs'
 
 const root = process.cwd()
 const failures = []
@@ -120,6 +121,16 @@ if (!buildWorkflow.includes('npm run harness:check')) {
 
 for (const failure of await checkServerModuleBoundaries(root)) {
   fail(failure)
+}
+
+for (const [file, factory] of [
+  ['packages/server/src/modules/hermes/services/mcp/studio-autoinject.ts', 'managedConfig'],
+  ['packages/server/src/modules/ekko/services/mcp.ts', 'managedMcpServerConfig'],
+  ['packages/server/src/modules/coding-agents/services/index.ts', 'hermesMcpServerConfig'],
+]) {
+  if (!hasManagedMcpNodeMode(await readText(file), factory)) {
+    fail(`${file}: ${factory} must inject ELECTRON_RUN_AS_NODE: '1' into every managed MCP env; Electron fallback must not launch the desktop GUI`)
+  }
 }
 
 const desktopReleaseWorkflow = await readText('.github/workflows/desktop-release.yml')

--- a/scripts/managed-mcp-harness.mjs
+++ b/scripts/managed-mcp-harness.mjs
@@ -1,0 +1,24 @@
+import ts from 'typescript'
+
+// Inspect the configuration factory, not comments or the desktop parent's env.
+export function hasManagedMcpNodeMode(source, factoryName) {
+  const file = ts.createSourceFile('mcp.ts', source, ts.ScriptTarget.Latest, true)
+  const factory = file.statements.find(node => ts.isFunctionDeclaration(node) && node.name?.text === factoryName)
+  if (!factory?.body) return false
+  const result = factory.body.statements.find(ts.isReturnStatement)?.expression
+  if (!result || !ts.isObjectLiteralExpression(result)) return false
+  const envProperty = result.properties.find(node => node.name?.getText(file) === 'env')
+  let env = envProperty && ts.isPropertyAssignment(envProperty) ? envProperty.initializer : undefined
+  if (envProperty && ts.isShorthandPropertyAssignment(envProperty)) {
+    for (const statement of factory.body.statements) {
+      if (!ts.isVariableStatement(statement)) continue
+      env = statement.declarationList.declarations.find(node => node.name.getText(file) === 'env')?.initializer || env
+    }
+  }
+  if (!env || !ts.isObjectLiteralExpression(env)) return false
+  const index = env.properties.findLastIndex(node => node.name?.getText(file).replace(/^['"]|['"]$/g, '') === 'ELECTRON_RUN_AS_NODE')
+  const flag = env.properties[index]
+  return !!flag && ts.isPropertyAssignment(flag)
+    && ts.isStringLiteral(flag.initializer) && flag.initializer.text === '1'
+    && !env.properties.slice(index + 1).some(ts.isSpreadAssignment)
+}

--- a/tests/server/managed-mcp-harness.test.ts
+++ b/tests/server/managed-mcp-harness.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { hasManagedMcpNodeMode } from '../../scripts/managed-mcp-harness.mjs'
+
+describe('managed MCP launch harness', () => {
+  it.each([
+    `function managed() { return { env: { ELECTRON_RUN_AS_NODE: '1' } } }`,
+    `function managed() { const env = { ELECTRON_RUN_AS_NODE: '1' }; return { env } }`,
+    `function managed() { return { env: { 'ELECTRON_RUN_AS_NODE': "1" } } }`,
+  ])('accepts an explicit subprocess Node-mode flag', source => {
+    expect(hasManagedMcpNodeMode(source, 'managed')).toBe(true)
+  })
+
+  it.each([
+    `function managed() { return { env: {} } }`,
+    `function managed() { return { env: { ELECTRON_RUN_AS_NODE: '0' } } }`,
+    `function managed() { return { env: { ELECTRON_RUN_AS_NODE: 1 } } }`,
+    `function managed() { return { env: { ...process.env } } }`,
+    `// ELECTRON_RUN_AS_NODE: '1'\nfunction managed() { return { env: {} } }`,
+    `function other() { return { env: { ELECTRON_RUN_AS_NODE: '1' } } }`,
+    `function managed() { return { ELECTRON_RUN_AS_NODE: '1', env: {} } }`,
+    `function managed() { return { env: { ELECTRON_RUN_AS_NODE: '1', ...overrides } } }`,
+  ])('rejects a missing, ineffective, or overwritten flag', source => {
+    expect(hasManagedMcpNodeMode(source, 'managed')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
Removing `ELECTRON_RUN_AS_NODE=1` from a Studio-managed MCP environment can make its Electron fallback reopen the desktop GUI instead of running the MCP script. Add a harness guard to preserve the launch requirement introduced in #2917.

- Inspect the Hermes, Ekko, and Coding Agent configuration factories with the TypeScript parser and require a literal string `1` in the MCP subprocess environment. Reject missing or incorrect flags, reliance on inherited environment, comment-only matches, and later environment spreads that could override the flag.
- Document that every Studio-injected MCP must carry this flag, including independent Node launches, and that new injection paths must join the harness check. The variable must not be set globally for the desktop GUI.

## Validation
- `npm run harness:check`
- `env -u PORT npm run test -- tests/server/managed-mcp-harness.test.ts tests/server/studio-mcp-autoinject.test.ts tests/server/ekko-agent-mcp.test.ts tests/server/coding-agents-launch.test.ts` — 110 tests passed, including 11 harness positive/negative cases.
- `npm run build`
